### PR TITLE
[MAINTENANCE] Restore the S3 docs fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,10 +187,11 @@ jobs:
       GOOGLE_APPLICATION_CREDENTIALS: "${{github.workspace}}/gcp-credentials.json"
       GX_GCS_TEST_BUCKET: ${{vars.GX_GCS_TEST_BUCKET}}
       # aws
-      AWS_ACCESS_KEY_ID: ${{secrets.CI_AWS_ACCESS_KEY_ID}}
-      AWS_DEFAULT_REGION: ${{secrets.CI_AWS_DEFAULT_REGION}}
-      AWS_REGION: ${{secrets.CI_AWS_DEFAULT_REGION}}
-      AWS_SECRET_ACCESS_KEY: ${{secrets.CI_AWS_SECRET_ACCESS_KEY}}
+      # No AWS_* mapping here. Credentials come from the OIDC role assumed in the
+      # "Configure AWS credentials" step below, which exports AWS_ACCESS_KEY_ID,
+      # AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN into $GITHUB_ENV. A job-level
+      # env: entry for any of those would shadow what that step exports.
+      GX_S3_TEST_BUCKET: ${{vars.GX_S3_TEST_BUCKET}}
       # aws-redshift
       REDSHIFT_USERNAME: ${{secrets.REDSHIFT_USERNAME}}
       REDSHIFT_PASSWORD: ${{secrets.REDSHIFT_PASSWORD}}
@@ -236,6 +237,15 @@ jobs:
         uses: actions/checkout@v4.3.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+
+      # Only the docs-creds-needed leg passes --aws; the other legs have no reason
+      # to hold AWS credentials, short-lived or not.
+      - name: Configure AWS credentials
+        if: matrix['doc-step'] == 'docs-creds-needed'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_DEFAULT_REGION }}
 
       - name: Upgrade Docker Compose
         uses: docker/setup-compose-action@v1

--- a/docs/docusaurus/docs/components/_testing/test_data_contexts/filesystem_datasource_aws_pandas_no_assets/gx/great_expectations.yml
+++ b/docs/docusaurus/docs/components/_testing/test_data_contexts/filesystem_datasource_aws_pandas_no_assets/gx/great_expectations.yml
@@ -81,6 +81,6 @@ analytics_enabled: true
 fluent_datasources:
   my_filesystem_data_source:
     type: pandas_s3
-    bucket: great-expectations-docs-test
+    bucket: ${GX_S3_TEST_BUCKET}
     boto3_options: {}
 data_context_id: 7fbbffee-f620-41fb-9b40-9e2a2032629a

--- a/docs/docusaurus/docs/components/_testing/test_data_contexts/filesystem_datasource_aws_spark_no_assets/gx/great_expectations.yml
+++ b/docs/docusaurus/docs/components/_testing/test_data_contexts/filesystem_datasource_aws_spark_no_assets/gx/great_expectations.yml
@@ -81,6 +81,6 @@ analytics_enabled: true
 fluent_datasources:
   my_filesystem_data_source:
     type: spark_s3
-    bucket: great-expectations-docs-test
+    bucket: ${GX_S3_TEST_BUCKET}
     boto3_options: {}
 data_context_id: b0994ef6-1290-461b-b065-5cb67870e555

--- a/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_s3/_pandas.py
+++ b/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_s3/_pandas.py
@@ -1,4 +1,6 @@
 # <snippet name="docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_s3/_pandas.py - full example">
+import os
+
 import great_expectations as gx
 
 context = gx.get_context()
@@ -6,9 +8,11 @@ context = gx.get_context()
 # Define the Data Source's parameters:
 # <snippet name="docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_s3/_pandas.py - define Data Source parameters">
 data_source_name = "my_filesystem_data_source"
-bucket_name = "great-expectations-docs-test"
+bucket_name = "my_bucket"
 boto3_options = {}
 # </snippet>
+
+bucket_name = os.environ["GX_S3_TEST_BUCKET"]
 
 # Create the Data Source:
 # <snippet name="docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_s3/_pandas.py - add Data Source">

