### PR TITLE
[CONTRIB] add explanatory message to NotImplementedError for unsupported regex dialects

### DIFF
--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_values_match_regex_values.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_values_match_regex_values.py
@@ -44,8 +44,10 @@ class ColumnValuesMatchRegexValues(ColumnAggregateMetricProvider):
 
         regex_expression = get_dialect_regex_expression(column, regex, _dialect)
         if regex_expression is None:
-            logger.warning(f"Regex is not supported for dialect {_dialect.name!s}")
-            raise NotImplementedError
+            dialect_name = getattr(getattr(_dialect, "dialect", _dialect), "name", str(_dialect))
+            msg = f"Regex is not supported for dialect {dialect_name}"
+            logger.warning(msg)
+            raise NotImplementedError(msg)
 
         query = sa.select(column).where(regex_expression).select_from(selectable)  # type: ignore[arg-type]
         if isinstance(limit, int):

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_values_not_match_regex_values.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_values_not_match_regex_values.py
@@ -44,8 +44,10 @@ class ColumnValuesNotMatchRegexValues(ColumnAggregateMetricProvider):
 
         regex_expression = get_dialect_regex_expression(column, regex, _dialect)
         if regex_expression is None:
-            logger.warning(f"Regex is not supported for dialect {_dialect.name!s}")
-            raise NotImplementedError
+            dialect_name = getattr(getattr(_dialect, "dialect", _dialect), "name", str(_dialect))
+            msg = f"Regex is not supported for dialect {dialect_name}"
+            logger.warning(msg)
+            raise NotImplementedError(msg)
 
         # Find values that DO NOT match the regex
         query = sa.select(column).where(sa.not_(regex_expression)).select_from(selectable)  # type: ignore[arg-type]

--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_match_regex.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_match_regex.py
@@ -44,8 +44,10 @@ class ColumnValuesMatchRegex(ColumnMapMetricProvider):
     def _sqlalchemy(cls, column, regex, _dialect, **kwargs):
         regex_expression = get_dialect_regex_expression(column, regex, _dialect)
         if regex_expression is None:
-            logger.warning(f"Regex is not supported for dialect {_dialect.dialect.name!s}")
-            raise NotImplementedError
+            dialect_name = getattr(getattr(_dialect, "dialect", _dialect), "name", str(_dialect))
+            msg = f"Regex is not supported for dialect {dialect_name}"
+            logger.warning(msg)
+            raise NotImplementedError(msg)
 
         return regex_expression
 

--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_match_regex_list.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_match_regex_list.py
@@ -53,8 +53,10 @@ class ColumnValuesMatchRegexList(ColumnMapMetricProvider):
 
         regex_expression = get_dialect_regex_expression(column, regex_list[0], _dialect)
         if regex_expression is None:
-            logger.warning(f"Regex is not supported for dialect {_dialect!s}")
-            raise NotImplementedError
+            dialect_name = getattr(getattr(_dialect, "dialect", _dialect), "name", str(_dialect))
+            msg = f"Regex is not supported for dialect {dialect_name}"
+            logger.warning(msg)
+            raise NotImplementedError(msg)
 
         if match_on == "any":
             condition = sa.or_(

--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_not_match_regex.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_not_match_regex.py
@@ -44,8 +44,10 @@ class ColumnValuesNotMatchRegex(ColumnMapMetricProvider):
     def _sqlalchemy(cls, column, regex, _dialect, **kwargs):
         regex_expression = get_dialect_regex_expression(column, regex, _dialect, positive=False)
         if regex_expression is None:
-            logger.warning(f"Regex is not supported for dialect {_dialect!s}")
-            raise NotImplementedError
+            dialect_name = getattr(getattr(_dialect, "dialect", _dialect), "name", str(_dialect))
+            msg = f"Regex is not supported for dialect {dialect_name}"
+            logger.warning(msg)
+            raise NotImplementedError(msg)
 
         return regex_expression
 

--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_not_match_regex_list.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_not_match_regex_list.py
@@ -41,8 +41,10 @@ class ColumnValuesNotMatchRegexList(ColumnMapMetricProvider):
             column, regex_list[0], _dialect, positive=False
         )
         if regex_expression is None:
