### PR TITLE
[BUGFIX] Restore the metrics coverage MySQL, SQL Server and Redshift were silently missing

### DIFF
--- a/tests/integration/metrics/column/test_values_match_regex_count.py
+++ b/tests/integration/metrics/column/test_values_match_regex_count.py
@@ -6,6 +6,7 @@ from great_expectations.metrics.column.values_match_regex_count import (
     ColumnValuesMatchRegexCountResult,
 )
 from tests.integration.conftest import parameterize_batch_for_data_sources
+from tests.integration.test_utils.data_source_config import SQLServerDatasourceTestConfig
 from tests.metrics.conftest import (
     ALL_DATA_SOURCES,
     SPARK_DATA_SOURCES,
@@ -17,16 +18,26 @@ COLUMN_NAME = "whatevs"
 
 DATA_FRAME = pd.DataFrame({COLUMN_NAME: ["abc", "def", "ghi", "1ab2", "1ab3", None]})
 
-ALL_DATA_SOURCES_EXCEPT_SNOWFLAKE = [
+# SQL Server ships no regex operator, so the per-dialect expression these metrics compile to has
+# no SQL Server form and the metric raises instead of computing. The regex expectation modules
+# draw the same line with hand-written supported-source lists; deriving it from the shared lists
+# here keeps this module in step as backends join them.
+REGEX_CAPABLE_SQL_DATA_SOURCES = [
+    datasource
+    for datasource in SQL_DATA_SOURCES
+    if not isinstance(datasource, SQLServerDatasourceTestConfig)
+]
+
+REGEX_CAPABLE_DATA_SOURCES_EXCEPT_SNOWFLAKE = [
     datasource
     for datasource in ALL_DATA_SOURCES
-    if not isinstance(datasource, SnowflakeDatasourceTestConfig)
+    if not isinstance(datasource, (SQLServerDatasourceTestConfig, SnowflakeDatasourceTestConfig))
 ]
 
 
 class TestColumnValuesMatchRegexCount:
     @parameterize_batch_for_data_sources(
-        data_source_configs=ALL_DATA_SOURCES_EXCEPT_SNOWFLAKE,
+        data_source_configs=REGEX_CAPABLE_DATA_SOURCES_EXCEPT_SNOWFLAKE,
         data=DATA_FRAME,
     )
     def test_partial_match_characters(self, batch_for_datasource: Batch) -> None:
@@ -37,7 +48,7 @@ class TestColumnValuesMatchRegexCount:
         assert metric_result.value == 3
 
     @parameterize_batch_for_data_sources(
-        data_source_configs=SPARK_DATA_SOURCES + SQL_DATA_SOURCES,
+        data_source_configs=SPARK_DATA_SOURCES + REGEX_CAPABLE_SQL_DATA_SOURCES,
         data=DATA_FRAME,
     )
     def test_special_characters(self, batch_for_datasource: Batch) -> None:

--- a/tests/integration/metrics/column/test_values_match_regex_values.py
+++ b/tests/integration/metrics/column/test_values_match_regex_values.py
@@ -6,6 +6,7 @@ from great_expectations.metrics.column.values_match_regex_values import (
     ColumnValuesMatchRegexValuesResult,
 )
 from tests.integration.conftest import parameterize_batch_for_data_sources
+from tests.integration.test_utils.data_source_config import SQLServerDatasourceTestConfig
 from tests.metrics.conftest import SQL_DATA_SOURCES, SnowflakeDatasourceTestConfig
 
 COLUMN_NAME = "whatevs"
@@ -15,16 +16,26 @@ MATCH_ALL_REGEX = ".+"
 DATA_FRAME = pd.DataFrame({COLUMN_NAME: ["abc", "def", "ghi", "1ab2", None]})
 DATA_FRAME_WITH_LOTS_OF_VALUES = pd.DataFrame({COLUMN_NAME: ["A"] * BIG_NUMBER})
 
-SQL_DATA_SOURCES_EXCEPT_SNOWFLAKE = [
+# SQL Server ships no regex operator, so the per-dialect expression these metrics compile to has
+# no SQL Server form and the metric raises instead of computing. The regex expectation modules
+# draw the same line with hand-written supported-source lists; deriving it from the shared lists
+# here keeps this module in step as backends join them.
+REGEX_CAPABLE_SQL_DATA_SOURCES = [
     datasource
     for datasource in SQL_DATA_SOURCES
+    if not isinstance(datasource, SQLServerDatasourceTestConfig)
+]
+
+REGEX_CAPABLE_SQL_DATA_SOURCES_EXCEPT_SNOWFLAKE = [
+    datasource
+    for datasource in REGEX_CAPABLE_SQL_DATA_SOURCES
     if not isinstance(datasource, SnowflakeDatasourceTestConfig)
 ]
 
 
 class TestColumnValuesMatchRegexValues:
     @parameterize_batch_for_data_sources(
-        data_source_configs=SQL_DATA_SOURCES_EXCEPT_SNOWFLAKE,
+        data_source_configs=REGEX_CAPABLE_SQL_DATA_SOURCES_EXCEPT_SNOWFLAKE,
         data=DATA_FRAME,
     )
     def test_partial_match_characters(self, batch_for_datasource: Batch) -> None:
@@ -35,7 +46,7 @@ class TestColumnValuesMatchRegexValues:
         assert sorted(metric_result.value) == ["1ab2", "abc"]
 
     @parameterize_batch_for_data_sources(
-        data_source_configs=SQL_DATA_SOURCES,
+        data_source_configs=REGEX_CAPABLE_SQL_DATA_SOURCES,
         data=DATA_FRAME,
     )
     def test_special_characters(self, batch_for_datasource: Batch) -> None:
@@ -46,7 +57,7 @@ class TestColumnValuesMatchRegexValues:
         assert sorted(metric_result.value) == ["abc", "def"]
 
     @parameterize_batch_for_data_sources(
-        data_source_configs=SQL_DATA_SOURCES,
+        data_source_configs=REGEX_CAPABLE_SQL_DATA_SOURCES,
         data=DATA_FRAME_WITH_LOTS_OF_VALUES,
     )
     def test_default_limit(self, batch_for_datasource: Batch) -> None:
@@ -57,7 +68,7 @@ class TestColumnValuesMatchRegexValues:
         assert len(metric_result.value) == 20
 
     @parameterize_batch_for_data_sources(
-        data_source_configs=SQL_DATA_SOURCES,
+        data_source_configs=REGEX_CAPABLE_SQL_DATA_SOURCES,
         data=DATA_FRAME_WITH_LOTS_OF_VALUES,
     )
     def test_custom_limit(self, batch_for_datasource: Batch) -> None:

--- a/tests/integration/metrics/column/test_values_not_match_regex_count.py
+++ b/tests/integration/metrics/column/test_values_not_match_regex_count.py
@@ -6,6 +6,7 @@ from great_expectations.metrics.column.values_not_match_regex_count import (
     ColumnValuesNotMatchRegexCountResult,
 )
 from tests.integration.conftest import parameterize_batch_for_data_sources
+from tests.integration.test_utils.data_source_config import SQLServerDatasourceTestConfig
 from tests.metrics.conftest import (
     ALL_DATA_SOURCES,
     SPARK_DATA_SOURCES,
@@ -17,16 +18,26 @@ COLUMN_NAME = "whatevs"
 
 DATA_FRAME = pd.DataFrame({COLUMN_NAME: ["abc", "def", "ghi", "1ab2", "1ab3", None]})
 
-ALL_DATA_SOURCES_EXCEPT_SNOWFLAKE = [
+# SQL Server ships no regex operator, so the per-dialect expression these metrics compile to has
+# no SQL Server form and the metric raises instead of computing. The regex expectation modules
+# draw the same line with hand-written supported-source lists; deriving it from the shared lists
+# here keeps this module in step as backends join them.
+REGEX_CAPABLE_SQL_DATA_SOURCES = [
+    datasource
+    for datasource in SQL_DATA_SOURCES
+    if not isinstance(datasource, SQLServerDatasourceTestConfig)
+]
+
+REGEX_CAPABLE_DATA_SOURCES_EXCEPT_SNOWFLAKE = [
     datasource
     for datasource in ALL_DATA_SOURCES
-    if not isinstance(datasource, SnowflakeDatasourceTestConfig)
+    if not isinstance(datasource, (SQLServerDatasourceTestConfig, SnowflakeDatasourceTestConfig))
 ]
 
 
 class TestColumnValuesNotMatchRegexCount:
     @parameterize_batch_for_data_sources(
-        data_source_configs=ALL_DATA_SOURCES_EXCEPT_SNOWFLAKE,
+        data_source_configs=REGEX_CAPABLE_DATA_SOURCES_EXCEPT_SNOWFLAKE,
         data=DATA_FRAME,
     )
     def test_partial_match_characters(self, batch_for_datasource: Batch) -> None:
@@ -38,7 +49,7 @@ class TestColumnValuesNotMatchRegexCount:
         assert int(metric_result.value) == 2
 
     @parameterize_batch_for_data_sources(
-        data_source_configs=SPARK_DATA_SOURCES + SQL_DATA_SOURCES,
+        data_source_configs=SPARK_DATA_SOURCES + REGEX_CAPABLE_SQL_DATA_SOURCES,
         data=DATA_FRAME,
     )
     def test_special_characters(self, batch_for_datasource: Batch) -> None:

--- a/tests/integration/metrics/column/test_values_not_match_regex_values.py
+++ b/tests/integration/metrics/column/test_values_not_match_regex_values.py
@@ -6,6 +6,7 @@ from great_expectations.metrics.column.values_not_match_regex_values import (
     ColumnValuesNotMatchRegexValuesResult,
 )
 from tests.integration.conftest import parameterize_batch_for_data_sources
+from tests.integration.test_utils.data_source_config import SQLServerDatasourceTestConfig
 from tests.metrics.conftest import SQL_DATA_SOURCES, SnowflakeDatasourceTestConfig
 
 COLUMN_NAME = "whatevs"
@@ -15,16 +16,26 @@ MATCH_NONE_REGEX = "^$"  # Regex that matches nothing
 DATA_FRAME = pd.DataFrame({COLUMN_NAME: ["abc", "def", "ghi", "1ab2", None]})
 DATA_FRAME_WITH_LOTS_OF_VALUES = pd.DataFrame({COLUMN_NAME: ["A"] * BIG_NUMBER})
 
-SQL_DATA_SOURCES_EXCEPT_SNOWFLAKE = [
+# SQL Server ships no regex operator, so the per-dialect expression these metrics compile to has
+# no SQL Server form and the metric raises instead of computing. The regex expectation modules
+# draw the same line with hand-written supported-source lists; deriving it from the shared lists
+# here keeps this module in step as backends join them.
+REGEX_CAPABLE_SQL_DATA_SOURCES = [
     datasource
     for datasource in SQL_DATA_SOURCES
+    if not isinstance(datasource, SQLServerDatasourceTestConfig)
+]
+
+REGEX_CAPABLE_SQL_DATA_SOURCES_EXCEPT_SNOWFLAKE = [
+    datasource
+    for datasource in REGEX_CAPABLE_SQL_DATA_SOURCES
     if not isinstance(datasource, SnowflakeDatasourceTestConfig)
 ]
 
 
 class TestColumnValuesNotMatchRegexValues:
     @parameterize_batch_for_data_sources(
-        data_source_configs=SQL_DATA_SOURCES_EXCEPT_SNOWFLAKE,
+        data_source_configs=REGEX_CAPABLE_SQL_DATA_SOURCES_EXCEPT_SNOWFLAKE,
         data=DATA_FRAME,
     )
     def test_partial_match_characters(self, batch_for_datasource: Batch) -> None:
@@ -36,7 +47,7 @@ class TestColumnValuesNotMatchRegexValues:
         assert sorted(metric_result.value) == ["def", "ghi"]
 
     @parameterize_batch_for_data_sources(
-        data_source_configs=SQL_DATA_SOURCES,
+        data_source_configs=REGEX_CAPABLE_SQL_DATA_SOURCES,
         data=DATA_FRAME,
     )
     def test_special_characters(self, batch_for_datasource: Batch) -> None:
@@ -48,7 +59,7 @@ class TestColumnValuesNotMatchRegexValues:
         assert sorted(metric_result.value) == ["1ab2", "ghi"]
 
     @parameterize_batch_for_data_sources(
-        data_source_configs=SQL_DATA_SOURCES,
+        data_source_configs=REGEX_CAPABLE_SQL_DATA_SOURCES,
         data=DATA_FRAME_WITH_LOTS_OF_VALUES,
     )
     def test_default_limit(self, batch_for_datasource: Batch) -> None:
@@ -62,7 +73,7 @@ class TestColumnValuesNotMatchRegexValues:
         assert all(val == "A" for val in metric_result.value)
 
     @parameterize_batch_for_data_sources(
-        data_source_configs=SQL_DATA_SOURCES,
+        data_source_configs=REGEX_CAPABLE_SQL_DATA_SOURCES,
         data=DATA_FRAME_WITH_LOTS_OF_VALUES,
     )
     def test_custom_limit(self, batch_for_datasource: Batch) -> None:

--- a/tests/integration/test_utils/data_source_config/mysql.py
+++ b/tests/integration/test_utils/data_source_config/mysql.py
@@ -10,6 +10,7 @@ from great_expectations.datasource.fluent.sql_datasource import TableAsset
 from tests.integration.sql_session_manager import SessionSQLEngineManager
 from tests.integration.test_utils.data_source_config.backend_spec import (
     BackendProvisioning,
+    BackendTier,
     CiLaneRef,
     SqlBackendSpec,
 )
@@ -27,6 +28,7 @@ class MySQLDatasourceTestConfig(SqlDatasourceTestConfig):
         provisioning=BackendProvisioning.LOCAL_CONTAINER,
         ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="mysql"),
         uses_schema=True,
+        tiers=frozenset({BackendTier.STANDARD_SQL}),
         # MySQL requires a length for VARCHAR.
         column_type_overrides={str: sqltypes.VARCHAR(255)},
         dev_requirements_file="reqs/requirements-dev-mysql.txt",

--- a/tests/integration/test_utils/data_source_config/redshift.py
+++ b/tests/integration/test_utils/data_source_config/redshift.py
@@ -8,6 +8,7 @@ from great_expectations.compatibility.typing_extensions import override
 from great_expectations.datasource.fluent.redshift_datasource import RedshiftDsn
 from tests.integration.test_utils.data_source_config.backend_spec import (
     BackendProvisioning,
+    BackendTier,
     CiLaneRef,
     SqlBackendSpec,
 )
@@ -54,6 +55,7 @@ class RedshiftDatasourceTestConfig(SqlDatasourceTestConfig):
         # the job is named explicitly here rather than being the shared matrix job.
         ci_lane=CiLaneRef(workflow_job="redshift", marker_token="redshift"),
         uses_schema=True,
+        tiers=frozenset({BackendTier.STANDARD_SQL}),
         dev_requirements_file="reqs/requirements-dev-redshift.txt",
         task_runner_marker="redshift",
     )

--- a/tests/integration/test_utils/data_source_config/sql_server.py
+++ b/tests/integration/test_utils/data_source_config/sql_server.py
@@ -14,6 +14,7 @@ from great_expectations.datasource.fluent.sql_server_datasource import (
 from tests.integration.sql_session_manager import ConnectionDetails, SessionSQLEngineManager
 from tests.integration.test_utils.data_source_config.backend_spec import (
     BackendProvisioning,
+    BackendTier,
     CiLaneRef,
     SqlBackendSpec,
 )
@@ -43,6 +44,7 @@ class SQLServerDatasourceTestConfig(SqlDatasourceTestConfig):
         provisioning=BackendProvisioning.LOCAL_CONTAINER,
         ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="sql_server"),
         uses_schema=True,
+        tiers=frozenset({BackendTier.STANDARD_SQL}),
         dev_requirements_file="reqs/requirements-dev-sql-server.txt",
         task_runner_marker="sql_server",
         container_service="mssql",

--- a/tests/test_sql_backend_registry.py
+++ b/tests/test_sql_backend_registry.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import fields
-from typing import TYPE_CHECKING, Iterator, List, Mapping, Optional, Tuple
+from typing import TYPE_CHECKING, Iterator, List, Mapping, Optional, Sequence, Tuple
 
 import pytest
 
@@ -14,13 +14,16 @@ from tests.integration.test_utils.data_source_config import (
     SQL_DATA_SOURCES,
     BigQueryDatasourceTestConfig,
     DatabricksDatasourceTestConfig,
+    MySQLDatasourceTestConfig,
     PandasDataFrameDatasourceTestConfig,
     PandasFilesystemCsvDatasourceTestConfig,
     PostgreSQLDatasourceTestConfig,
+    RedshiftDatasourceTestConfig,
     SingleStoreDatasourceTestConfig,
     SnowflakeDatasourceTestConfig,
     SparkFilesystemCsvDatasourceTestConfig,
     SqliteDatasourceTestConfig,
+    SQLServerDatasourceTestConfig,
     data_sources_for_tier_case,
 )
 from tests.integration.test_utils.data_source_config.backend_spec import (
@@ -913,14 +916,24 @@ class TestRegisteredBackendsKeepTheInheritedHash:
             hash(config_class())  # a regenerated hash raises TypeError here
 
 
-class TestStandardDataSourceListsMatchPreChangeMembership:
+class TestStandardDataSourceListsMatchDeclaredMembership:
     """Regression pin for the four standard data-source lists now defined once in `tiers.py`.
 
-    Every literal below is transcribed from the two metrics conftest modules exactly as they
-    existed before those lists gained a single shared definition, not derived from the module
-    under test — so a mistake in the derivation shows up as a mismatch here rather than agreeing
-    with itself. `PANDAS_DATA_SOURCES` is deliberately not alphabetical: the filesystem CSV
-    config is listed before the DataFrame config, and that order is preserved on purpose.
+    Every literal below is written out here rather than derived from the module under test — so a
+    mistake in the derivation shows up as a mismatch here rather than agreeing with itself. The
+    pandas and Spark literals are transcribed from the two metrics conftest modules exactly as
+    they existed before those lists gained a single shared definition, and `PANDAS_DATA_SOURCES`
+    is deliberately not alphabetical: the filesystem CSV config is listed before the DataFrame
+    config, and that order is preserved on purpose.
+
+    The two SQL literals began as the same transcription and have since widened, once, by
+    declaration. MySQL, Microsoft SQL Server and Redshift appeared in the hand-written lists that
+    `test_canonical_expectations.py` still keeps but declared no tier, so the derived lists — the
+    pair the metrics tree consumes — omitted all three, and roughly 165 metrics parameterizations
+    never ran against them while the same backends ran the full expectation suite. Declaring
+    `BackendTier.STANDARD_SQL` on those three configs is what puts them in the literals below;
+    `TestDerivedSqlListsMatchTheHandWrittenCanonicalLists` is what stops the two definitions
+    parting again.
 
     The four constants imported above are captured at module-import time, before any test in this
     module runs. That matters because this module's `_snapshot_registry` fixture clears the
@@ -930,37 +943,116 @@ class TestStandardDataSourceListsMatchPreChangeMembership:
     observe the isolation seam's emptied registry and pass vacuously.
     """
 
-    def test_pandas_data_sources_match_pre_change_membership_and_order(self) -> None:
+    def test_pandas_data_sources_match_declared_membership_and_order(self) -> None:
         assert [
             PandasFilesystemCsvDatasourceTestConfig(),
             PandasDataFrameDatasourceTestConfig(),
         ] == PANDAS_DATA_SOURCES
 
-    def test_spark_data_sources_match_pre_change_membership_and_order(self) -> None:
+    def test_spark_data_sources_match_declared_membership_and_order(self) -> None:
         assert [
             SparkFilesystemCsvDatasourceTestConfig(),
         ] == SPARK_DATA_SOURCES
 
-    def test_sql_data_sources_match_pre_change_membership_and_order(self) -> None:
+    def test_sql_data_sources_match_declared_membership_and_order(self) -> None:
         assert [
             BigQueryDatasourceTestConfig(),
             DatabricksDatasourceTestConfig(),
+            SQLServerDatasourceTestConfig(),
+            MySQLDatasourceTestConfig(),
             PostgreSQLDatasourceTestConfig(),
+            RedshiftDatasourceTestConfig(),
             SnowflakeDatasourceTestConfig(),
             SqliteDatasourceTestConfig(),
         ] == SQL_DATA_SOURCES
 
-    def test_all_data_sources_match_pre_change_membership_and_order(self) -> None:
+    def test_all_data_sources_match_declared_membership_and_order(self) -> None:
         assert [
             PandasFilesystemCsvDatasourceTestConfig(),
             PandasDataFrameDatasourceTestConfig(),
             SparkFilesystemCsvDatasourceTestConfig(),
             BigQueryDatasourceTestConfig(),
             DatabricksDatasourceTestConfig(),
+            SQLServerDatasourceTestConfig(),
+            MySQLDatasourceTestConfig(),
             PostgreSQLDatasourceTestConfig(),
+            RedshiftDatasourceTestConfig(),
             SnowflakeDatasourceTestConfig(),
             SqliteDatasourceTestConfig(),
         ] == ALL_DATA_SOURCES
+
+
+class TestDerivedSqlListsMatchTheHandWrittenCanonicalLists:
+    """The derived lists and the hand-written ones name the same backends.
+
+    `SQL_DATA_SOURCES` and `ALL_DATA_SOURCES` are each defined twice under the same names: in
+    `tiers.py`, derived from tier declarations, and in
+    `tests/integration/data_sources_and_expectations/test_canonical_expectations.py`, written by
+    hand. The expectation modules import the hand-written pair and the metrics tree imports the
+    derived pair, so a backend can sit in one and be absent from the other, and nothing compared
+    them. Three did: MySQL, Microsoft SQL Server and Redshift ran every expectation module through
+    the hand-written lists while declaring no tier, which left them out of every list-driven
+    metrics parameterization with no error, no skip and no warning. The comparison below is what
+    was missing. It fails in both directions, so neither a config added to the hand-written lists
+    without a declaration nor a declaration with no corresponding hand-written entry can repeat
+    it.
+
+    `GenericSQLDatasourceTestConfig` is exempt, and is the one entry no derivation can reproduce:
+    it takes a caller-supplied connection string, has no fixed identity to register under, and its
+    own docstring says it "must never appear in the set that gates CI". A plain equality between
+    the two lists would therefore fail for a correct reason, so the assertion is against the
+    hand-written list minus that one config — and the third test pins the exemption at exactly
+    that config, so it cannot quietly widen to cover a second one.
+
+    Membership, not order: the hand-written module promises no particular ordering, while the
+    derived lists' own order is pinned above against a literal naming every entry.
+    """
+
+    @staticmethod
+    def _escape_hatch_name() -> str:
+        from tests.integration.test_utils.data_source_config.generic_sql import (
+            GenericSQLDatasourceTestConfig,
+        )
+
+        return GenericSQLDatasourceTestConfig.__name__
+
+    @staticmethod
+    def _class_names(configs: Sequence[DataSourceTestConfig]) -> List[str]:
+        return sorted(type(config).__name__ for config in configs)
+
+    @classmethod
+    def _hand_written_names(cls, configs: Sequence[DataSourceTestConfig]) -> List[str]:
+        return [name for name in cls._class_names(configs) if name != cls._escape_hatch_name()]
+
+    def test_sql_data_sources_hold_the_same_backends_under_either_import(self) -> None:
+        from tests.integration.data_sources_and_expectations.test_canonical_expectations import (
+            SQL_DATA_SOURCES as HAND_WRITTEN_SQL,
+        )
+
+        assert self._class_names(SQL_DATA_SOURCES) == self._hand_written_names(HAND_WRITTEN_SQL)
+
+    def test_all_data_sources_hold_the_same_backends_under_either_import(self) -> None:
+        from tests.integration.data_sources_and_expectations.test_canonical_expectations import (
+            ALL_DATA_SOURCES as HAND_WRITTEN_ALL,
+        )
+
+        assert self._class_names(ALL_DATA_SOURCES) == self._hand_written_names(HAND_WRITTEN_ALL)
+
+    def test_the_escape_hatch_is_the_only_entry_the_derivation_cannot_reproduce(self) -> None:
+        """Pins the exemption at one named config.
+
+        Without this, a second unregistered config added to the hand-written lists would leave the
+        two tests above passing, because the exemption they apply would have widened to cover it.
+        """
+        from tests.integration.data_sources_and_expectations.test_canonical_expectations import (
+            ALL_DATA_SOURCES as HAND_WRITTEN_ALL,
+        )
+
+        unreproducible = set(self._class_names(HAND_WRITTEN_ALL)) - set(
+            self._class_names(ALL_DATA_SOURCES)
+        )
+
+        assert unreproducible == {self._escape_hatch_name()}
 
 
 class TestCuratedSqlDataSourcesEqualsClickHouseOracleSingleStoreAndTrino:


### PR DESCRIPTION
## Summary

`SQL_DATA_SOURCES` and `ALL_DATA_SOURCES` are each defined twice under the same names:
`tests/integration/test_utils/data_source_config/tiers.py` derives them from what each backend
declares, and `tests/integration/data_sources_and_expectations/test_canonical_expectations.py`
writes them by hand. MySQL, Microsoft SQL Server and Redshift appear in the hand-written pair but
declare no tier, so they were absent from the derived pair — the one the metrics tree consumes.

This declares `BackendTier.STANDARD_SQL` on those three configs and adds a comparison between the
two definitions so they cannot part again. Three follow-on changes come with it: the membership pin
in `tests/test_sql_backend_registry.py` is updated to the widened lists, and four regex metric
modules now exclude SQL Server, which has no regex operator for those metrics to compile to.

Net effect on selection, measured by collecting the whole suite before and after: **+56 tests for
MySQL, +56 for Redshift, +44 for SQL Server, and no test removed from any other backend.**

## Why

Nothing compared the two definitions, so adding a backend to the hand-written list without also
declaring its tier produced no error, no skip and no warning — the metrics suite just ran against
fewer backends. All three arrived that way, and the result is a coverage hole that looks like
coverage: they run all 46 expectation modules through the hand-written lists while being absent from
every list-driven metrics parameterization. MySQL had no metrics coverage at all.

The new comparison fails in both directions, so neither half of that mistake can repeat.
`GenericSQLDatasourceTestConfig` is exempt and is the only exemption — it takes a caller-supplied
connection string, has no fixed identity to register under, and its own docstring says it must never
appear in the set that gates CI, so no derivation can reproduce it. A third assertion pins the
exemption at exactly that config so it cannot quietly widen to cover a second one.

## User impact

None. No shipped code path changes — the diff is entirely under `tests/`. What changes is how much
of the suite runs: three backends now execute the metrics parameterizations they were missing.

## How to review

- **The three declarations** (`mysql.py`, `sql_server.py`, `redshift.py`) are one line each, placed
  where `postgres.py` and `snowflake.py` place theirs.
- **The SQL Server regex exclusion is the one judgment call.** Twelve of SQL Server's newly selected
  tests failed, all in the four regex metric modules: `get_dialect_regex_expression` has no SQL
  Server branch, because SQL Server ships no regex predicate for it to compile to, so the metric
  raises rather than computing. The regex *expectation* modules already draw this line with
  hand-written supported-source lists (see `test_expect_column_values_to_match_regex.py`); these four
  derive it from the shared lists instead, so a backend joining those lists is covered automatically
  unless it is one the metric cannot serve.
- **The membership pin** in `tests/test_sql_backend_registry.py` was named for the pre-change
  transcription it started as; it is renamed and its docstring now records that the SQL literals have
  widened once, deliberately, and why.
- **Redshift is the one lane not verified locally** — it authenticates against hosted
  infrastructure. MySQL (238 passed) and SQL Server (245 passed, 3 skipped, 3 xfailed) are both green
  locally after the change, as are the `project` and `sqlite` lanes (752 passed). Redshift's 56 new
  tests run for the first time in this PR's `redshift` job; that lane is the thing to watch.