--- a/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_s3/_spark.py
+++ b/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_s3/_spark.py
@@ -1,4 +1,6 @@
 # <snippet name="docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_s3/_spark.py - full example">
+import os
+
 import great_expectations as gx
 
 context = gx.get_context()
@@ -6,9 +8,11 @@ context = gx.get_context()
 # Define the Data Source's parameters:
 # <snippet name="docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_s3/_spark.py - define Data Source parameters">
 data_source_name = "my_filesystem_data_source"
-bucket_name = "great-expectations-docs-test"
+bucket_name = "my_bucket"
 boto3_options = {}
 # </snippet>
+
+bucket_name = os.environ["GX_S3_TEST_BUCKET"]
 
 # Create the Data Source:
 # <snippet name="docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_s3/_spark.py - add Data Source">

--- a/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_pandas.py
+++ b/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_pandas.py
@@ -5,6 +5,8 @@ pytest -v --docs-tests -k "how_to_connect_to_data_on_s3_using_pandas" tests/inte
 ```
 """
 
+import os
+
 import great_expectations as gx
 
 context = gx.get_context()
@@ -16,7 +18,7 @@ bucket_name = "my_bucket"
 boto3_options = {}
 # </snippet>
 
-bucket_name = "great-expectations-docs-test"
+bucket_name = os.environ["GX_S3_TEST_BUCKET"]
 
 # Python
 # <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_pandas.py create_datasource">

--- a/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_spark.py
+++ b/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_spark.py
@@ -5,6 +5,8 @@ pytest -v --docs-tests -k "how_to_connect_to_data_on_s3_using_spark" tests/integ
 ```
 """
 
+import os
+
 import great_expectations as gx
 
 context = gx.get_context()
@@ -16,7 +18,7 @@ bucket_name = "my_bucket"
 boto3_options = {}
 # </snippet>
 
-bucket_name = "great-expectations-docs-test"
+bucket_name = os.environ["GX_S3_TEST_BUCKET"]
 
 
 # Python

--- a/tasks.py
+++ b/tasks.py
@@ -1027,11 +1027,12 @@ MARKER_DEPENDENCY_MAP: Final[Mapping[str, TestDependencies]] = {
         ),
         services=("mssql", "trino"),
         extra_pytest_args=(
-            # TEMPORARY (CI transition): the S3, Azure Blob, BigQuery, Redshift, and
-            # Snowflake backends are unavailable while their CI infrastructure is torn down.
+            # TEMPORARY (CI transition): the Azure Blob, BigQuery, Redshift, and Snowflake
+            # backends are unavailable while their CI infrastructure is torn down.
             # Requesting any of them makes test collection eagerly connect to a dead backend
             # and abort the whole session, so only the available backends are requested here.
             # Restore the remaining cloud/warehouse flags once the infra is back.
+            "--aws",
             "--gcs",
             "--trino",
             "--docs-tests",

--- a/tests/integration/integration_test_fixture.py
+++ b/tests/integration/integration_test_fixture.py
@@ -6,7 +6,8 @@ from typing import List, Optional, Tuple
 from tests.integration.backend_dependencies import BackendDependencies
 
 GCS_TEST_BUCKET_ENV_VAR = "GX_GCS_TEST_BUCKET"
-GCS_TEST_BUCKET_TEMPLATE = "${" + GCS_TEST_BUCKET_ENV_VAR + "}"
+S3_TEST_BUCKET_ENV_VAR = "GX_S3_TEST_BUCKET"
+TEST_BUCKET_ENV_VARS = (GCS_TEST_BUCKET_ENV_VAR, S3_TEST_BUCKET_ENV_VAR)
 
 
 @dataclass
@@ -37,27 +38,32 @@ class IntegrationTestFixture:
     util_script: Optional[str] = None
 
 
-def substitute_gcs_test_bucket(config_path: pathlib.Path) -> None:
-    """Resolve the GCS bucket placeholder in a copied test Data Context config.
+def substitute_test_buckets(config_path: pathlib.Path) -> None:
+    """Resolve object-store bucket placeholders in a copied test Data Context config.
 
-    The GCS-backed `data_context_dir` configs name their bucket with a placeholder rather
-    than a literal, so the bucket can be changed without editing the fixtures. GX applies
-    config substitution to credential fields only, not to `bucket_or_name`, so the
-    placeholder is resolved here — on the copy the test runs against, never the checked-in
-    fixture.
+    The GCS- and S3-backed `data_context_dir` configs name their bucket with a
+    placeholder rather than a literal, so the bucket can be changed without editing the
+    fixtures. GX applies config substitution to credential fields only, not to `bucket`
+    or `bucket_or_name`, so the placeholder is resolved here — on the copy the test runs
+    against, never the checked-in fixture.
 
-    Only this one placeholder is substituted. Other config templates are left for GX to
+    Only these placeholders are substituted. Other config templates are left for GX to
     resolve, since exercising that path is the point of the fixtures that use them.
     """
     if not config_path.exists():
         return