-            logger.warning(f"Regex is not supported for dialect {_dialect!s}")
-            raise NotImplementedError
+            dialect_name = getattr(getattr(_dialect, "dialect", _dialect), "name", str(_dialect))
+            msg = f"Regex is not supported for dialect {dialect_name}"
+            logger.warning(msg)
+            raise NotImplementedError(msg)
 
         return sa.and_(
             *(

--- a/tests/expectations/metrics/test_regex_unsupported_dialect.py
+++ b/tests/expectations/metrics/test_regex_unsupported_dialect.py
@@ -1,0 +1,17 @@
+import pytest
+from great_expectations.expectations.metrics.column_map_metrics.column_values_match_regex import (
+    ColumnValuesMatchRegex,
+)
+
+class DummyMSSQLDialect:
+    class dialect:
+        name = "mssql"
+
+def test_regex_unsupported_dialect_raises_not_implemented_error_with_message():
+    fake_dialect = DummyMSSQLDialect()
+    raw_fn = ColumnValuesMatchRegex._sqlalchemy.__wrapped__.__wrapped__
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        raw_fn(ColumnValuesMatchRegex, "test_col", "^abc$", fake_dialect)
+
+    assert "Regex is not supported for dialect mssql" in str(exc_info.value)

--- a/tests/expectations/metrics/test_regex_unsupported_dialect.py
+++ b/tests/expectations/metrics/test_regex_unsupported_dialect.py
@@ -1,20 +1,115 @@
+"""A regex metric that cannot compile for the active dialect must say so.
+
+Six ``_sqlalchemy`` implementations share one fallback: when
+``get_dialect_regex_expression`` has no branch for the active dialect it returns
+``None`` and the metric raises ``NotImplementedError``. The message that exception
+carries is the only statement of the cause that reaches
+``ExpectationValidationResult.exception_info`` -- a bare ``raise`` records an empty
+``exception_message``, which is indistinguishable from a regex that simply matched
+nothing.
+
+These tests pin the message at each of the six raise sites. The end-to-end
+propagation of that message through the validation machinery is covered against a
+live SQL Server in
+``tests/integration/data_sources_and_expectations/expectations/test_expect_column_values_to_match_regex.py``.
+"""
+
+from typing import Any, Callable
+
 import pytest
 
-from great_expectations.expectations.metrics.column_map_metrics.column_values_match_regex import (
+from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
+from great_expectations.expectations.metrics.column_aggregate_metrics import (
+    ColumnValuesMatchRegexValues,
+    ColumnValuesNotMatchRegexValues,
+)
+from great_expectations.expectations.metrics.column_map_metrics import (
     ColumnValuesMatchRegex,
+    ColumnValuesMatchRegexList,
+    ColumnValuesNotMatchRegex,
+    ColumnValuesNotMatchRegexList,
 )
 
+# SQL Server has no branch in get_dialect_regex_expression, and this module is what
+# SqlAlchemyExecutionEngine hands the metrics as `_dialect` for that backend.
+MSSQL_DIALECT_MODULE = sa.dialects.mssql
 
-class DummyMSSQLDialect:
-    class dialect:
-        name = "mssql"
+EXPECTED_MESSAGE = "Regex is not supported for dialect mssql"
 
 
-def test_regex_unsupported_dialect_raises_not_implemented_error_with_message():
-    fake_dialect = DummyMSSQLDialect()
-    raw_fn = ColumnValuesMatchRegex._sqlalchemy.__wrapped__.__wrapped__
+def _undecorated(metric_fn: Callable) -> Callable:
+    """Peel the metric decorators off, leaving the implementation itself."""
+    while hasattr(metric_fn, "__wrapped__"):
+        metric_fn = metric_fn.__wrapped__
+    return metric_fn
 
+
+class StubSqlAlchemyExecutionEngine:
+    """The little of the execution engine the aggregate metrics touch before raising."""
+
+    dialect_module = MSSQL_DIALECT_MODULE
+
+    def get_compute_domain(
+        self, metric_domain_kwargs: dict, domain_type: Any
+    ) -> tuple[Any, dict, dict]:
+        return sa.table("test_table"), {}, {"column": "test_column"}
+
+
+def _call_column_map_metric(metric_cls: Any, **kwargs: Any) -> None:
+    _undecorated(metric_cls._sqlalchemy)(
+        metric_cls,
+        sa.column("test_column"),
+        _dialect=MSSQL_DIALECT_MODULE,
+        **kwargs,
+    )
+
+
+def _call_column_aggregate_metric(metric_cls: Any) -> None:
+    _undecorated(metric_cls._sqlalchemy)(
+        metric_cls,
+        execution_engine=StubSqlAlchemyExecutionEngine(),
+        metric_domain_kwargs={},
+        metric_value_kwargs={"regex": "^abc$", "limit": None},
+        metrics={},
+        runtime_configuration={},
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "call_metric",
+    [
+        pytest.param(
+            lambda: _call_column_map_metric(ColumnValuesMatchRegex, regex="^abc$"),
+            id="column_values.match_regex",
+        ),
+        pytest.param(
+            lambda: _call_column_map_metric(ColumnValuesNotMatchRegex, regex="^abc$"),
+            id="column_values.not_match_regex",
+        ),
+        pytest.param(
+            lambda: _call_column_map_metric(
+                ColumnValuesMatchRegexList, regex_list=["^abc$"], match_on="any"
+            ),
+            id="column_values.match_regex_list",
+        ),
+        pytest.param(
+            lambda: _call_column_map_metric(ColumnValuesNotMatchRegexList, regex_list=["^abc$"]),
+            id="column_values.not_match_regex_list",
+        ),
+        pytest.param(
+            lambda: _call_column_aggregate_metric(ColumnValuesMatchRegexValues),
+            id="column_values.match_regex_values",
+        ),
+        pytest.param(
+            lambda: _call_column_aggregate_metric(ColumnValuesNotMatchRegexValues),
+            id="column_values.not_match_regex_values",
+        ),
+    ],
+)
+def test_regex_metric_names_the_unsupported_dialect(call_metric: Callable[[], None]) -> None:
+    """Every raise site carries the same message, naming the dialect, not a module repr."""
     with pytest.raises(NotImplementedError) as exc_info:
-        raw_fn(ColumnValuesMatchRegex, "test_col", "^abc$", fake_dialect)
+        call_metric()
 
-    assert "Regex is not supported for dialect mssql" in str(exc_info.value)
+    assert str(exc_info.value) == EXPECTED_MESSAGE

--- a/tests/expectations/metrics/test_regex_unsupported_dialect.py
+++ b/tests/expectations/metrics/test_regex_unsupported_dialect.py
@@ -1,11 +1,14 @@
 import pytest
+
 from great_expectations.expectations.metrics.column_map_metrics.column_values_match_regex import (
     ColumnValuesMatchRegex,
 )
 
+
 class DummyMSSQLDialect:
     class dialect:
         name = "mssql"
+
 
 def test_regex_unsupported_dialect_raises_not_implemented_error_with_message():
     fake_dialect = DummyMSSQLDialect()

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_values_to_match_regex.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_values_to_match_regex.py
@@ -18,6 +18,7 @@ from tests.integration.test_utils.data_source_config import (
     PostgreSQLDatasourceTestConfig,
     RedshiftDatasourceTestConfig,
     SparkFilesystemCsvDatasourceTestConfig,
+    SQLServerDatasourceTestConfig,
 )
 from tests.integration.test_utils.data_source_config.base import DataSourceTestConfig
 from tests.integration.test_utils.data_source_config.sqlite import SqliteDatasourceTestConfig
@@ -250,3 +251,26 @@ def test_include_unexpected_rows_sql(batch_for_datasource: Batch) -> None:
     unexpected_rows_str = str(unexpected_rows_data)
     assert "123" in unexpected_rows_str
     assert "a1b2" in unexpected_rows_str
+
+
+@parameterize_batch_for_data_sources(
+    data_source_configs=[SQLServerDatasourceTestConfig()],
+    data=DATA,
+)
+def test_unsupported_dialect_states_the_reason(batch_for_datasource: Batch) -> None:
+    """A dialect with no regex support must say so in the result, not fail silently.
+
+    SQL Server has no regex predicate to compile to, so the metric raises. The reason
+    reaches the user only through exception_info; a bare raise leaves it empty, which is
+    indistinguishable from a regex that matched nothing or a column that does not exist.
+    """
+    result = batch_for_datasource.validate(
+        gxe.ExpectColumnValuesToMatchRegex(column=BASIC_STRINGS, regex="^[a-z]{3}$")
+    )
+
+    assert result.success is False
+    messages = [info["exception_message"] for info in result.exception_info.values()]
+    assert messages, "expected the result to record an exception"
+    assert all("Regex is not supported for dialect mssql" in message for message in messages), (
+        f"exception_message does not state the cause: {messages!r}"
+    )


### PR DESCRIPTION
## Description
Fixes #12108 where running regex-based Expectations against SQL dialects that do not support regex (such as SQL Server / MSSQL) returns an empty `exception_message: ''` inside `ExpectationValidationResult.exception_info`. 

This issue was caused by six metric `_sqlalchemy` raise sites logging a warning string but calling `raise NotImplementedError` without passing the message argument to the exception.

## Changes Proposed
- **Standardized Exception Messages:** Updated all 6 regex metric `_sqlalchemy` raise sites to extract the dialect name cleanly and pass `msg = f"Regex is not supported for dialect {dialect_name}"` directly to `raise NotImplementedError(msg)`:
  - `great_expectations/expectations/metrics/column_map_metrics/column_values_match_regex.py`
  - `great_expectations/expectations/metrics/column_map_metrics/column_values_not_match_regex.py`
  - `great_expectations/expectations/metrics/column_map_metrics/column_values_match_regex_list.py`
  - `great_expectations/expectations/metrics/column_map_metrics/column_values_not_match_regex_list.py`
  - `great_expectations/expectations/metrics/column_aggregate_metrics/column_values_match_regex_values.py`
  - `great_expectations/expectations/metrics/column_aggregate_metrics/column_values_not_match_regex_values.py`
- **Dialect Name Normalization:** Replaced inconsistent string formatting with `dialect_name = getattr(getattr(_dialect, "dialect", _dialect), "name", str(_dialect))` across all six sites to prevent `<module 'sqlalchemy...'>` string repr outputs.
- **Unit Testing:** Added a dedicated unit test in `tests/expectations/metrics/test_regex_unsupported_dialect.py` to verify that `NotImplementedError` captures the expected message string on unsupported dialects.

## Related Issues
Closes #12108

## How Has This Been Tested?
- [x] Ran localized unit test: `pytest tests/expectations/metrics/test_regex_unsupported_dialect.py` (Passed)
- [x] Ran non-spark metric test suite: `pytest tests/expectations/metrics/ -m "not spark"` (368 passed)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have signed off my commits using `git commit -s` (DCO)