### PR TITLE
[BUGFIX] Render the derived-table alias in the form each grammar accepts

### DIFF
--- a/great_expectations/expectations/metrics/query_metric_provider.py
+++ b/great_expectations/expectations/metrics/query_metric_provider.py
@@ -88,6 +88,17 @@ def strip_top_level_order_by(query: str) -> str:
     return query[:pos].rstrip()
 
 
+def render_derived_table_alias(subquery: str, alias: str, dialect_name: Optional[str]) -> str:
+    """Return a parenthesized subquery bound to a table alias, in the form the dialect accepts.
+
+    Oracle's grammar admits AS before a column alias but not before a table alias, so the
+    keyword is omitted there and emitted everywhere else.
+    """
+    if dialect_name == "oracle":
+        return f"({subquery}) {alias}"
+    return f"({subquery}) AS {alias}"
+
+
 class MissingElementError(TypeError):
     def __init__(self):
         super().__init__(
@@ -191,7 +202,14 @@ class QueryMetricProvider(MetricProvider):
             if "JOIN" in query.upper():
                 query = query.format(batch=f"({batch})", **parameters)
             else:
-                query = query.format(batch=f"({batch}) AS subselect", **parameters)
+                query = query.format(
+                    batch=render_derived_table_alias(
+                        subquery=str(batch),
+                        alias="subselect",
+                        dialect_name=getattr(execution_engine, "dialect_name", None),
+                    ),
+                    **parameters,
+                )
         else:
             query = query.format(batch=f"({batch_selectable})", **parameters)
 

--- a/great_expectations/expectations/metrics/query_metric_provider.py
+++ b/great_expectations/expectations/metrics/query_metric_provider.py
@@ -213,7 +213,11 @@ class QueryMetricProvider(MetricProvider):
         else:
             query = query.format(batch=f"({batch_selectable})", **parameters)
 
-        if getattr(execution_engine, "dialect_name", None) == "mssql":  # fix for batch error
+        # SQL Server has no boolean literal, and Oracle rejects a bare `true` as a
+        # WHERE-clause predicate with ORA-00920 before it gained a SQL boolean type in 23ai.
+        # A user-authored query carrying that literal is rewritten to `1=1`, which every one
+        # of these grammars accepts.
+        if getattr(execution_engine, "dialect_name", None) in ("mssql", "oracle"):
             query = query.replace("WHERE true", "WHERE 1=1")
 
         return query

--- a/great_expectations/expectations/metrics/query_metrics/query_row_count/query_row_count.py
+++ b/great_expectations/expectations/metrics/query_metrics/query_row_count/query_row_count.py
@@ -13,6 +13,7 @@ from great_expectations.execution_engine import (
 from great_expectations.expectations.metrics.metric_provider import metric_value
 from great_expectations.expectations.metrics.query_metric_provider import (
     QueryMetricProvider,
+    render_derived_table_alias,
     strip_top_level_order_by,
 )
 
@@ -48,10 +49,12 @@ class QueryRowCount(QueryMetricProvider):
             substituted_batch_subquery = strip_top_level_order_by(substituted_batch_subquery)
 
         count_column_name = "unexpected_row_count"
-        row_count_query = (
-            f"SELECT COUNT(*) as {count_column_name} FROM "
-            f"({substituted_batch_subquery}) AS substituted_batch_subquery"
+        aliased_subquery = render_derived_table_alias(
+            subquery=substituted_batch_subquery,
+            alias="substituted_batch_subquery",
+            dialect_name=execution_engine.dialect_name,
         )
+        row_count_query = f"SELECT COUNT(*) as {count_column_name} FROM {aliased_subquery}"
         result: Union[Sequence[sa.Row[Any]], Any] = execution_engine.execute_query(
             sa.text(row_count_query)
         ).fetchone()

--- a/great_expectations/expectations/metrics/query_metrics/query_template_values.py
+++ b/great_expectations/expectations/metrics/query_metrics/query_template_values.py
@@ -14,6 +14,7 @@ from great_expectations.execution_engine import (
 from great_expectations.expectations.metrics.metric_provider import metric_value
 from great_expectations.expectations.metrics.query_metric_provider import (
     QueryMetricProvider,
+    render_derived_table_alias,
 )
 from great_expectations.util import get_sqlalchemy_subquery_type
 
@@ -79,7 +80,11 @@ class QueryTemplateValues(QueryMetricProvider):
             query = cls.get_query(
                 query,
                 template_dict,
-                f"({compiled_selectable}) AS subselect",
+                render_derived_table_alias(
+                    subquery=str(compiled_selectable),
+                    alias="subselect",
+                    dialect_name=getattr(execution_engine, "dialect_name", None),
+                ),
             )
 
         else:

--- a/tests/expectations/metrics/query_metrics/test_query_metrics.py
+++ b/tests/expectations/metrics/query_metrics/test_query_metrics.py
@@ -3,7 +3,7 @@ from unittest import mock
 from unittest.mock import create_autospec
 
 import pytest
-from sqlalchemy.dialects import mysql
+from sqlalchemy.dialects import mysql, oracle  # noqa: F401 # registers sa.dialects.oracle
 
 from great_expectations.compatibility.sqlalchemy import (
     sqlalchemy as sa,
@@ -542,6 +542,25 @@ def mock_sql_server_execution_engine() -> MockSQLServerSqlAlchemyExecutionEngine
     return engine
 
 
+class MockOracleSqlAlchemyExecutionEngine(MockSqlAlchemyExecutionEngine):
+    """Mock engine that reports dialect_name as 'oracle'."""
+
+    def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        super().__init__(*args, **kwargs)
+        from tests.expectations.metrics.conftest import MockSaEngine
+
+        self.engine = MockSaEngine(dialect=sa.dialects.oracle.dialect())  # type: ignore[assignment]
+
+
+@pytest.fixture
+def mock_oracle_execution_engine() -> MockOracleSqlAlchemyExecutionEngine:
+    from tests.expectations.metrics.conftest import MockBatchManager
+
+    engine = MockOracleSqlAlchemyExecutionEngine()
+    engine._batch_manager = MockBatchManager()
+    return engine
+
+
 class TestQueryRowCountSQLServerOrderByStripping:
     @pytest.mark.unit
     @mock.patch.object(sa, "text")
@@ -656,3 +675,457 @@ class TestQueryRowCountSQLServerOrderByStripping:
 
         actual_sql = mock_text.call_args[0][0]
         assert "ORDER BY" in actual_sql
+
+
+class TestDerivedTableAliasDialectInvariance:
+    """Characterization tests pinning the derived-table alias text rendered today, before any
+    dialect-specific renderer exists.
+
+    Three sites build a derived-table alias by string formatting: the single-nested form here
+    (a query-metric re-embedding a compiled ``Select`` as ``(...) AS subselect``) and the
+    doubly-nested form in ``TestRowCountDerivedTableAliasDialectInvariance`` below (the row-count
+    statement's ``(...) AS substituted_batch_subquery`` wrapped around the same inner form). They
+    are asserted separately because the two nesting depths surface as two distinct database
+    errors on Oracle, from two different metrics of the same expectation.
+    """
+
+    @pytest.mark.unit
+    def test_single_nested_alias_default_dialect(
+        self,
+        mock_sqlalchemy_execution_engine: MockSqlAlchemyExecutionEngine,
+        batch_selectable: sa.Table,
+    ) -> None:
+        result = (
+            QueryMetricProvider._get_substituted_batch_subquery_from_query_and_batch_selectable(
+                query="SELECT * FROM {batch} WHERE passenger_count > 7",
+                batch_selectable=sa.select(batch_selectable),
+                execution_engine=mock_sqlalchemy_execution_engine,
+            )
+        )
+        assert result == (
+            "SELECT * FROM (SELECT \nFROM my_table) AS subselect WHERE passenger_count > 7"
+        )
+
+    @pytest.mark.unit
+    def test_single_nested_alias_sql_server(
+        self,
+        mock_sql_server_execution_engine: MockSQLServerSqlAlchemyExecutionEngine,
+        batch_selectable: sa.Table,
+    ) -> None:
+        result = (
+            QueryMetricProvider._get_substituted_batch_subquery_from_query_and_batch_selectable(
+                query="SELECT * FROM {batch} WHERE passenger_count > 7",
+                batch_selectable=sa.select(batch_selectable),
+                execution_engine=mock_sql_server_execution_engine,
+            )
+        )
+        assert result == (
+            "SELECT * FROM (SELECT \nFROM my_table) AS subselect WHERE passenger_count > 7"
+        )
+
+    @pytest.mark.unit
+    def test_single_nested_alias_oracle_current_behavior(
+        self,
+        mock_oracle_execution_engine: MockOracleSqlAlchemyExecutionEngine,
+        batch_selectable: sa.Table,
+    ) -> None:
+        """Pins today's defect: Oracle receives the same ``AS``-bearing alias form as every
+        other dialect, even though Oracle's grammar rejects ``AS`` immediately before a table
+        alias. This is the single assertion in this module that a dialect-specific renderer is
+        expected to invert; every other assertion in this module must stay byte-identical
+        alongside it.
+        """
+        result = (
+            QueryMetricProvider._get_substituted_batch_subquery_from_query_and_batch_selectable(
+                query="SELECT * FROM {batch} WHERE passenger_count > 7",
+                batch_selectable=sa.select(batch_selectable),
+                execution_engine=mock_oracle_execution_engine,
+            )
+        )
+        assert result == (
+            "SELECT * FROM (SELECT \nFROM my_table) AS subselect WHERE passenger_count > 7"
+        )
+
+    @pytest.mark.unit
+    def test_join_query_receives_no_alias_default_dialect(
+        self,
+        mock_sqlalchemy_execution_engine: MockSqlAlchemyExecutionEngine,
+        batch_selectable: sa.Table,
+    ) -> None:
+        """The sibling branch immediately above the aliased one: a JOIN query gets no alias at
+        all, on any dialect. This branch carries no dialect condition, so a dialect-specific
+        renderer applied to the aliased branch must not disturb it.
+        """
+        result = (
+            QueryMetricProvider._get_substituted_batch_subquery_from_query_and_batch_selectable(
+                query="SELECT * FROM {batch} JOIN other_table ON 1=1",
+                batch_selectable=sa.select(batch_selectable),
+                execution_engine=mock_sqlalchemy_execution_engine,
+            )
+        )
+        assert result == "SELECT * FROM (SELECT \nFROM my_table) JOIN other_table ON 1=1"
+
+    @pytest.mark.unit
+    def test_join_query_receives_no_alias_oracle(
+        self,
+        mock_oracle_execution_engine: MockOracleSqlAlchemyExecutionEngine,
+        batch_selectable: sa.Table,
+    ) -> None:
+        """The unaliased JOIN branch is already identical on Oracle today; it is not part of the
+        defect and is not expected to change.
+        """
+        result = (
+            QueryMetricProvider._get_substituted_batch_subquery_from_query_and_batch_selectable(
+                query="SELECT * FROM {batch} JOIN other_table ON 1=1",
+                batch_selectable=sa.select(batch_selectable),
+                execution_engine=mock_oracle_execution_engine,
+            )
+        )
+        assert result == "SELECT * FROM (SELECT \nFROM my_table) JOIN other_table ON 1=1"
+
+
+class TestRowCountDerivedTableAliasDialectInvariance:
+    """Characterization tests pinning the row-count statement's doubly-nested derived-table
+    alias, and the column alias that sits alongside it in the same statement, before any
+    dialect-specific renderer exists.
+
+    The inner ``AS subselect`` form is supplied pre-compiled here (mirroring the existing
+    ``TestQueryRowCountSQLServerOrderByStripping`` pattern in this module) so each test isolates
+    the outer wrapping this statement adds: the table alias ``AS substituted_batch_subquery`` and
+    the column alias ``AS unexpected_row_count``.
+
+    Each test asserts the full statement text and then, separately, a standalone assertion
+    isolating the column alias (``SELECT COUNT(*) as unexpected_row_count FROM``). The two are
+    kept independent on purpose: a future renderer change is expected to rewrite this class's
+    Oracle-side full-statement literal, and the standalone assertion is what keeps a dropped or
+    renamed column alias from riding through that rewrite unnoticed.
+    """
+
+    @pytest.mark.unit
+    @mock.patch.object(sa, "text")
+    @mock.patch.object(
+        QueryMetricProvider, "_get_substituted_batch_subquery_from_query_and_batch_selectable"
+    )
+    def test_double_nested_alias_default_dialect(
+        self,
+        mock_get_sub,
+        mock_text,
+        mock_sqlalchemy_execution_engine: MockSqlAlchemyExecutionEngine,
+        batch_selectable: sa.Table,
+    ) -> None:
+        mock_get_sub.return_value = (
+            "SELECT * FROM (my_table) AS subselect WHERE passenger_count > 7"
+        )
+        mock_text.return_value = "*"
+        mock_result = create_autospec(sa.engine.CursorResult)
+        mock_result.fetchone.return_value = (42,)
+
+        with mock.patch.object(
+            mock_sqlalchemy_execution_engine, "execute_query", return_value=mock_result
+        ):
+            MyQueryRowCount._sqlalchemy(
+                cls=MyQueryRowCount,
+                execution_engine=mock_sqlalchemy_execution_engine,
+                metric_domain_kwargs={},
+                metric_value_kwargs={
+                    "query_param": "my_query",
+                    "my_query": "SELECT * FROM {batch}",
+                },
+                metrics={},
+                runtime_configuration={},
+            )
+
+        actual_sql = mock_text.call_args[0][0]
+        assert actual_sql == (
+            "SELECT COUNT(*) as unexpected_row_count FROM "
+            "(SELECT * FROM (my_table) AS subselect WHERE passenger_count > 7) "
+            "AS substituted_batch_subquery"
+        )
+        # Standalone: the column alias, pinned independently of the table alias above, so a
+        # future rewrite of this test's Oracle-side full-statement literal cannot silently drop
+        # or rename it.
+        assert "SELECT COUNT(*) as unexpected_row_count FROM" in actual_sql
+
+    @pytest.mark.unit
+    @mock.patch.object(sa, "text")
+    @mock.patch.object(
+        QueryMetricProvider, "_get_substituted_batch_subquery_from_query_and_batch_selectable"
+    )
+    def test_double_nested_alias_sql_server(
+        self,
+        mock_get_sub,
+        mock_text,
+        mock_sql_server_execution_engine: MockSQLServerSqlAlchemyExecutionEngine,
+        batch_selectable: sa.Table,
+    ) -> None:
+        mock_get_sub.return_value = (
+            "SELECT * FROM (my_table) AS subselect WHERE passenger_count > 7"
+        )
+        mock_text.return_value = "*"
+        mock_result = create_autospec(sa.engine.CursorResult)
+        mock_result.fetchone.return_value = (42,)
+
+        with mock.patch.object(
+            mock_sql_server_execution_engine, "execute_query", return_value=mock_result
+        ):
+            MyQueryRowCount._sqlalchemy(
+                cls=MyQueryRowCount,
+                execution_engine=mock_sql_server_execution_engine,
+                metric_domain_kwargs={},
+                metric_value_kwargs={
+                    "query_param": "my_query",
+                    "my_query": "SELECT * FROM {batch}",
+                },
+                metrics={},
+                runtime_configuration={},
+            )
+
+        actual_sql = mock_text.call_args[0][0]
+        assert actual_sql == (
+            "SELECT COUNT(*) as unexpected_row_count FROM "
+            "(SELECT * FROM (my_table) AS subselect WHERE passenger_count > 7) "
+            "AS substituted_batch_subquery"
+        )
+        # Standalone: the column alias, pinned independently of the table alias above, so a
+        # future rewrite of this test's Oracle-side full-statement literal cannot silently drop
+        # or rename it.
+        assert "SELECT COUNT(*) as unexpected_row_count FROM" in actual_sql
+
+    @pytest.mark.unit
+    @mock.patch.object(sa, "text")
+    @mock.patch.object(
+        QueryMetricProvider, "_get_substituted_batch_subquery_from_query_and_batch_selectable"
+    )
+    def test_double_nested_alias_oracle_current_behavior(
+        self,
+        mock_get_sub,
+        mock_text,
+        mock_oracle_execution_engine: MockOracleSqlAlchemyExecutionEngine,
+        batch_selectable: sa.Table,
+    ) -> None:
+        """Pins today's defect at the second nesting depth: Oracle receives the same
+        ``AS``-bearing outer table alias as every other dialect, even though Oracle's grammar
+        rejects ``AS`` immediately before a table alias. This is the doubly-nested counterpart to
+        ``test_single_nested_alias_oracle_current_behavior`` above -- both are expected to invert
+        together, because the two nesting depths surface as two distinct database errors from two
+        different metrics. The column alias ``as unexpected_row_count`` in this same statement is
+        a separate, accepted construct; it is pinned independently below via a standalone
+        assertion, not only inside this method's full-statement literal, so a rewrite of that
+        literal cannot silently carry the column alias along with it.
+        """
+        mock_get_sub.return_value = (
+            "SELECT * FROM (my_table) AS subselect WHERE passenger_count > 7"
+        )
+        mock_text.return_value = "*"
+        mock_result = create_autospec(sa.engine.CursorResult)
+        mock_result.fetchone.return_value = (42,)
+
+        with mock.patch.object(
+            mock_oracle_execution_engine, "execute_query", return_value=mock_result
+        ):
+            MyQueryRowCount._sqlalchemy(
+                cls=MyQueryRowCount,
+                execution_engine=mock_oracle_execution_engine,
+                metric_domain_kwargs={},
+                metric_value_kwargs={
+                    "query_param": "my_query",
+                    "my_query": "SELECT * FROM {batch}",
+                },
+                metrics={},
+                runtime_configuration={},
+            )
+
+        actual_sql = mock_text.call_args[0][0]
+        assert actual_sql == (
+            "SELECT COUNT(*) as unexpected_row_count FROM "
+            "(SELECT * FROM (my_table) AS subselect WHERE passenger_count > 7) "
+            "AS substituted_batch_subquery"
+        )
+        # Standalone: the column alias, pinned independently of the table alias above, so a
+        # future rewrite of this test's Oracle-side full-statement literal cannot silently drop
+        # or rename it.
+        assert "SELECT COUNT(*) as unexpected_row_count FROM" in actual_sql
+
+
+class TestQueryTemplateValuesDerivedTableAliasDialectInvariance:
+    """Characterization tests pinning the third derived-table alias construction site, in
+    ``QueryTemplateValues._sqlalchemy``, before any dialect-specific renderer exists.
+
+    The stock mock execution engine's ``get_compute_domain`` returns a ``sa.Table``, which
+    takes the unaliased ``sa.Table`` branch in ``query_template_values.py`` rather than the
+    ``sa.sql.Select`` branch that builds ``(compiled_selectable) AS subselect``. Each test below
+    patches ``get_compute_domain`` on the engine instance to return a compiled ``Select``
+    instead, so the aliased branch is actually exercised, and patches ``execute_query`` so no
+    real database call is attempted. The exact text passed to ``sa.text`` is asserted.
+    """
+
+    @pytest.mark.unit
+    def test_single_nested_alias_default_dialect(
+        self,
+        mock_sqlalchemy_execution_engine: MockSqlAlchemyExecutionEngine,
+        batch_selectable: sa.Table,
+    ) -> None:
+        mock_result = create_autospec(sa.engine.CursorResult)
+        mock_result.fetchall.return_value = []
+
+        with (
+            mock.patch.object(
+                mock_sqlalchemy_execution_engine,
+                "get_compute_domain",
+                return_value=(sa.select(batch_selectable), {}, {}),
+            ),
+            mock.patch.object(
+                mock_sqlalchemy_execution_engine, "execute_query", return_value=mock_result
+            ) as mock_execute_query,
+            mock.patch.object(sa, "text", side_effect=lambda x: x),
+        ):
+            QueryTemplateValues._sqlalchemy(
+                cls=QueryTemplateValues,
+                execution_engine=mock_sqlalchemy_execution_engine,
+                metric_domain_kwargs={},
+                metric_value_kwargs={
+                    "template_dict": {},
+                    "query": "SELECT * FROM {batch} WHERE passenger_count > 7",
+                },
+                metrics={},
+                runtime_configuration={},
+            )
+            actual_sql = mock_execute_query.call_args[0][0]
+        assert actual_sql == (
+            "SELECT * FROM (SELECT \nFROM my_table) AS subselect WHERE passenger_count > 7"
+        )
+
+    @pytest.mark.unit
+    def test_single_nested_alias_sql_server(
+        self,
+        mock_sql_server_execution_engine: MockSQLServerSqlAlchemyExecutionEngine,
+        batch_selectable: sa.Table,
+    ) -> None:
+        mock_result = create_autospec(sa.engine.CursorResult)
+        mock_result.fetchall.return_value = []
+
+        with (
+            mock.patch.object(
+                mock_sql_server_execution_engine,
+                "get_compute_domain",
+                return_value=(sa.select(batch_selectable), {}, {}),
+            ),
+            mock.patch.object(
+                mock_sql_server_execution_engine, "execute_query", return_value=mock_result
+            ) as mock_execute_query,
+            mock.patch.object(sa, "text", side_effect=lambda x: x),
+        ):
+            QueryTemplateValues._sqlalchemy(
+                cls=QueryTemplateValues,
+                execution_engine=mock_sql_server_execution_engine,
+                metric_domain_kwargs={},
+                metric_value_kwargs={
+                    "template_dict": {},
+                    "query": "SELECT * FROM {batch} WHERE passenger_count > 7",
+                },
+                metrics={},
+                runtime_configuration={},
+            )
+            actual_sql = mock_execute_query.call_args[0][0]
+        assert actual_sql == (
+            "SELECT * FROM (SELECT \nFROM my_table) AS subselect WHERE passenger_count > 7"
+        )
+
+    @pytest.mark.unit
+    def test_single_nested_alias_oracle_current_behavior(
+        self,
+        mock_oracle_execution_engine: MockOracleSqlAlchemyExecutionEngine,
+        batch_selectable: sa.Table,
+    ) -> None:
+        """Pins today's defect at this third construction site: Oracle receives the same
+        ``AS``-bearing alias form as every other dialect, even though Oracle's grammar rejects
+        ``AS`` immediately before a table alias. This is one of the assertions in this module
+        expected to invert together with its siblings in the other two alias-construction test
+        classes.
+        """
+        mock_result = create_autospec(sa.engine.CursorResult)
+        mock_result.fetchall.return_value = []
+
+        with (
+            mock.patch.object(
+                mock_oracle_execution_engine,
+                "get_compute_domain",
+                return_value=(sa.select(batch_selectable), {}, {}),
+            ),
+            mock.patch.object(
+                mock_oracle_execution_engine, "execute_query", return_value=mock_result
+            ) as mock_execute_query,
+            mock.patch.object(sa, "text", side_effect=lambda x: x),
+        ):
+            QueryTemplateValues._sqlalchemy(
+                cls=QueryTemplateValues,
+                execution_engine=mock_oracle_execution_engine,
+                metric_domain_kwargs={},
+                metric_value_kwargs={
+                    "template_dict": {},
+                    "query": "SELECT * FROM {batch} WHERE passenger_count > 7",
+                },
+                metrics={},
+                runtime_configuration={},
+            )
+            actual_sql = mock_execute_query.call_args[0][0]
+        assert actual_sql == (
+            "SELECT * FROM (SELECT \nFROM my_table) AS subselect WHERE passenger_count > 7"
+        )
+
+
+class TestLiteralBooleanReplacementDialectInvariance:
+    """Characterization tests pinning today's literal-boolean replacement behavior.
+
+    ``query_metric_provider.py`` replaces the literal ``WHERE true`` with ``WHERE 1=1`` only when
+    the execution engine reports the ``mssql`` dialect. These tests pin that behavior on SQL
+    Server and pin its absence on Oracle and on a default dialect, so that whichever way a future
+    determination of what this guard protects goes, before-and-after evidence for both dialects
+    already exists. This class does not determine what the guard protects and does not extend it
+    to Oracle; it only pins what exists today.
+    """
+
+    @pytest.mark.unit
+    def test_sql_server_replaces_literal_where_true(
+        self,
+        mock_sql_server_execution_engine: MockSQLServerSqlAlchemyExecutionEngine,
+        batch_selectable: sa.Table,
+    ) -> None:
+        result = (
+            QueryMetricProvider._get_substituted_batch_subquery_from_query_and_batch_selectable(
+                query="SELECT * FROM {batch} WHERE true",
+                batch_selectable=batch_selectable,
+                execution_engine=mock_sql_server_execution_engine,
+            )
+        )
+        assert result == "SELECT * FROM my_table WHERE 1=1"
+
+    @pytest.mark.unit
+    def test_oracle_does_not_replace_literal_where_true(
+        self,
+        mock_oracle_execution_engine: MockOracleSqlAlchemyExecutionEngine,
+        batch_selectable: sa.Table,
+    ) -> None:
+        result = (
+            QueryMetricProvider._get_substituted_batch_subquery_from_query_and_batch_selectable(
+                query="SELECT * FROM {batch} WHERE true",
+                batch_selectable=batch_selectable,
+                execution_engine=mock_oracle_execution_engine,
+            )
+        )
+        assert result == "SELECT * FROM my_table WHERE true"
+
+    @pytest.mark.unit
+    def test_default_dialect_does_not_replace_literal_where_true(
+        self,
+        mock_sqlalchemy_execution_engine: MockSqlAlchemyExecutionEngine,
+        batch_selectable: sa.Table,
+    ) -> None:
+        result = (
+            QueryMetricProvider._get_substituted_batch_subquery_from_query_and_batch_selectable(
+                query="SELECT * FROM {batch} WHERE true",
+                batch_selectable=batch_selectable,
+                execution_engine=mock_sqlalchemy_execution_engine,
+            )
+        )
+        assert result == "SELECT * FROM my_table WHERE true"

--- a/tests/expectations/metrics/query_metrics/test_query_metrics.py
+++ b/tests/expectations/metrics/query_metrics/test_query_metrics.py
@@ -678,6 +678,21 @@ class TestQueryRowCountSQLServerOrderByStripping:
         assert "ORDER BY" in actual_sql
 
 
+def _compile_batch_selectable(
+    batch_selectable: sa.Table, dialect: sa.engine.interfaces.Dialect
+) -> str:
+    """Compile the same selectable, in the same way, that the code under test compiles it.
+
+    ``sa.select(batch_selectable)`` with no columns pulled out renders differently across
+    SQLAlchemy major versions (e.g. an extra space after ``SELECT``), so that fragment is
+    derived here at runtime rather than hardcoded, leaving only this work's contribution --
+    the alias wrapping asserted alongside this helper's return value -- pinned as a literal.
+    """
+    return str(
+        sa.select(batch_selectable).compile(dialect=dialect, compile_kwargs={"literal_binds": True})
+    )
+
+
 class TestDerivedTableAliasDialectInvariance:
     """Characterization tests pinning the derived-table alias text each dialect receives.
 
@@ -705,9 +720,10 @@ class TestDerivedTableAliasDialectInvariance:
                 execution_engine=mock_sqlalchemy_execution_engine,
             )
         )
-        assert result == (
-            "SELECT * FROM (SELECT \nFROM my_table) AS subselect WHERE passenger_count > 7"
+        compiled = _compile_batch_selectable(
+            batch_selectable, mock_sqlalchemy_execution_engine.engine.dialect
         )
+        assert result == (f"SELECT * FROM ({compiled}) AS subselect WHERE passenger_count > 7")
 
     @pytest.mark.unit
     def test_alias_keyword_is_emitted_when_the_dialect_is_unknown(self) -> None:
@@ -736,9 +752,10 @@ class TestDerivedTableAliasDialectInvariance:
                 execution_engine=mock_sql_server_execution_engine,
             )
         )
-        assert result == (
-            "SELECT * FROM (SELECT \nFROM my_table) AS subselect WHERE passenger_count > 7"
+        compiled = _compile_batch_selectable(
+            batch_selectable, mock_sql_server_execution_engine.engine.dialect
         )
+        assert result == (f"SELECT * FROM ({compiled}) AS subselect WHERE passenger_count > 7")
 
     @pytest.mark.unit
     def test_single_nested_alias_oracle(
@@ -757,9 +774,10 @@ class TestDerivedTableAliasDialectInvariance:
                 execution_engine=mock_oracle_execution_engine,
             )
         )
-        assert result == (
-            "SELECT * FROM (SELECT \nFROM my_table) subselect WHERE passenger_count > 7"
+        compiled = _compile_batch_selectable(
+            batch_selectable, mock_oracle_execution_engine.engine.dialect
         )
+        assert result == (f"SELECT * FROM ({compiled}) subselect WHERE passenger_count > 7")
 
     @pytest.mark.unit
     def test_join_query_receives_no_alias_default_dialect(
@@ -778,7 +796,10 @@ class TestDerivedTableAliasDialectInvariance:
                 execution_engine=mock_sqlalchemy_execution_engine,
             )
         )
-        assert result == "SELECT * FROM (SELECT \nFROM my_table) JOIN other_table ON 1=1"
+        compiled = _compile_batch_selectable(
+            batch_selectable, mock_sqlalchemy_execution_engine.engine.dialect
+        )
+        assert result == f"SELECT * FROM ({compiled}) JOIN other_table ON 1=1"
 
     @pytest.mark.unit
     def test_join_query_receives_no_alias_oracle(
@@ -796,7 +817,10 @@ class TestDerivedTableAliasDialectInvariance:
                 execution_engine=mock_oracle_execution_engine,
             )
         )
-        assert result == "SELECT * FROM (SELECT \nFROM my_table) JOIN other_table ON 1=1"
+        compiled = _compile_batch_selectable(
+            batch_selectable, mock_oracle_execution_engine.engine.dialect
+        )
+        assert result == f"SELECT * FROM ({compiled}) JOIN other_table ON 1=1"
 
 
 class TestRowCountDerivedTableAliasDialectInvariance:
@@ -1008,9 +1032,10 @@ class TestQueryTemplateValuesDerivedTableAliasDialectInvariance:
                 runtime_configuration={},
             )
             actual_sql = mock_execute_query.call_args[0][0]
-        assert actual_sql == (
-            "SELECT * FROM (SELECT \nFROM my_table) AS subselect WHERE passenger_count > 7"
+        compiled = _compile_batch_selectable(
+            batch_selectable, mock_sqlalchemy_execution_engine.engine.dialect
         )
+        assert actual_sql == (f"SELECT * FROM ({compiled}) AS subselect WHERE passenger_count > 7")
 
     @pytest.mark.unit
     def test_single_nested_alias_sql_server(
@@ -1044,9 +1069,10 @@ class TestQueryTemplateValuesDerivedTableAliasDialectInvariance:
                 runtime_configuration={},
             )
             actual_sql = mock_execute_query.call_args[0][0]
-        assert actual_sql == (
-            "SELECT * FROM (SELECT \nFROM my_table) AS subselect WHERE passenger_count > 7"
+        compiled = _compile_batch_selectable(
+            batch_selectable, mock_sql_server_execution_engine.engine.dialect
         )
+        assert actual_sql == (f"SELECT * FROM ({compiled}) AS subselect WHERE passenger_count > 7")
 
     @pytest.mark.unit
     def test_single_nested_alias_oracle(
@@ -1085,9 +1111,10 @@ class TestQueryTemplateValuesDerivedTableAliasDialectInvariance:
                 runtime_configuration={},
             )
             actual_sql = mock_execute_query.call_args[0][0]
-        assert actual_sql == (
-            "SELECT * FROM (SELECT \nFROM my_table) subselect WHERE passenger_count > 7"
+        compiled = _compile_batch_selectable(
+            batch_selectable, mock_oracle_execution_engine.engine.dialect
         )
+        assert actual_sql == (f"SELECT * FROM ({compiled}) subselect WHERE passenger_count > 7")
 
 
 class TestLiteralBooleanReplacementDialectInvariance:

--- a/tests/expectations/metrics/query_metrics/test_query_metrics.py
+++ b/tests/expectations/metrics/query_metrics/test_query_metrics.py
@@ -13,6 +13,7 @@ from great_expectations.expectations.metrics.query_metric_provider import (
     QueryParameters,
     find_last_top_level_order_by,
     has_top_level_token,
+    render_derived_table_alias,
     strip_top_level_order_by,
 )
 from great_expectations.expectations.metrics.query_metrics import (
@@ -678,13 +679,15 @@ class TestQueryRowCountSQLServerOrderByStripping:
 
 
 class TestDerivedTableAliasDialectInvariance:
-    """Characterization tests pinning the derived-table alias text rendered today, before any
-    dialect-specific renderer exists.
+    """Characterization tests pinning the derived-table alias text each dialect receives.
 
-    Three sites build a derived-table alias by string formatting: the single-nested form here
-    (a query-metric re-embedding a compiled ``Select`` as ``(...) AS subselect``) and the
-    doubly-nested form in ``TestRowCountDerivedTableAliasDialectInvariance`` below (the row-count
-    statement's ``(...) AS substituted_batch_subquery`` wrapped around the same inner form). They
+    Three sites build a derived-table alias, all of them through
+    ``render_derived_table_alias``: the single-nested form here (a query-metric re-embedding a
+    compiled ``Select`` bound to ``subselect``) and the doubly-nested form in
+    ``TestRowCountDerivedTableAliasDialectInvariance`` below (the row-count statement's
+    ``substituted_batch_subquery`` wrapping around the same inner form). The keyword ``AS``
+    precedes the alias on every dialect whose grammar admits it there, and is omitted on the
+    one whose grammar does not. They
     are asserted separately because the two nesting depths surface as two distinct database
     errors on Oracle, from two different metrics of the same expectation.
     """
@@ -707,6 +710,20 @@ class TestDerivedTableAliasDialectInvariance:
         )
 
     @pytest.mark.unit
+    def test_alias_keyword_is_emitted_when_the_dialect_is_unknown(self) -> None:
+        """The renderer emits the keyword when the dialect name is unknown.
+
+        ``render_derived_table_alias`` omits ``AS`` only for the one grammar that rejects it
+        before a table alias. A ``None`` dialect name means the caller could not say which
+        grammar applies, so the form every other dialect receives is the safe answer -- an
+        unknown dialect must not inherit the exception.
+        """
+        assert (
+            render_derived_table_alias(subquery="SELECT 1", alias="subselect", dialect_name=None)
+            == "(SELECT 1) AS subselect"
+        )
+
+    @pytest.mark.unit
     def test_single_nested_alias_sql_server(
         self,
         mock_sql_server_execution_engine: MockSQLServerSqlAlchemyExecutionEngine,
@@ -724,16 +741,14 @@ class TestDerivedTableAliasDialectInvariance:
         )
 
     @pytest.mark.unit
-    def test_single_nested_alias_oracle_current_behavior(
+    def test_single_nested_alias_oracle(
         self,
         mock_oracle_execution_engine: MockOracleSqlAlchemyExecutionEngine,
         batch_selectable: sa.Table,
     ) -> None:
-        """Pins today's defect: Oracle receives the same ``AS``-bearing alias form as every
-        other dialect, even though Oracle's grammar rejects ``AS`` immediately before a table
-        alias. This is the single assertion in this module that a dialect-specific renderer is
-        expected to invert; every other assertion in this module must stay byte-identical
-        alongside it.
+        """Oracle's grammar admits ``AS`` before a column alias but not before a table alias, so
+        the derived-table alias renderer omits the keyword here. Every other assertion in this
+        module must stay byte-identical alongside this inversion.
         """
         result = (
             QueryMetricProvider._get_substituted_batch_subquery_from_query_and_batch_selectable(
@@ -743,7 +758,7 @@ class TestDerivedTableAliasDialectInvariance:
             )
         )
         assert result == (
-            "SELECT * FROM (SELECT \nFROM my_table) AS subselect WHERE passenger_count > 7"
+            "SELECT * FROM (SELECT \nFROM my_table) subselect WHERE passenger_count > 7"
         )
 
     @pytest.mark.unit
@@ -786,19 +801,19 @@ class TestDerivedTableAliasDialectInvariance:
 
 class TestRowCountDerivedTableAliasDialectInvariance:
     """Characterization tests pinning the row-count statement's doubly-nested derived-table
-    alias, and the column alias that sits alongside it in the same statement, before any
-    dialect-specific renderer exists.
+    alias, and the column alias that sits alongside it in the same statement.
 
-    The inner ``AS subselect`` form is supplied pre-compiled here (mirroring the existing
+    The inner form is supplied pre-compiled here (mirroring the existing
     ``TestQueryRowCountSQLServerOrderByStripping`` pattern in this module) so each test isolates
-    the outer wrapping this statement adds: the table alias ``AS substituted_batch_subquery`` and
-    the column alias ``AS unexpected_row_count``.
+    the outer wrapping this statement adds: the table alias ``substituted_batch_subquery``,
+    whose keyword is dialect-dependent, and the column alias ``AS unexpected_row_count``, which
+    every dialect here accepts and which no dialect-specific rendering touches.
 
     Each test asserts the full statement text and then, separately, a standalone assertion
     isolating the column alias (``SELECT COUNT(*) as unexpected_row_count FROM``). The two are
-    kept independent on purpose: a future renderer change is expected to rewrite this class's
-    Oracle-side full-statement literal, and the standalone assertion is what keeps a dropped or
-    renamed column alias from riding through that rewrite unnoticed.
+    kept independent on purpose: a change to the table alias rewrites this class's Oracle-side
+    full-statement literal, and the standalone assertion is what keeps a dropped or renamed
+    column alias from riding through that rewrite unnoticed.
     """
 
     @pytest.mark.unit
@@ -896,22 +911,24 @@ class TestRowCountDerivedTableAliasDialectInvariance:
     @mock.patch.object(
         QueryMetricProvider, "_get_substituted_batch_subquery_from_query_and_batch_selectable"
     )
-    def test_double_nested_alias_oracle_current_behavior(
+    def test_double_nested_alias_oracle(
         self,
         mock_get_sub,
         mock_text,
         mock_oracle_execution_engine: MockOracleSqlAlchemyExecutionEngine,
         batch_selectable: sa.Table,
     ) -> None:
-        """Pins today's defect at the second nesting depth: Oracle receives the same
-        ``AS``-bearing outer table alias as every other dialect, even though Oracle's grammar
-        rejects ``AS`` immediately before a table alias. This is the doubly-nested counterpart to
-        ``test_single_nested_alias_oracle_current_behavior`` above -- both are expected to invert
-        together, because the two nesting depths surface as two distinct database errors from two
-        different metrics. The column alias ``as unexpected_row_count`` in this same statement is
-        a separate, accepted construct; it is pinned independently below via a standalone
-        assertion, not only inside this method's full-statement literal, so a rewrite of that
-        literal cannot silently carry the column alias along with it.
+        """Pins the derived-table alias renderer's effect at the second nesting depth: Oracle's
+        outer table alias omits ``AS``, while the inner alias supplied via the mocked
+        ``_get_substituted_batch_subquery_from_query_and_batch_selectable`` return value is
+        unaffected -- that call is mocked here, so this test exercises only the outer wrapping
+        this statement adds. This is the doubly-nested counterpart to
+        ``test_single_nested_alias_oracle`` above -- both invert together, because the two
+        nesting depths surface as two distinct database errors from two different metrics. The
+        column alias ``as unexpected_row_count`` in this same statement is a separate, accepted
+        construct; it is pinned independently below via a standalone assertion, not only inside
+        this method's full-statement literal, so a rewrite of that literal cannot silently carry
+        the column alias along with it.
         """
         mock_get_sub.return_value = (
             "SELECT * FROM (my_table) AS subselect WHERE passenger_count > 7"
@@ -939,7 +956,7 @@ class TestRowCountDerivedTableAliasDialectInvariance:
         assert actual_sql == (
             "SELECT COUNT(*) as unexpected_row_count FROM "
             "(SELECT * FROM (my_table) AS subselect WHERE passenger_count > 7) "
-            "AS substituted_batch_subquery"
+            "substituted_batch_subquery"
         )
         # Standalone: the column alias, pinned independently of the table alias above, so a
         # future rewrite of this test's Oracle-side full-statement literal cannot silently drop
@@ -949,11 +966,11 @@ class TestRowCountDerivedTableAliasDialectInvariance:
 
 class TestQueryTemplateValuesDerivedTableAliasDialectInvariance:
     """Characterization tests pinning the third derived-table alias construction site, in
-    ``QueryTemplateValues._sqlalchemy``, before any dialect-specific renderer exists.
+    ``QueryTemplateValues._sqlalchemy``.
 
     The stock mock execution engine's ``get_compute_domain`` returns a ``sa.Table``, which
     takes the unaliased ``sa.Table`` branch in ``query_template_values.py`` rather than the
-    ``sa.sql.Select`` branch that builds ``(compiled_selectable) AS subselect``. Each test below
+    ``sa.sql.Select`` branch that binds the compiled selectable to ``subselect``. Each test below
     patches ``get_compute_domain`` on the engine instance to return a compiled ``Select``
     instead, so the aliased branch is actually exercised, and patches ``execute_query`` so no
     real database call is attempted. The exact text passed to ``sa.text`` is asserted.
@@ -1032,16 +1049,15 @@ class TestQueryTemplateValuesDerivedTableAliasDialectInvariance:
         )
 
     @pytest.mark.unit
-    def test_single_nested_alias_oracle_current_behavior(
+    def test_single_nested_alias_oracle(
         self,
         mock_oracle_execution_engine: MockOracleSqlAlchemyExecutionEngine,
         batch_selectable: sa.Table,
     ) -> None:
-        """Pins today's defect at this third construction site: Oracle receives the same
-        ``AS``-bearing alias form as every other dialect, even though Oracle's grammar rejects
-        ``AS`` immediately before a table alias. This is one of the assertions in this module
-        expected to invert together with its siblings in the other two alias-construction test
-        classes.
+        """Oracle's grammar admits ``AS`` before a column alias but not before a table alias, so
+        the derived-table alias renderer omits the keyword at this third construction site too.
+        This is one of the assertions in this module that inverts together with its siblings in
+        the other two alias-construction test classes.
         """
         mock_result = create_autospec(sa.engine.CursorResult)
         mock_result.fetchall.return_value = []
@@ -1070,7 +1086,7 @@ class TestQueryTemplateValuesDerivedTableAliasDialectInvariance:
             )
             actual_sql = mock_execute_query.call_args[0][0]
         assert actual_sql == (
-            "SELECT * FROM (SELECT \nFROM my_table) AS subselect WHERE passenger_count > 7"
+            "SELECT * FROM (SELECT \nFROM my_table) subselect WHERE passenger_count > 7"
         )
 
 

--- a/tests/expectations/metrics/query_metrics/test_query_metrics.py
+++ b/tests/expectations/metrics/query_metrics/test_query_metrics.py
@@ -1091,14 +1091,13 @@ class TestQueryTemplateValuesDerivedTableAliasDialectInvariance:
 
 
 class TestLiteralBooleanReplacementDialectInvariance:
-    """Characterization tests pinning today's literal-boolean replacement behavior.
+    """Characterization tests pinning the literal-boolean replacement behavior.
 
-    ``query_metric_provider.py`` replaces the literal ``WHERE true`` with ``WHERE 1=1`` only when
-    the execution engine reports the ``mssql`` dialect. These tests pin that behavior on SQL
-    Server and pin its absence on Oracle and on a default dialect, so that whichever way a future
-    determination of what this guard protects goes, before-and-after evidence for both dialects
-    already exists. This class does not determine what the guard protects and does not extend it
-    to Oracle; it only pins what exists today.
+    ``query_metric_provider.py`` replaces the literal ``WHERE true`` with ``WHERE 1=1`` when the
+    execution engine reports the ``mssql`` or ``oracle`` dialect: SQL Server has no boolean
+    literal, and Oracle rejects a bare ``true`` as a ``WHERE``-clause predicate with ORA-00920
+    before it gained a SQL boolean type in 23ai. These tests pin that behavior on SQL Server and
+    on Oracle, and pin its absence on a default dialect.
     """
 
     @pytest.mark.unit
@@ -1117,7 +1116,7 @@ class TestLiteralBooleanReplacementDialectInvariance:
         assert result == "SELECT * FROM my_table WHERE 1=1"
 
     @pytest.mark.unit
-    def test_oracle_does_not_replace_literal_where_true(
+    def test_oracle_replaces_literal_where_true(
         self,
         mock_oracle_execution_engine: MockOracleSqlAlchemyExecutionEngine,
         batch_selectable: sa.Table,
@@ -1129,7 +1128,7 @@ class TestLiteralBooleanReplacementDialectInvariance:
                 execution_engine=mock_oracle_execution_engine,
             )
         )
-        assert result == "SELECT * FROM my_table WHERE true"
+        assert result == "SELECT * FROM my_table WHERE 1=1"
 
     @pytest.mark.unit
     def test_default_dialect_does_not_replace_literal_where_true(

--- a/tests/integration/test_utils/data_source_config/oracle.py
+++ b/tests/integration/test_utils/data_source_config/oracle.py
@@ -69,18 +69,6 @@ class OracleDatasourceTestConfig(SqlDatasourceTestConfig):
                 "unmatched dialect; Oracle exposes REGEXP_LIKE, but the helper never compiles a "
                 "predicate for it, so no regex-based case can execute against this dialect."
             ),
-            # The query-metric providers re-embed the batch as a derived-table subquery using a
-            # hardcoded `AS <alias>` construction. Oracle's grammar accepts `AS` before a column
-            # alias but rejects it before a table/derived-table alias, so any query that
-            # re-embeds the batch fails with a database error before the expectation can
-            # evaluate.
-            "unexpected_rows_query": (
-                "The query-metric providers re-embed the batch as a derived-table subquery "
-                "using a hardcoded `AS <alias>` construction; Oracle's grammar accepts AS "
-                "before a column alias but rejects it before a table/derived-table alias, so "
-                "any query that re-embeds the batch fails with a database error (ORA-00933 or "
-                "ORA-00907, depending on nesting depth) before the expectation can evaluate."
-            ),
         },
     )
 


### PR DESCRIPTION
## Summary

Three call sites built a derived-table alias by string formatting, each hardcoding `AS` before the alias. Oracle's grammar admits `AS` before a *column* alias but not before a *table* alias, so query-based Expectations failed there — and a single Expectation produced two different errors in one run, `ORA-00933` from the `.table` metric at one level of nesting and `ORA-00907` from the `.row_count` metric at two, because both metrics build their own alias at different depths.

This adds one shared renderer that binds a parenthesized subquery to its alias, omitting the keyword for the grammar that rejects it and emitting it everywhere else — including when the dialect name is unknown, so a caller that cannot report a dialect keeps today's form rather than inheriting the exception. All three sites are migrated onto it, and the curated-suite exclusion the defect had justified is removed.

It also extends an existing dialect-gated rewrite of a literal boolean predicate to Oracle, and removes the exclusion's stale justification along with the entry.

## Why

Dropping `AS` unconditionally would fix Oracle with less code, since `(subquery) alias` is valid ANSI accepted by every dialect here. That is deliberately not done, because it would change the rendered SQL of every other backend.

The literal-boolean rewrite arrived without a recorded failing input, so what it guarded was unclear. It guards **user-authored** text: the framework's own permissive clause is built with `sa.true()`, which SQLAlchemy renders as `1 = 1` on both SQL Server and Oracle, so no framework-compiled string carries the literal. What does carry it is a query written by a user, which reaches that point unmodified. Removing the line makes SQL Server reject such a query, and Oracle rejects the same input with `ORA-00920` before it gained a SQL boolean type in 23ai, so the same protection now applies there.

## User impact

`UnexpectedRowsExpectation` and the other query-metric Expectations now execute on Oracle. A user-authored query containing a bare `true` predicate is rewritten to an equivalent the grammar accepts, as it already was on SQL Server. No other backend's rendered SQL changes.

## How to review

The characterization tests pinning all three alias sites, both nesting depths, and the literal-boolean behavior on each dialect were committed and shown green **before** the fix.

Two things in the same statement are deliberately left alone: the *column* alias in the row-count query, which that grammar accepts, and the sibling branch that renders a joined batch with no alias at all. The column alias has its own standalone assertion, separate from the full-statement one, so regenerating the full-statement literal cannot carry away a dropped column alias unnoticed.

The literal-boolean rewrite is intentionally unchanged in shape — still a plain, case-sensitive replacement. A more tolerant one may be warranted, but it would change what SQL Server does today, so it is left as it is. Note that its regression coverage is unit-level only: no curated case's query body contains the literal.