-    config = config_path.read_text()
-    if GCS_TEST_BUCKET_TEMPLATE not in config:
-        return
-    bucket = os.environ.get(GCS_TEST_BUCKET_ENV_VAR)
-    if not bucket:
-        raise RuntimeError(
-            f"{config_path.name} requires a GCS bucket, but the"
-            f" {GCS_TEST_BUCKET_ENV_VAR} environment variable is not set."
-        )
-    config_path.write_text(config.replace(GCS_TEST_BUCKET_TEMPLATE, bucket))
+    original = config_path.read_text()
+    config = original
+    for env_var in TEST_BUCKET_ENV_VARS:
+        template = "${" + env_var + "}"
+        if template not in config:
+            continue
+        bucket = os.environ.get(env_var)
+        if not bucket:
+            raise RuntimeError(
+                f"{config_path.name} requires an object-store bucket, but the"
+                f" {env_var} environment variable is not set."
+            )
+        config = config.replace(template, bucket)
+    if config != original:
+        config_path.write_text(config)

--- a/tests/integration/test_definitions/s3/README.md
+++ b/tests/integration/test_definitions/s3/README.md
@@ -1,0 +1,63 @@
+# S3 Integration tests
+
+S3 = Amazon Simple Storage Service
+
+S3 is a blob store similar to Google Cloud Storage and Microsoft ABS.
+
+## Configuration
+
+These tests read from a real S3 bucket, named by the `GX_S3_TEST_BUCKET` environment
+variable. The bucket is expected to contain the taxi sample data at
+`data/taxi_yellow_tripdata_samples/`, and the credentials in use must be able to read it.
+The variable is required — the test scripts fail immediately if it is not set — so that a
+missing or misconfigured bucket name is reported directly instead of surfacing as an
+object-not-found error.
+
+Credentials come from the standard boto3 environment chain, since the fixtures pass
+`boto3_options={}`. In CI they are short-lived and obtained by assuming a role through
+GitHub's OIDC provider; locally, any profile that can read the bucket will do.
+
+The identity needs exactly two permissions: `s3:ListBucket` on the bucket and
+`s3:GetObject` on its objects. Those are different resources — the bucket ARN and the
+object ARN with a `/*` suffix — and granting only the former produces a clean listing
+followed by a `403` on the first batch read.
+
+## Running them
+
+The tests are gated behind `--aws`:
+
+```bash
+pytest -v --docs-tests --aws -k "s3" tests/integration/test_script_runner.py
+```
+
+Watch for skips rather than failures — a skip means the flag or a gate is still wrong, and
+a green run of zero tests is the failure mode worth guarding against.
+
+## Exactly three objects
+
+`partition_on_datetime.py` asserts that the monthly batch definition yields exactly three
+batches, matching `yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv`. A fourth
+month uploaded under the same prefix breaks that assertion, and the failure reads like a
+partitioner bug rather than a data problem. Objects that do not match the regex are
+harmless — the connector compiles prefix and regex together and filters on the result.
+
+## What does not run yet: Spark
+
+`create_a_data_source_filesystem_s3_spark` and the Spark half of
+`how_to_connect_to_data_on_s3_using_spark` need both AWS and Spark. They are deliberately
+left skipped: the `docs-creds-needed` leg requests `--aws` without `--spark`, and
+`docs-spark` requests `--spark` without `--aws`, so no leg requests both.
+
+The blocker is not the pytest flags. Spark reads S3 through `s3a://` URIs, which Hadoop
+resolves only when the `hadoop-aws` connector and its matching `aws-java-sdk-bundle` are
+on the JVM classpath. Without them the read fails:
+
+```
+java.lang.ClassNotFoundException: org.apache.hadoop.fs.s3a.S3AFileSystem
+```
+
+Those jars must be present when the JVM starts, so no Python requirement can supply them —
+it needs `PYSPARK_SUBMIT_ARGS` or a pre-staged jar in the workflow, plus Hadoop
+credential-provider configuration. This mirrors the GCS situation described in
+`tests/integration/test_definitions/gcs/README.md`. Adding `--aws` to `docs-spark` before
+that exists only converts a skip into a failure.

--- a/tests/integration/test_definitions/s3/partition_on_datetime.py
+++ b/tests/integration/test_definitions/s3/partition_on_datetime.py
@@ -1,3 +1,4 @@
+import os
 import re
 
 import great_expectations as gx
@@ -5,7 +6,7 @@ import great_expectations as gx
 context = gx.get_context()
 
 datasource_name = "my_s3_datasource"
-bucket_name = "great-expectations-docs-test"
+bucket_name = os.environ["GX_S3_TEST_BUCKET"]
 
 datasource = context.data_sources.add_pandas_s3(
     name=datasource_name, bucket=bucket_name, boto3_options={}

--- a/tests/integration/test_definitions/s3/select_batch_by_path.py
+++ b/tests/integration/test_definitions/s3/select_batch_by_path.py
@@ -1,9 +1,11 @@
+import os
+
 import great_expectations as gx
 
 context = gx.get_context()
 
 datasource_name = "my_s3_datasource"
-bucket_name = "great-expectations-docs-test"
+bucket_name = os.environ["GX_S3_TEST_BUCKET"]
 
 datasource = context.data_sources.add_pandas_s3(
     name=datasource_name, bucket=bucket_name, boto3_options={}

--- a/tests/integration/test_integration_test_fixture.py
+++ b/tests/integration/test_integration_test_fixture.py
@@ -2,47 +2,75 @@ import pathlib
 
 import pytest
 
-from tests.integration.integration_test_fixture import substitute_gcs_test_bucket
+from tests.integration.integration_test_fixture import substitute_test_buckets
 
 
 @pytest.mark.filesystem
-def test_substitute_gcs_test_bucket(monkeypatch, tmp_path: pathlib.Path):
-    monkeypatch.setenv("GX_GCS_TEST_BUCKET", "bucket_from_the_environment")
+@pytest.mark.parametrize(
+    ("env_var", "field"),
+    [
+        ("GX_GCS_TEST_BUCKET", "bucket_or_name"),
+        ("GX_S3_TEST_BUCKET", "bucket"),
+    ],
+)
+def test_substitute_test_buckets(monkeypatch, tmp_path: pathlib.Path, env_var: str, field: str):
+    monkeypatch.setenv(env_var, "bucket_from_the_environment")
     config = tmp_path / "great_expectations.yml"
-    config.write_text("    bucket_or_name: ${GX_GCS_TEST_BUCKET}\n")
+    config.write_text(f"    {field}: ${{{env_var}}}\n")
 
-    substitute_gcs_test_bucket(config)
+    substitute_test_buckets(config)
 
-    assert config.read_text() == "    bucket_or_name: bucket_from_the_environment\n"
+    assert config.read_text() == f"    {field}: bucket_from_the_environment\n"
 
 
 @pytest.mark.filesystem
-def test_substitute_gcs_test_bucket_raises_when_env_var_unset(monkeypatch, tmp_path: pathlib.Path):
-    monkeypatch.delenv("GX_GCS_TEST_BUCKET", raising=False)
+@pytest.mark.parametrize("env_var", ["GX_GCS_TEST_BUCKET", "GX_S3_TEST_BUCKET"])
+def test_substitute_test_buckets_raises_when_env_var_unset(
+    monkeypatch, tmp_path: pathlib.Path, env_var: str
+):
+    monkeypatch.delenv(env_var, raising=False)
     config = tmp_path / "great_expectations.yml"
-    config.write_text("    bucket_or_name: ${GX_GCS_TEST_BUCKET}\n")
+    config.write_text(f"    bucket: ${{{env_var}}}\n")
 
-    with pytest.raises(RuntimeError, match="GX_GCS_TEST_BUCKET"):
-        substitute_gcs_test_bucket(config)
+    with pytest.raises(RuntimeError, match=env_var):
+        substitute_test_buckets(config)
 
 
 @pytest.mark.filesystem
-def test_substitute_gcs_test_bucket_leaves_other_templates_alone(
+def test_substitute_test_buckets_only_requires_the_placeholder_that_is_present(
     monkeypatch, tmp_path: pathlib.Path
 ):
+    """An S3 fixture must not require the GCS bucket, or vice versa.
+
+    Each config names one object store. Demanding both env vars would make every
+    S3 fixture fail on a machine set up only for S3.
+    """
+    monkeypatch.setenv("GX_S3_TEST_BUCKET", "s3_bucket")
+    monkeypatch.delenv("GX_GCS_TEST_BUCKET", raising=False)
+    config = tmp_path / "great_expectations.yml"
+    config.write_text("    bucket: ${GX_S3_TEST_BUCKET}\n")
+
+    substitute_test_buckets(config)
+
+    assert config.read_text() == "    bucket: s3_bucket\n"
+
+
+@pytest.mark.filesystem
+def test_substitute_test_buckets_leaves_other_templates_alone(monkeypatch, tmp_path: pathlib.Path):
     """Templates GX resolves itself must survive, so those fixtures still exercise that path."""
     monkeypatch.setenv("GX_GCS_TEST_BUCKET", "bucket_from_the_environment")
+    monkeypatch.setenv("GX_S3_TEST_BUCKET", "bucket_from_the_environment")
     monkeypatch.setenv("AZURE_CREDENTIAL", "should_not_be_substituted")
     original = "      credential: ${AZURE_CREDENTIAL}\n"
     config = tmp_path / "great_expectations.yml"
     config.write_text(original)
 
-    substitute_gcs_test_bucket(config)
+    substitute_test_buckets(config)
 
     assert config.read_text() == original
 
 
 @pytest.mark.filesystem
-def test_substitute_gcs_test_bucket_is_a_noop_without_a_config(tmp_path: pathlib.Path):
+def test_substitute_test_buckets_is_a_noop_without_a_config(tmp_path: pathlib.Path):
     """A fixture with no Data Context config of its own must not raise."""
-    substitute_gcs_test_bucket(tmp_path / "does_not_exist.yml")
+    substitute_test_buckets(tmp_path / "does_not_exist.yml")

--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -30,7 +30,7 @@ from great_expectations.data_context.util import file_relative_path
 from tests.integration.backend_dependencies import BackendDependencies
 from tests.integration.integration_test_fixture import (
     IntegrationTestFixture,
-    substitute_gcs_test_bucket,
+    substitute_test_buckets,
 )
 from tests.integration.test_definitions.abs.integration_tests import (
     abs_integration_tests,
@@ -428,7 +428,7 @@ def _execute_integration_test(  # noqa: C901, PLR0915 # FIXME CoP
                 context_source_dir,
                 test_context_dir,
             )
-            substitute_gcs_test_bucket(test_context_dir / FileDataContext.GX_YML)
+            substitute_test_buckets(test_context_dir / FileDataContext.GX_YML)
 
         # Test Data
         data_dir = integration_test_fixture.data_dir
@@ -548,17 +548,10 @@ def _check_for_skipped_tests(  # noqa: C901, PLR0912 # FIXME CoP
     dependencies = integration_test_fixture.backend_dependencies
     if not dependencies:
         return
-    # TEMPORARY: Tests backed by S3 and Azure Blob are unconditionally skipped during the
-    # CI transition -- neither has a bucket or a live credential to run against. Remove
-    # this block once that infrastructure is restored.
-    elif any(
-        dependency
-        in (
-            BackendDependencies.AWS,
-            BackendDependencies.AZURE,
-        )
-        for dependency in dependencies
-    ):
+    # TEMPORARY: Tests backed by Azure Blob are unconditionally skipped during the CI
+    # transition -- there is no storage account or live credential to run against yet.
+    # Remove this block once that infrastructure is restored.
+    elif BackendDependencies.AZURE in dependencies:
         pytest.skip("CI TRANSITION")
     elif BackendDependencies.POSTGRESQL in dependencies and (
         not pytest_args.postgresql or pytest_args.no_sqlalchemy


### PR DESCRIPTION
## What

Turns the five pandas S3 docs fixtures back on. They have been unconditionally skipped since the CI transition, because there was no bucket and no live credential to run them against. Both now exist.

Azure Blob keeps its skip — it still has no storage account or credential.

## The bucket comes from a repository variable

`GX_S3_TEST_BUCKET`, mirroring what `GX_GCS_TEST_BUCKET` already does for GCS (#12056). The bucket name previously written into these files is not recoverable — S3 bucket names are globally unique — and reading it from a variable means the next rename touches no published docs snippet. The variable is required, so a missing or misconfigured name is reported directly instead of surfacing as an object-not-found error.

`substitute_gcs_test_bucket` becomes `substitute_test_buckets` and resolves both placeholders rather than gaining a near-duplicate. Only the placeholder actually present in a config is required, so an S3 fixture does not fail on a machine set up only for S3.

## Authentication moves to OIDC

From static access keys to a role assumed through GitHub's OIDC provider. The `docs-snippets` job already declared `id-token: write` but never used it.

The static `AWS_*` env mapping is **removed** rather than left alongside. Those job-level entries would shadow the credentials `configure-aws-credentials` exports into `$GITHUB_ENV`, so keeping them would silently defeat the new path. The step is gated to the `docs-creds-needed` leg, the only one that passes `--aws`.

The identity needs exactly two permissions: `s3:ListBucket` on the bucket ARN and `s3:GetObject` on the object ARN. Those are different resources, and granting only the first produces a clean listing followed by a `403` on the first batch read.

## Scope — checked, not assumed

- **`--aws` also selects the five Athena fixtures and the Glue one**, since they declare `AWS` alongside their own backend. They still skip: the `ATHENA` branch is evaluated after the `AWS` branch, and Glue is gated on `--spark`. Verified by running them — 6 skipped, 0 attempted.
- **The three S3 Spark fixtures stay skipped.** `docs-creds-needed` passes `--aws` without `--spark`; `docs-spark` passes `--spark` without `--aws`. That is deliberate: Spark reads `s3a://` through Hadoop, which needs the `hadoop-aws` connector on the JVM classpath, and no Python requirement can supply a jar. `tests/integration/test_definitions/s3/README.md` records this, as the GCS one already does.
- **No dependency change.** boto3 is already installed for this leg via `requirements-dev-test.txt` → `requirements-dev-lite.txt`.

## Verification

Locally, with deliberately invalid credentials, the pandas fixtures now **reach S3 and are rejected** (`TestConnectionError: Could not connect to asset using S3DataConnector: Got ClientError`) rather than reporting `SKIPPED (CI TRANSITION)` — which is the evidence that the gate opened. `create_a_data_source_filesystem_s3_pandas` passes even so, because `PandasS3Datasource.test_connection()` constructs the client and issues no API call.

- `tests/integration/test_integration_test_fixture.py` — 7 passed
- `ruff check` / `ruff format --check` — clean
- `invoke type-check --ci` — no issues in 778 source files

Real credentials only exist in CI, so the fixtures passing is what this PR is asking CI to demonstrate.