### PR TITLE
[MAINTENANCE] Declare metric values, render-content payloads, and metric keys as what they actually are

### DIFF
--- a/great_expectations/expectations/core/expect_column_distinct_values_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_distinct_values_to_be_in_set.py
@@ -351,14 +351,12 @@ class ExpectColumnDistinctValuesToBeInSet(ColumnAggregateExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]
 

--- a/great_expectations/expectations/core/expect_column_kl_divergence_to_be_less_than.py
+++ b/great_expectations/expectations/core/expect_column_kl_divergence_to_be_less_than.py
@@ -994,36 +994,32 @@ class ExpectColumnKLDivergenceToBeLessThan(ColumnAggregateExpectation):
 
             if header:
                 expected_distribution = RenderedGraphContent(
-                    **{
-                        "content_block_type": "graph",
-                        "graph": chart,
-                        "header": header,
-                        "styling": {
-                            "classes": [
-                                f"col-{chart_container_col_width!s}",
-                                "mt-2",
-                                "pl-1",
-                                "pr-1",
-                            ],
-                            "parent": {"styles": {"list-style-type": "none"}},
-                        },
-                    }
+                    content_block_type="graph",
+                    graph=chart,
+                    header=header,
+                    styling={
+                        "classes": [
+                            f"col-{chart_container_col_width!s}",
+                            "mt-2",
+                            "pl-1",
+                            "pr-1",
+                        ],
+                        "parent": {"styles": {"list-style-type": "none"}},
+                    },
                 )
             else:
                 expected_distribution = RenderedGraphContent(
-                    **{
-                        "content_block_type": "graph",
-                        "graph": chart,
-                        "styling": {
-                            "classes": [
-                                f"col-{chart_container_col_width!s}",
-                                "mt-2",
-                                "pl-1",
-                                "pr-1",
-                            ],
-                            "parent": {"styles": {"list-style-type": "none"}},
-                        },
-                    }
+                    content_block_type="graph",
+                    graph=chart,
+                    styling={
+                        "classes": [
+                            f"col-{chart_container_col_width!s}",
+                            "mt-2",
+                            "pl-1",
+                            "pr-1",
+                        ],
+                        "parent": {"styles": {"list-style-type": "none"}},
+                    },
                 )
         return expected_distribution
 
@@ -1548,27 +1544,23 @@ class ExpectColumnKLDivergenceToBeLessThan(ColumnAggregateExpectation):
         )
 
         observed_value_content_block = RenderedStringTemplateContent(
-            **{
-                "content_block_type": "string_template",
-                "string_template": {
-                    "template": "KL Divergence: $observed_value",
-                    "params": {
-                        "observed_value": (
-                            str(observed_value)
-                            if observed_value
-                            else "None (-infinity, infinity, or NaN)"
-                        ),
-                    },
-                    "styling": {"classes": ["mb-2"]},
+            content_block_type="string_template",
+            string_template={
+                "template": "KL Divergence: $observed_value",
+                "params": {
+                    "observed_value": (
+                        str(observed_value)
+                        if observed_value
+                        else "None (-infinity, infinity, or NaN)"
+                    ),
                 },
-            }
+                "styling": {"classes": ["mb-2"]},
+            },
         )
 
         return RenderedContentBlockContainer(
-            **{
-                "content_block_type": "content_block_container",
-                "content_blocks": [observed_value_content_block, observed_distribution],
-            }
+            content_block_type="content_block_container",
+            content_blocks=[observed_value_content_block, observed_distribution],
         )
 
     @classmethod
@@ -1587,14 +1579,12 @@ class ExpectColumnKLDivergenceToBeLessThan(ColumnAggregateExpectation):
             return None
 
         header = RenderedStringTemplateContent(
-            **{
-                "content_block_type": "string_template",
-                "string_template": {
-                    "template": "Histogram",
-                    "tooltip": {"content": "expect_column_kl_divergence_to_be_less_than"},
-                    "tag": "h6",
-                },
-            }
+            content_block_type="string_template",
+            string_template={
+                "template": "Histogram",
+                "tooltip": {"content": "expect_column_kl_divergence_to_be_less_than"},
+                "tag": "h6",
+            },
         )
 
         return cls._get_kl_divergence_chart(observed_partition_object, header)

--- a/great_expectations/expectations/core/expect_column_most_common_value_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_most_common_value_to_be_in_set.py
@@ -345,14 +345,12 @@ class ExpectColumnMostCommonValueToBeInSet(ColumnAggregateExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]
 

--- a/great_expectations/expectations/core/expect_column_pair_cramers_phi_value_to_be_less_than.py
+++ b/great_expectations/expectations/core/expect_column_pair_cramers_phi_value_to_be_less_than.py
@@ -111,14 +111,12 @@ class ExpectColumnPairCramersPhiValueToBeLessThan(BatchExpectation):
             template_str = "Values in $column_A and $column_B must be independent."
 
         rendered_string_template_content = RenderedStringTemplateContent(
-            **{
-                "content_block_type": "string_template",
-                "string_template": {
-                    "template": template_str,
-                    "params": params,
-                    "styling": styling,
-                },
-            }
+            content_block_type="string_template",
+            string_template={
+                "template": template_str,
+                "params": params,
+                "styling": styling,
+            },
         )
 
         return [rendered_string_template_content]
@@ -145,23 +143,21 @@ class ExpectColumnPairCramersPhiValueToBeLessThan(BatchExpectation):
                     table.append([crosstab.index[col]] + list(crosstab.iloc[col, :]))
 
                 return RenderedTableContent(
-                    **{
-                        "content_block_type": "table",
-                        "header": f"Observed cramers phi of {observed_value}. \n"
-                        f"Crosstab between {column_A} (rows) and {column_B} (columns):",
-                        "table": table,
-                        "styling": {
-                            "body": {
-                                "classes": [
-                                    "table",
-                                    "table-sm",
-                                    "table-unbordered",
-                                    "col-4",
-                                    "mt-2",
-                                ],
-                            }
-                        },
-                    }
+                    content_block_type="table",
+                    header=f"Observed cramers phi of {observed_value}. \n"
+                    f"Crosstab between {column_A} (rows) and {column_B} (columns):",
+                    table=table,
+                    styling={
+                        "body": {
+                            "classes": [
+                                "table",
+                                "table-sm",
+                                "table-unbordered",
+                                "col-4",
+                                "mt-2",
+                            ],
+                        }
+                    },
                 )
             else:
                 return observed_value

--- a/great_expectations/expectations/core/expect_column_pair_values_a_to_be_greater_than_b.py
+++ b/great_expectations/expectations/core/expect_column_pair_values_a_to_be_greater_than_b.py
@@ -364,13 +364,11 @@ class ExpectColumnPairValuesAToBeGreaterThanB(ColumnPairMapExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]

--- a/great_expectations/expectations/core/expect_column_pair_values_to_be_equal.py
+++ b/great_expectations/expectations/core/expect_column_pair_values_to_be_equal.py
@@ -342,13 +342,11 @@ class ExpectColumnPairValuesToBeEqual(ColumnPairMapExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]

--- a/great_expectations/expectations/core/expect_column_proportion_of_unique_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_proportion_of_unique_values_to_be_between.py
@@ -380,14 +380,12 @@ class ExpectColumnProportionOfUniqueValuesToBeBetween(ColumnAggregateExpectation
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]
 
@@ -405,15 +403,11 @@ class ExpectColumnProportionOfUniqueValuesToBeBetween(ColumnAggregateExpectation
         assert result, "Must pass in result."
         observed_value = result.result["observed_value"]
         template_string_object = RenderedStringTemplateContent(
-            **{
-                "content_block_type": "string_template",
-                "string_template": {
-                    "template": "Distinct (%)",
-                    "tooltip": {
-                        "content": "expect_column_proportion_of_unique_values_to_be_between"
-                    },
-                },
-            }
+            content_block_type="string_template",
+            string_template={
+                "template": "Distinct (%)",
+                "tooltip": {"content": "expect_column_proportion_of_unique_values_to_be_between"},
+            },
         )
         if not observed_value:
             return [template_string_object, "--"]

--- a/great_expectations/expectations/core/expect_column_quantile_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_quantile_values_to_be_between.py
@@ -521,23 +521,21 @@ class ExpectColumnQuantileValuesToBeBetween(ColumnAggregateExpectation):
             )
 
         quantile_range_table = RenderedTableContent(
-            **{
-                "content_block_type": "table",
-                "header_row": table_header_row,
-                "table": table_rows,
-                "styling": {
-                    "body": {
-                        "classes": [
-                            "table",
-                            "table-sm",
-                            "table-unbordered",
-                            "col-4",
-                            "mt-2",
-                        ],
-                    },
-                    "parent": {"styles": {"list-style-type": "none"}},
+            content_block_type="table",
+            header_row=table_header_row,
+            table=table_rows,
+            styling={
+                "body": {
+                    "classes": [
+                        "table",
+                        "table-sm",
+                        "table-unbordered",
+                        "col-4",
+                        "mt-2",
+                    ],
                 },
-            }
+                "parent": {"styles": {"list-style-type": "none"}},
+            },
         )
 
         return [expectation_string_obj, quantile_range_table]
@@ -572,16 +570,14 @@ class ExpectColumnQuantileValuesToBeBetween(ColumnAggregateExpectation):
             )
 
         return RenderedTableContent(
-            **{
-                "content_block_type": "table",
-                "header_row": table_header_row,
-                "table": table_rows,
-                "styling": {
-                    "body": {
-                        "classes": ["table", "table-sm", "table-unbordered", "col-4"],
-                    }
-                },
-            }
+            content_block_type="table",
+            header_row=table_header_row,
+            table=table_rows,
+            styling={
+                "body": {
+                    "classes": ["table", "table-sm", "table-unbordered", "col-4"],
+                }
+            },
         )
 
     @classmethod
@@ -717,22 +713,18 @@ class ExpectColumnQuantileValuesToBeBetween(ColumnAggregateExpectation):
             )
 
         return RenderedTableContent(
-            **{
-                "content_block_type": "table",
-                "header": RenderedStringTemplateContent(
-                    **{
-                        "content_block_type": "string_template",
-                        "string_template": {"template": "Quantiles", "tag": "h6"},
-                    }
-                ),
-                "table": table_rows,
-                "styling": {
-                    "classes": ["col-3", "mt-1", "pl-1", "pr-1"],
-                    "body": {
-                        "classes": ["table", "table-sm", "table-unbordered"],
-                    },
+            content_block_type="table",
+            header=RenderedStringTemplateContent(
+                content_block_type="string_template",
+                string_template={"template": "Quantiles", "tag": "h6"},
+            ),
+            table=table_rows,
+            styling={
+                "classes": ["col-3", "mt-1", "pl-1", "pr-1"],
+                "body": {
+                    "classes": ["table", "table-sm", "table-unbordered"],
                 },
-            }
+            },
         )
 
     def get_validation_dependencies(

--- a/great_expectations/expectations/core/expect_column_stdev_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_stdev_to_be_between.py
@@ -364,14 +364,12 @@ class ExpectColumnStdevToBeBetween(ColumnAggregateExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]
 

--- a/great_expectations/expectations/core/expect_column_unique_value_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_unique_value_count_to_be_between.py
@@ -369,14 +369,12 @@ class ExpectColumnUniqueValueCountToBeBetween(ColumnAggregateExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]
 
@@ -394,13 +392,11 @@ class ExpectColumnUniqueValueCountToBeBetween(ColumnAggregateExpectation):
         assert result, "Must pass in result."
         observed_value = result.result["observed_value"]
         template_string_object = RenderedStringTemplateContent(
-            **{
-                "content_block_type": "string_template",
-                "string_template": {
-                    "template": "Distinct (n)",
-                    "tooltip": {"content": "expect_column_unique_value_count_to_be_between"},
-                },
-            }
+            content_block_type="string_template",
+            string_template={
+                "template": "Distinct (n)",
+                "tooltip": {"content": "expect_column_unique_value_count_to_be_between"},
+            },
         )
         if not observed_value:
             return [template_string_object, "--"]

--- a/great_expectations/expectations/core/expect_column_value_lengths_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_value_lengths_to_be_between.py
@@ -451,13 +451,11 @@ class ExpectColumnValueLengthsToBeBetween(ColumnMapExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]

--- a/great_expectations/expectations/core/expect_column_value_lengths_to_equal.py
+++ b/great_expectations/expectations/core/expect_column_value_lengths_to_equal.py
@@ -322,13 +322,11 @@ class ExpectColumnValueLengthsToEqual(ColumnMapExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]

--- a/great_expectations/expectations/core/expect_column_values_to_be_dateutil_parseable.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_dateutil_parseable.py
@@ -152,13 +152,11 @@ class ExpectColumnValuesToBeDateutilParseable(ColumnMapExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]

--- a/great_expectations/expectations/core/expect_column_values_to_be_decreasing.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_decreasing.py
@@ -182,13 +182,11 @@ class ExpectColumnValuesToBeDecreasing(ColumnMapExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]

--- a/great_expectations/expectations/core/expect_column_values_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_set.py
@@ -367,14 +367,12 @@ class ExpectColumnValuesToBeInSet(ColumnMapExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]
 
@@ -408,14 +406,12 @@ class ExpectColumnValuesToBeInSet(ColumnMapExpectation):
             **{
                 "content_block_type": content_block_type,
                 "header": RenderedStringTemplateContent(
-                    **{
-                        "content_block_type": "string_template",
-                        "string_template": {
-                            "template": "Example Values",
-                            "tooltip": {"content": "expect_column_values_to_be_in_set"},
-                            "tag": "h6",
-                        },
-                    }
+                    content_block_type="string_template",
+                    string_template={
+                        "template": "Example Values",
+                        "tooltip": {"content": "expect_column_values_to_be_in_set"},
+                        "tag": "h6",
+                    },
                 ),
                 content_block_type: [
                     {

--- a/great_expectations/expectations/core/expect_column_values_to_be_increasing.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_increasing.py
@@ -183,13 +183,11 @@ class ExpectColumnValuesToBeIncreasing(ColumnMapExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]

--- a/great_expectations/expectations/core/expect_column_values_to_be_json_parseable.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_json_parseable.py
@@ -160,13 +160,11 @@ class ExpectColumnValuesToBeJsonParseable(ColumnMapExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]

--- a/great_expectations/expectations/core/expect_column_values_to_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_null.py
@@ -307,14 +307,12 @@ class ExpectColumnValuesToBeNull(ColumnMapExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]
 

--- a/great_expectations/expectations/core/expect_column_values_to_match_json_schema.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_json_schema.py
@@ -204,13 +204,11 @@ class ExpectColumnValuesToMatchJsonSchema(ColumnMapExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": {"params": {"formatted_json": {"classes": []}}},
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": {"params": {"formatted_json": {"classes": []}}},
+                },
             )
         ]

--- a/great_expectations/expectations/core/expect_column_values_to_match_like_pattern.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_like_pattern.py
@@ -306,13 +306,11 @@ class ExpectColumnValuesToMatchLikePattern(ColumnMapExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]

--- a/great_expectations/expectations/core/expect_column_values_to_match_like_pattern_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_like_pattern_list.py
@@ -357,13 +357,11 @@ class ExpectColumnValuesToMatchLikePatternList(ColumnMapExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]

--- a/great_expectations/expectations/core/expect_column_values_to_match_regex.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_regex.py
@@ -368,13 +368,11 @@ class ExpectColumnValuesToMatchRegex(ColumnMapExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]

--- a/great_expectations/expectations/core/expect_column_values_to_match_regex_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_regex_list.py
@@ -395,13 +395,11 @@ class ExpectColumnValuesToMatchRegexList(ColumnMapExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]

--- a/great_expectations/expectations/core/expect_column_values_to_match_strftime_format.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_strftime_format.py
@@ -323,13 +323,11 @@ class ExpectColumnValuesToMatchStrftimeFormat(ColumnMapExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]

--- a/great_expectations/expectations/core/expect_column_values_to_not_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_in_set.py
@@ -352,14 +352,12 @@ class ExpectColumnValuesToNotBeInSet(ColumnMapExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]
 

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern.py
@@ -307,13 +307,11 @@ class ExpectColumnValuesToNotMatchLikePattern(ColumnMapExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern_list.py
@@ -345,13 +345,11 @@ class ExpectColumnValuesToNotMatchLikePatternList(ColumnMapExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_regex.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_regex.py
@@ -343,14 +343,12 @@ class ExpectColumnValuesToNotMatchRegex(ColumnMapExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]
 

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_regex_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_regex_list.py
@@ -358,13 +358,11 @@ class ExpectColumnValuesToNotMatchRegexList(ColumnMapExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]

--- a/great_expectations/expectations/core/expect_compound_columns_to_be_unique.py
+++ b/great_expectations/expectations/core/expect_compound_columns_to_be_unique.py
@@ -333,13 +333,11 @@ class ExpectCompoundColumnsToBeUnique(MulticolumnMapExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]

--- a/great_expectations/expectations/core/expect_multicolumn_sum_to_equal.py
+++ b/great_expectations/expectations/core/expect_multicolumn_sum_to_equal.py
@@ -333,13 +333,11 @@ class ExpectMulticolumnSumToEqual(MulticolumnMapExpectation):
         template_str = f"Sum across columns {column_list_str} must be $sum_total{mostly_str}."
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]

--- a/great_expectations/expectations/core/expect_multicolumn_values_to_be_equal.py
+++ b/great_expectations/expectations/core/expect_multicolumn_values_to_be_equal.py
@@ -340,13 +340,11 @@ class ExpectMulticolumnValuesToBeEqual(MulticolumnMapExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{  # type: ignore[arg-type]  # FIXME CoP
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]

--- a/great_expectations/expectations/core/expect_multicolumn_values_to_be_unique.py
+++ b/great_expectations/expectations/core/expect_multicolumn_values_to_be_unique.py
@@ -197,13 +197,11 @@ class ExpectMulticolumnValuesToBeUnique(ColumnMapExpectation):
             )
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]

--- a/great_expectations/expectations/core/expect_select_column_values_to_be_unique_within_record.py
+++ b/great_expectations/expectations/core/expect_select_column_values_to_be_unique_within_record.py
@@ -348,13 +348,11 @@ class ExpectSelectColumnValuesToBeUniqueWithinRecord(MulticolumnMapExpectation):
             )
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]

--- a/great_expectations/expectations/core/expect_table_column_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_column_count_to_equal.py
@@ -227,14 +227,12 @@ class ExpectTableColumnCountToEqual(BatchExpectation):
         template_str = "Must have exactly $value columns."
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]
 

--- a/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
@@ -304,14 +304,12 @@ class ExpectTableColumnsToMatchOrderedList(BatchExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]
 

--- a/great_expectations/expectations/core/expect_table_columns_to_match_set.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_set.py
@@ -337,14 +337,12 @@ class ExpectTableColumnsToMatchSet(BatchExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]
 

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal.py
@@ -241,14 +241,12 @@ class ExpectTableRowCountToEqual(BatchExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{  # type: ignore[arg-type] # FIXME CoP
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]
 

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -188,14 +188,12 @@ def render_suite_parameter_string(render_func: Callable[P, T]) -> Callable[P, T]
                             app_params["eval_param"] = key
                             app_params["eval_param_value"] = val
                             rendered_content = RenderedStringTemplateContent(
-                                **{  # type: ignore[arg-type] # FIXME CoP
-                                    "content_block_type": "string_template",
-                                    "string_template": {
-                                        "template": app_template_str,
-                                        "params": app_params,
-                                        "styling": styling,
-                                    },
-                                }
+                                content_block_type="string_template",
+                                string_template={
+                                    "template": app_template_str,
+                                    "params": app_params,
+                                    "styling": styling,
+                                },
                             )
                             rendered_string_template.append(rendered_content)
             else:
@@ -743,24 +741,22 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
         )
         return [
             RenderedStringTemplateContent(
-                **{  # type: ignore[arg-type] # FIXME CoP
-                    "content_block_type": "string_template",
-                    "styling": {"parent": {"classes": ["alert", "alert-warning"]}},
-                    "string_template": {
-                        "template": "$expectation_type(**$kwargs)",
-                        "params": {
-                            "expectation_type": renderer_configuration.expectation_type,
-                            "kwargs": renderer_configuration.kwargs,
-                        },
-                        "styling": {
-                            "params": {
-                                "expectation_type": {
-                                    "classes": ["badge", "badge-warning"],
-                                }
-                            }
-                        },
+                content_block_type="string_template",
+                styling={"parent": {"classes": ["alert", "alert-warning"]}},
+                string_template={
+                    "template": "$expectation_type(**$kwargs)",
+                    "params": {
+                        "expectation_type": renderer_configuration.expectation_type,
+                        "kwargs": renderer_configuration.kwargs,
                     },
-                }
+                    "styling": {
+                        "params": {
+                            "expectation_type": {
+                                "classes": ["badge", "badge-warning"],
+                            }
+                        }
+                    },
+                },
             )
         ]
 
@@ -841,67 +837,61 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
                 raised_exception = v["raised_exception"]
         if raised_exception:
             return RenderedStringTemplateContent(
-                **{  # type: ignore[arg-type] # FIXME CoP
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": "$icon",
-                        "params": {"icon": "", "markdown_status_icon": "❗"},
-                        "styling": {
-                            "params": {
-                                "icon": {
-                                    "classes": [
-                                        "fas",
-                                        "fa-exclamation-triangle",
-                                        "text-warning",
-                                    ],
-                                    "tag": "i",
-                                }
+                content_block_type="string_template",
+                string_template={
+                    "template": "$icon",
+                    "params": {"icon": "", "markdown_status_icon": "❗"},
+                    "styling": {
+                        "params": {
+                            "icon": {
+                                "classes": [
+                                    "fas",
+                                    "fa-exclamation-triangle",
+                                    "text-warning",
+                                ],
+                                "tag": "i",
                             }
-                        },
+                        }
                     },
-                }
+                },
             )
 
         if result.success:
             return RenderedStringTemplateContent(
-                **{  # type: ignore[arg-type] # FIXME CoP
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": "$icon",
-                        "params": {"icon": "", "markdown_status_icon": "✅"},
-                        "styling": {
-                            "params": {
-                                "icon": {
-                                    "classes": [
-                                        "fas",
-                                        "fa-check-circle",
-                                        "text-success",
-                                    ],
-                                    "tag": "i",
-                                }
+                content_block_type="string_template",
+                string_template={
+                    "template": "$icon",
+                    "params": {"icon": "", "markdown_status_icon": "✅"},
+                    "styling": {
+                        "params": {
+                            "icon": {
+                                "classes": [
+                                    "fas",
+                                    "fa-check-circle",
+                                    "text-success",
+                                ],
+                                "tag": "i",
                             }
-                        },
+                        }
                     },
-                    "styling": {"parent": {"classes": ["hide-succeeded-validation-target-child"]}},
-                }
+                },
+                styling={"parent": {"classes": ["hide-succeeded-validation-target-child"]}},
             )
         else:
             return RenderedStringTemplateContent(
-                **{  # type: ignore[arg-type] # FIXME CoP
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": "$icon",
-                        "params": {"icon": "", "markdown_status_icon": "❌"},
-                        "styling": {
-                            "params": {
-                                "icon": {
-                                    "tag": "i",
-                                    "classes": ["fas", "fa-times", "text-danger"],
-                                }
+                content_block_type="string_template",
+                string_template={
+                    "template": "$icon",
+                    "params": {"icon": "", "markdown_status_icon": "❌"},
+                    "styling": {
+                        "params": {
+                            "icon": {
+                                "tag": "i",
+                                "classes": ["fas", "fa-times", "text-danger"],
                             }
-                        },
+                        }
                     },
-                }
+                },
             )
 
     @classmethod
@@ -945,41 +935,35 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
                 expectation_type = None
 
             exception_message = RenderedStringTemplateContent(
-                **{  # type: ignore[arg-type] # FIXME CoP
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": exception_message_template_str,
+                content_block_type="string_template",
+                string_template={
+                    "template": exception_message_template_str,
+                    "params": {
+                        "expectation_type": expectation_type,
+                        "exception_message": exception["exception_message"],
+                    },
+                    "tag": "strong",
+                    "styling": {
+                        "classes": ["text-danger"],
                         "params": {
-                            "expectation_type": expectation_type,
-                            "exception_message": exception["exception_message"],
-                        },
-                        "tag": "strong",
-                        "styling": {
-                            "classes": ["text-danger"],
-                            "params": {
-                                "exception_message": {"tag": "code"},
-                                "expectation_type": {"classes": ["badge", "badge-danger", "mb-2"]},
-                            },
+                            "exception_message": {"tag": "code"},
+                            "expectation_type": {"classes": ["badge", "badge-danger", "mb-2"]},
                         },
                     },
-                }
+                },
             )
 
             exception_traceback_collapse = CollapseContent(
-                **{  # type: ignore[arg-type] # FIXME CoP
-                    "collapse_toggle_link": "Show exception traceback...",
-                    "collapse": [
-                        RenderedStringTemplateContent(
-                            **{  # type: ignore[arg-type] # FIXME CoP
-                                "content_block_type": "string_template",
-                                "string_template": {
-                                    "template": exception["exception_traceback"],
-                                    "tag": "code",
-                                },
-                            }
-                        )
-                    ],
-                }
+                collapse_toggle_link="Show exception traceback...",  # type: ignore[arg-type] # FIXME CoP
+                collapse=[
+                    RenderedStringTemplateContent(
+                        content_block_type="string_template",
+                        string_template={
+                            "template": exception["exception_traceback"],
+                            "tag": "code",
+                        },
+                    )
+                ],
             )
 
             return [exception_message, exception_traceback_collapse]
@@ -1000,19 +984,17 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
 
             return [
                 RenderedStringTemplateContent(
-                    **{  # type: ignore[arg-type] # FIXME CoP
-                        "content_block_type": "string_template",
-                        "string_template": {
-                            "template": template_str,
-                            "params": {
-                                "unexpected_count": unexpected_count,
-                                "unexpected_percent": unexpected_percent,
-                                "element_count": element_count,
-                            },
-                            "tag": "strong",
-                            "styling": {"classes": ["text-danger"]},
+                    content_block_type="string_template",
+                    string_template={
+                        "template": template_str,
+                        "params": {
+                            "unexpected_count": unexpected_count,
+                            "unexpected_percent": unexpected_percent,
+                            "element_count": element_count,
                         },
-                    }
+                        "tag": "strong",
+                        "styling": {"classes": ["text-danger"]},
+                    },
                 )
             ]
 
@@ -1086,12 +1068,10 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
                         sampled_values_set.add(string_unexpected_value)
 
         unexpected_table_content_block = RenderedTableContent(
-            **{  # type: ignore[arg-type] # FIXME CoP
-                "content_block_type": "table",
-                "table": table_rows,
-                "header_row": header_row,
-                "styling": {"body": {"classes": ["table-bordered", "table-sm", "mt-3"]}},
-            }
+            content_block_type="table",
+            table=table_rows,
+            header_row=header_row,  # type: ignore[arg-type] # FIXME CoP
+            styling={"body": {"classes": ["table-bordered", "table-sm", "mt-3"]}},
         )
         if result_dict.get("unexpected_index_query"):
             query = result_dict.get("unexpected_index_query")
@@ -1099,20 +1079,16 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
             if not isinstance(query, str):
                 query = str(query)
             query_info = CollapseContent(
-                **{  # type: ignore[arg-type] # FIXME CoP
-                    "collapse_toggle_link": "To retrieve all unexpected values...",
-                    "collapse": [
-                        RenderedStringTemplateContent(
-                            **{  # type: ignore[arg-type] # FIXME CoP
-                                "content_block_type": "string_template",
-                                "string_template": {
-                                    "template": query,
-                                    "tag": "code",
-                                },
-                            }
-                        )
-                    ],
-                }
+                collapse_toggle_link="To retrieve all unexpected values...",  # type: ignore[arg-type] # FIXME CoP
+                collapse=[
+                    RenderedStringTemplateContent(
+                        content_block_type="string_template",
+                        string_template={
+                            "template": query,
+                            "tag": "code",
+                        },
+                    )
+                ],
             )
             return [unexpected_table_content_block, query_info]
         return [unexpected_table_content_block]

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -954,7 +954,7 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
             )
 
             exception_traceback_collapse = CollapseContent(
-                collapse_toggle_link="Show exception traceback...",  # type: ignore[arg-type] # FIXME CoP
+                collapse_toggle_link="Show exception traceback...",
                 collapse=[
                     RenderedStringTemplateContent(
                         content_block_type="string_template",
@@ -1070,7 +1070,7 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
         unexpected_table_content_block = RenderedTableContent(
             content_block_type="table",
             table=table_rows,
-            header_row=header_row,  # type: ignore[arg-type] # FIXME CoP
+            header_row=header_row,
             styling={"body": {"classes": ["table-bordered", "table-sm", "mt-3"]}},
         )
         if result_dict.get("unexpected_index_query"):
@@ -1079,7 +1079,7 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
             if not isinstance(query, str):
                 query = str(query)
             query_info = CollapseContent(
-                collapse_toggle_link="To retrieve all unexpected values...",  # type: ignore[arg-type] # FIXME CoP
+                collapse_toggle_link="To retrieve all unexpected values...",
                 collapse=[
                     RenderedStringTemplateContent(
                         content_block_type="string_template",

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -734,6 +734,24 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
         result: Optional[ExpectationValidationResult] = None,
         runtime_configuration: Optional[dict] = None,
     ) -> List[RenderedStringTemplateContent]:
+        """Render a prescriptive description of this expectation. Subclasses may override.
+
+        A renderer method's declared signature is its dispatch contract, not merely a
+        convenience for the common caller: the content-block dispatcher that invokes this
+        method (and its sibling diagnostic/observed-value renderers) calls the same method
+        with different argument sets depending on what kind of object is being rendered and
+        which code path reaches it. `configuration` and `result` are genuinely absent on
+        some dispatch paths -- passed as `None` or omitted outright -- for example when the
+        object being rendered is a validation result whose own `expectation_config` is
+        unset, or a bare expectation configuration with no associated validation result. An
+        override must not assume a parameter typed `Optional[...] = None` is present just
+        because most callers happen to supply it; it should either narrow explicitly at
+        entry or accept that some inputs are out of scope. The dispatcher catches exceptions
+        raised by the primary renderer call and reroutes them to a fallback renderer, but
+        that fallback itself runs unguarded on several dispatch paths, so an unhandled
+        absent-parameter read is not automatically contained -- it can still reach the
+        caller.
+        """
         renderer_configuration: RendererConfiguration = RendererConfiguration(
             configuration=configuration,
             result=result,
@@ -1207,6 +1225,12 @@ class Expectation(pydantic.BaseModel, metaclass=MetaExpectation):
         result: Optional[ExpectationValidationResult] = None,
         runtime_configuration: Optional[dict] = None,
     ) -> str:
+        """Render this expectation's observed value. Subclasses may override.
+
+        Same dispatch-contract convention as `_prescriptive_renderer` above: `result` (and
+        `configuration`) can arrive `None` or omitted depending on the dispatch path, and an
+        override must handle that explicitly rather than assume presence.
+        """
         return cls._get_observed_value_from_evr(result=result)
 
     @classmethod

--- a/great_expectations/render/components.py
+++ b/great_expectations/render/components.py
@@ -272,10 +272,14 @@ class RenderedTableContent(RenderedComponentContent):
     """RenderedTableContent is RenderedComponentContent that is a table.
 
     Args:
-        table: The table to be rendered.
-        header: The header for this content block.
+        table: The table to be rendered. Rows may be a mix of ``RenderedContent``,
+            already-rendered rows (lists of cell values), and other JSON-serializable
+            values.
+        header: The header for this content block. May be a ``RenderedContent``, a
+            dict, or a plain string.
         subheader: The subheader for this content block.
-        header_row: The header row for the table.
+        header_row: The header row for the table. May contain ``RenderedContent`` or
+            plain values such as strings.
         styling: A dictionary containing styling information.
         content_block_type: The type of content block.
         table_options: The options that can be set for the table.
@@ -291,10 +295,10 @@ class RenderedTableContent(RenderedComponentContent):
 
     def __init__(  # noqa: PLR0913 # FIXME CoP
         self,
-        table: list[RenderedContent],
-        header: Optional[Union[RenderedContent, dict]] = None,
+        table: list[Any],
+        header: Optional[Union[RenderedContent, dict, str]] = None,
         subheader: Optional[Union[RenderedContent, dict]] = None,
-        header_row: Optional[list[RenderedContent]] = None,
+        header_row: Optional[list[Any]] = None,
         styling: Optional[dict] = None,
         content_block_type: str = "table",
         table_options: Optional[dict] = None,
@@ -618,7 +622,8 @@ class CollapseContent(RenderedComponentContent):
 
     Args:
         collapse: The content to be collapsed. If a list is provided, it can recursively contain RenderedContent.
-        collpase_toggle_link: The toggle link for this CollapseContent.
+        collapse_toggle_link: The toggle link for this CollapseContent. May be a
+            ``RenderedContent``, a dict, or a plain string.
         header: The header for this content block.
         subheader: The subheader for this content block.
         styling: A dictionary containing styling information.
@@ -629,7 +634,7 @@ class CollapseContent(RenderedComponentContent):
     def __init__(  # noqa: PLR0913 # FIXME CoP
         self,
         collapse: Union[RenderedContent, list],
-        collapse_toggle_link: Optional[Union[RenderedContent, dict]] = None,
+        collapse_toggle_link: Optional[Union[RenderedContent, dict, str]] = None,
         header: Optional[Union[RenderedContent, dict]] = None,
         subheader: Optional[Union[RenderedContent, dict]] = None,
         styling: Optional[dict] = None,

--- a/great_expectations/render/renderer/column_section_renderer.py
+++ b/great_expectations/render/renderer/column_section_renderer.py
@@ -123,10 +123,8 @@ diagnose and repair the underlying issue.  Detailed information follows:
         populated_content_blocks = list(filter(None, content_blocks))
 
         return RenderedSectionContent(
-            **{
-                "section_name": column,
-                "content_blocks": populated_content_blocks,
-            }
+            section_name=column,
+            content_blocks=populated_content_blocks,
         )
 
     @classmethod
@@ -138,43 +136,37 @@ diagnose and repair the underlying issue.  Detailed information follows:
             column_name = "Table-level expectations"
 
         return RenderedHeaderContent(
-            **{
-                "content_block_type": "header",
-                "header": RenderedStringTemplateContent(
-                    **{
-                        "content_block_type": "string_template",
-                        "string_template": {
-                            "template": convert_to_string_and_escape(column_name),
-                            "tooltip": {
-                                "content": "expect_column_to_exist",
-                                "placement": "top",
-                            },
-                            "tag": "h5",
-                            "styling": {"classes": ["m-0", "p-0"]},
-                        },
-                    }
-                ),
-                "subheader": RenderedStringTemplateContent(
-                    **{
-                        "content_block_type": "string_template",
-                        "string_template": {
-                            "template": f"Type: {column_type}",
-                            "tooltip": {
-                                "content": "expect_column_values_to_be_of_type <br>expect_column_values_to_be_in_type_list",  # noqa: E501 # FIXME CoP
-                            },
-                            "tag": "h6",
-                            "styling": {"classes": ["mt-1", "mb-0"]},
-                        },
-                    }
-                ),
-                # {
-                #     "template": column_type,
-                # },
-                "styling": {
-                    "classes": ["col-12", "p-0"],
-                    "header": {"classes": ["alert", "alert-secondary"]},
+            content_block_type="header",
+            header=RenderedStringTemplateContent(
+                content_block_type="string_template",
+                string_template={
+                    "template": convert_to_string_and_escape(column_name),
+                    "tooltip": {
+                        "content": "expect_column_to_exist",
+                        "placement": "top",
+                    },
+                    "tag": "h5",
+                    "styling": {"classes": ["m-0", "p-0"]},
                 },
-            }
+            ),
+            subheader=RenderedStringTemplateContent(
+                content_block_type="string_template",
+                string_template={
+                    "template": f"Type: {column_type}",
+                    "tooltip": {
+                        "content": "expect_column_values_to_be_of_type <br>expect_column_values_to_be_in_type_list",  # noqa: E501 # FIXME CoP
+                    },
+                    "tag": "h6",
+                    "styling": {"classes": ["mt-1", "mb-0"]},
+                },
+            ),
+            # {
+            #     "template": column_type,
+            # },
+            styling={
+                "classes": ["col-12", "p-0"],
+                "header": {"classes": ["alert", "alert-secondary"]},
+            },
         )
 
     @classmethod
@@ -218,38 +210,34 @@ diagnose and repair the underlying issue.  Detailed information follows:
 
         content_blocks.append(
             RenderedBulletListContent(
-                **{
-                    "content_block_type": "bullet_list",
-                    "header": RenderedStringTemplateContent(
-                        **{  # type: ignore[arg-type] # FIXME CoP
-                            "content_block_type": "string_template",
-                            "string_template": {
-                                "template": 'Expectation types <span class="mr-3 triangle"></span>',
-                                "tag": "h6",
-                            },
-                        }
-                    ),
-                    "bullet_list": bullet_list,
-                    "styling": {
-                        "classes": ["col-12", "mt-1"],
-                        "header": {
-                            "classes": ["collapsed"],
-                            "attributes": {
-                                "data-toggle": "collapse",
-                                "href": "#{{content_block_id}}-body",
-                                "role": "button",
-                                "aria-expanded": "true",
-                                "aria-controls": "collapseExample",
-                            },
-                            "styles": {
-                                "cursor": "pointer",
-                            },
+                content_block_type="bullet_list",
+                header=RenderedStringTemplateContent(
+                    content_block_type="string_template",
+                    string_template={
+                        "template": 'Expectation types <span class="mr-3 triangle"></span>',
+                        "tag": "h6",
+                    },
+                ),
+                bullet_list=bullet_list,
+                styling={
+                    "classes": ["col-12", "mt-1"],
+                    "header": {
+                        "classes": ["collapsed"],
+                        "attributes": {
+                            "data-toggle": "collapse",
+                            "href": "#{{content_block_id}}-body",
+                            "role": "button",
+                            "aria-expanded": "true",
+                            "aria-controls": "collapseExample",
                         },
-                        "body": {
-                            "classes": ["list-group", "collapse"],
+                        "styles": {
+                            "cursor": "pointer",
                         },
                     },
-                }
+                    "body": {
+                        "classes": ["list-group", "collapse"],
+                    },
+                },
             )
         )
 
@@ -265,10 +253,8 @@ diagnose and repair the underlying issue.  Detailed information follows:
         if len(evrs) > 0:
             new_content_block = self._properties_table_renderer.render(evrs)
             new_content_block.header = RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {"template": "Properties", "tag": "h6"},
-                }
+                content_block_type="string_template",
+                string_template={"template": "Properties", "tag": "h6"},
             )
             new_content_block.styling = {
                 "classes": ["col-3", "mt-1", "pl-1", "pr-1"],
@@ -312,22 +298,18 @@ diagnose and repair the underlying issue.  Detailed information follows:
 
         if len(table_rows) > 0:
             return RenderedTableContent(
-                **{
-                    "content_block_type": "table",
-                    "header": RenderedStringTemplateContent(
-                        **{
-                            "content_block_type": "string_template",
-                            "string_template": {"template": "Statistics", "tag": "h6"},
-                        }
-                    ),
-                    "table": table_rows,
-                    "styling": {
-                        "classes": ["col-3", "mt-1", "pl-1", "pr-1"],
-                        "body": {
-                            "classes": ["table", "table-sm", "table-unbordered"],
-                        },
+                content_block_type="table",
+                header=RenderedStringTemplateContent(
+                    content_block_type="string_template",
+                    string_template={"template": "Statistics", "tag": "h6"},
+                ),
+                table=table_rows,
+                styling={
+                    "classes": ["col-3", "mt-1", "pl-1", "pr-1"],
+                    "body": {
+                        "classes": ["table", "table-sm", "table-unbordered"],
                     },
-                }
+                },
             )
         else:
             return
@@ -406,22 +388,18 @@ class ValidationResultsColumnSectionRenderer(ColumnSectionRenderer):
         column = cls._get_column_name(validation_results)
 
         new_block = RenderedHeaderContent(
-            **{
-                "header": RenderedStringTemplateContent(
-                    **{
-                        "content_block_type": "string_template",
-                        "string_template": {
-                            "template": convert_to_string_and_escape(column),
-                            "tag": "h5",
-                            "styling": {"classes": ["m-0"]},
-                        },
-                    }
-                ),
-                "styling": {
-                    "classes": ["col-12", "p-0"],
-                    "header": {"classes": ["alert", "alert-secondary"]},
+            header=RenderedStringTemplateContent(
+                content_block_type="string_template",
+                string_template={
+                    "template": convert_to_string_and_escape(column),
+                    "tag": "h5",
+                    "styling": {"classes": ["m-0"]},
                 },
-            }
+            ),
+            styling={
+                "classes": ["col-12", "p-0"],
+                "header": {"classes": ["alert", "alert-secondary"]},
+            },
         )
 
         return validation_results, new_block
@@ -441,7 +419,7 @@ class ValidationResultsColumnSectionRenderer(ColumnSectionRenderer):
         content_blocks.append(content_block)
         remaining_evrs, content_block = self._render_table(remaining_evrs, suite_parameters)
         content_blocks.append(content_block)
-        return RenderedSectionContent(**{"section_name": column, "content_blocks": content_blocks})
+        return RenderedSectionContent(section_name=column, content_blocks=content_blocks)
 
 
 class ExpectationSuiteColumnSectionRenderer(ColumnSectionRenderer):
@@ -461,22 +439,18 @@ class ExpectationSuiteColumnSectionRenderer(ColumnSectionRenderer):
         column = cls._get_column_name(expectations)
 
         new_block = RenderedHeaderContent(
-            **{
-                "header": RenderedStringTemplateContent(
-                    **{
-                        "content_block_type": "string_template",
-                        "string_template": {
-                            "template": convert_to_string_and_escape(column),
-                            "tag": "h5",
-                            "styling": {"classes": ["m-0"]},
-                        },
-                    }
-                ),
-                "styling": {
-                    "classes": ["col-12"],
-                    "header": {"classes": ["alert", "alert-secondary"]},
+            header=RenderedStringTemplateContent(
+                content_block_type="string_template",
+                string_template={
+                    "template": convert_to_string_and_escape(column),
+                    "tag": "h5",
+                    "styling": {"classes": ["m-0"]},
                 },
-            }
+            ),
+            styling={
+                "classes": ["col-12"],
+                "header": {"classes": ["alert", "alert-secondary"]},
+            },
         )
 
         return expectations, new_block

--- a/great_expectations/render/renderer/content_block/content_block.py
+++ b/great_expectations/render/renderer/content_block/content_block.py
@@ -177,17 +177,15 @@ diagnose and repair the underlying issue.  Detailed information follows:
                         result[0] = [result[0], expectation_notes]
 
                     horizontal_rule = RenderedStringTemplateContent(
-                        **{
-                            "content_block_type": "string_template",
-                            "string_template": {
-                                "template": "",
-                                "tag": "hr",
-                                "styling": {
-                                    "classes": ["mt-1", "mb-1"],
-                                },
+                        content_block_type="string_template",
+                        string_template={
+                            "template": "",
+                            "tag": "hr",
+                            "styling": {
+                                "classes": ["mt-1", "mb-1"],
                             },
-                            "styling": {"parent": {"styles": {"list-style-type": "none"}}},
-                        }
+                        },
+                        styling={"parent": {"styles": {"list-style-type": "none"}}},
                     )
                     result.append(horizontal_rule)
 
@@ -313,41 +311,35 @@ diagnose and repair the underlying issue.  Detailed information follows:
             return None
         else:
             collapse_link = RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": "$icon",
-                        "params": {"icon": ""},
-                        "styling": {
-                            "params": {
-                                "icon": {
-                                    "classes": ["fas", "fa-comment", "text-info"],
-                                    "tag": "i",
-                                }
+                content_block_type="string_template",
+                string_template={
+                    "template": "$icon",
+                    "params": {"icon": ""},
+                    "styling": {
+                        "params": {
+                            "icon": {
+                                "classes": ["fas", "fa-comment", "text-info"],
+                                "tag": "i",
                             }
-                        },
+                        }
                     },
-                }
+                },
             )
 
             if isinstance(notes, str):
                 note_content = [
                     RenderedMarkdownContent(
-                        **{
-                            "content_block_type": "markdown",
-                            "markdown": notes,
-                            "styling": {"parent": {"styles": {"color": "red"}}},
-                        }
+                        content_block_type="markdown",
+                        markdown=notes,
+                        styling={"parent": {"styles": {"color": "red"}}},
                     )
                 ]
             elif isinstance(notes, list):
                 note_content = [
                     RenderedMarkdownContent(
-                        **{
-                            "content_block_type": "markdown",
-                            "markdown": note,
-                            "styling": {"parent": {}},
-                        }
+                        content_block_type="markdown",
+                        markdown=note,
+                        styling={"parent": {}},
                     )
                     for note in notes
                 ]
@@ -355,27 +347,23 @@ diagnose and repair the underlying issue.  Detailed information follows:
                 note_content = None
 
             notes_block = TextContent(
-                **{
-                    "content_block_type": "text",
-                    "subheader": "Notes:",
-                    "text": note_content,
-                    "styling": {
-                        "classes": ["col-12", "mt-2", "mb-2"],
-                        "parent": {"styles": {"list-style-type": "none"}},
-                    },
-                }
+                content_block_type="text",
+                subheader="Notes:",
+                text=note_content,
+                styling={
+                    "classes": ["col-12", "mt-2", "mb-2"],
+                    "parent": {"styles": {"list-style-type": "none"}},
+                },
             )
 
             return CollapseContent(
-                **{
-                    "collapse_toggle_link": collapse_link,
-                    "collapse": [notes_block],
-                    "inline_link": True,
-                    "styling": {
-                        "body": {"classes": ["card", "card-body", "p-1"]},
-                        "parent": {"styles": {"list-style-type": "none"}},
-                    },
-                }
+                collapse_toggle_link=collapse_link,
+                collapse=[notes_block],
+                inline_link=True,
+                styling={
+                    "body": {"classes": ["card", "card-body", "p-1"]},
+                    "parent": {"styles": {"list-style-type": "none"}},
+                },
             )
 
     @classmethod

--- a/great_expectations/render/renderer/content_block/exception_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/exception_list_content_block.py
@@ -86,17 +86,15 @@ class ExceptionListContentBlockRenderer(ContentBlockRenderer):
                 column = None
             return [
                 RenderedStringTemplateContent(
-                    **{
-                        "content_block_type": "string_template",
-                        "string_template": {
-                            "template": template_str,
-                            "params": {
-                                "column": column,
-                                "expectation_type": result.expectation_config.type,
-                                "exception_message": result.exception_info["exception_message"],
-                            },
-                            "styling": styling,
+                    content_block_type="string_template",
+                    string_template={
+                        "template": template_str,
+                        "params": {
+                            "column": column,
+                            "expectation_type": result.expectation_config.type,
+                            "exception_message": result.exception_info["exception_message"],
                         },
-                    }
+                        "styling": styling,
+                    },
                 )
             ]

--- a/great_expectations/render/renderer/content_block/expectation_string.py
+++ b/great_expectations/render/renderer/content_block/expectation_string.py
@@ -35,24 +35,22 @@ class ExpectationStringRenderer(ContentBlockRenderer):
         )
         return [
             RenderedStringTemplateContent(
-                **{  # type: ignore[arg-type] # FIXME CoP
-                    "content_block_type": "string_template",
-                    "styling": {"parent": {"classes": ["alert", "alert-warning"]}},
-                    "string_template": {
-                        "template": "$expectation_type(**$kwargs)",
-                        "params": {
-                            "expectation_type": renderer_configuration.expectation_type,
-                            "kwargs": renderer_configuration.kwargs,
-                        },
-                        "styling": {
-                            "params": {
-                                "expectation_type": {
-                                    "classes": ["badge", "badge-warning"],
-                                }
-                            }
-                        },
+                content_block_type="string_template",
+                styling={"parent": {"classes": ["alert", "alert-warning"]}},
+                string_template={
+                    "template": "$expectation_type(**$kwargs)",
+                    "params": {
+                        "expectation_type": renderer_configuration.expectation_type,
+                        "kwargs": renderer_configuration.kwargs,
                     },
-                }
+                    "styling": {
+                        "params": {
+                            "expectation_type": {
+                                "classes": ["badge", "badge-warning"],
+                            }
+                        }
+                    },
+                },
             )
         ]
 
@@ -67,65 +65,59 @@ class ExpectationStringRenderer(ContentBlockRenderer):
         assert result, "Must provide a result object."
         if result.exception_info["raised_exception"]:
             return RenderedStringTemplateContent(
-                **{  # type: ignore[arg-type] # FIXME CoP
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": "$icon",
-                        "params": {"icon": "", "markdown_status_icon": "❗"},
-                        "styling": {
-                            "params": {
-                                "icon": {
-                                    "classes": [
-                                        "fas",
-                                        "fa-exclamation-triangle",
-                                        "text-warning",
-                                    ],
-                                    "tag": "i",
-                                }
+                content_block_type="string_template",
+                string_template={
+                    "template": "$icon",
+                    "params": {"icon": "", "markdown_status_icon": "❗"},
+                    "styling": {
+                        "params": {
+                            "icon": {
+                                "classes": [
+                                    "fas",
+                                    "fa-exclamation-triangle",
+                                    "text-warning",
+                                ],
+                                "tag": "i",
                             }
-                        },
+                        }
                     },
-                }
+                },
             )
 
         if result.success:
             return RenderedStringTemplateContent(
-                **{  # type: ignore[arg-type] # FIXME CoP
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": "$icon",
-                        "params": {"icon": "", "markdown_status_icon": "✅"},
-                        "styling": {
-                            "params": {
-                                "icon": {
-                                    "classes": [
-                                        "fas",
-                                        "fa-check-circle",
-                                        "text-success",
-                                    ],
-                                    "tag": "i",
-                                }
+                content_block_type="string_template",
+                string_template={
+                    "template": "$icon",
+                    "params": {"icon": "", "markdown_status_icon": "✅"},
+                    "styling": {
+                        "params": {
+                            "icon": {
+                                "classes": [
+                                    "fas",
+                                    "fa-check-circle",
+                                    "text-success",
+                                ],
+                                "tag": "i",
                             }
-                        },
+                        }
                     },
-                    "styling": {"parent": {"classes": ["hide-succeeded-validation-target-child"]}},
-                }
+                },
+                styling={"parent": {"classes": ["hide-succeeded-validation-target-child"]}},
             )
         else:
             return RenderedStringTemplateContent(
-                **{  # type: ignore[arg-type] # FIXME CoP
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": "$icon",
-                        "params": {"icon": "", "markdown_status_icon": "❌"},
-                        "styling": {
-                            "params": {
-                                "icon": {
-                                    "tag": "i",
-                                    "classes": ["fas", "fa-times", "text-danger"],
-                                }
+                content_block_type="string_template",
+                string_template={
+                    "template": "$icon",
+                    "params": {"icon": "", "markdown_status_icon": "❌"},
+                    "styling": {
+                        "params": {
+                            "icon": {
+                                "tag": "i",
+                                "classes": ["fas", "fa-times", "text-danger"],
                             }
-                        },
+                        }
                     },
-                }
+                },
             )

--- a/great_expectations/render/renderer/content_block/profiling_column_properties_table_content_block.py
+++ b/great_expectations/render/renderer/content_block/profiling_column_properties_table_content_block.py
@@ -56,9 +56,7 @@ class ProfilingColumnPropertiesTableContentBlockRenderer(ContentBlockRenderer):
                 table_rows.extend(new_rows)
 
         return RenderedTableContent(
-            **{
-                "content_block_type": "table",
-                "header_row": header_row,
-                "table": table_rows,
-            }
+            content_block_type="table",
+            header_row=header_row,
+            table=table_rows,
         )

--- a/great_expectations/render/renderer/page_renderer.py
+++ b/great_expectations/render/renderer/page_renderer.py
@@ -757,7 +757,7 @@ class ExpectationSuitePageRenderer(Renderer):
     # TODO: Update tests
     @classmethod
     def _render_expectation_suite_notes(cls, expectations: ExpectationSuite) -> TextContent:
-        content = []
+        content: list[str | RenderedMarkdownContent] = []
 
         total_expectations = len(expectations.expectations)
         columns = []

--- a/great_expectations/render/renderer/page_renderer.py
+++ b/great_expectations/render/renderer/page_renderer.py
@@ -119,15 +119,13 @@ class ValidationResultsPageRenderer(Renderer):
         )
 
         return RenderedDocumentContent(
-            **{
-                "renderer_type": "ValidationResultsPageRenderer",
-                "page_title": page_title,
-                "batch_kwargs": batch_kwargs if "batch_kwargs" in validation_results.meta else None,
-                "batch_spec": batch_kwargs if "batch_spec" in validation_results.meta else None,
-                "expectation_suite_name": expectation_suite_name,
-                "sections": sections,
-                "utm_medium": "validation-results-page",
-            }
+            renderer_type="ValidationResultsPageRenderer",
+            page_title=page_title,
+            batch_kwargs=batch_kwargs if "batch_kwargs" in validation_results.meta else None,
+            batch_spec=batch_kwargs if "batch_spec" in validation_results.meta else None,
+            expectation_suite_name=expectation_suite_name,
+            sections=sections,
+            utm_medium="validation-results-page",
         )
 
     def _parse_run_values(
@@ -204,14 +202,12 @@ class ValidationResultsPageRenderer(Renderer):
                 collapse_content_blocks.append(table)
 
         collapse_content_block = CollapseContent(
-            **{
-                "collapse_toggle_link": "Show more info...",
-                "collapse": collapse_content_blocks,
-                "styling": {
-                    "body": {"classes": ["card", "card-body"]},
-                    "classes": ["col-12", "p-1"],
-                },
-            }
+            collapse_toggle_link="Show more info...",
+            collapse=collapse_content_blocks,
+            styling={
+                "body": {"classes": ["card", "card-body"]},
+                "classes": ["col-12", "p-1"],
+            },
         )
 
         return collapse_content_block
@@ -226,10 +222,8 @@ class ValidationResultsPageRenderer(Renderer):
         ordered_columns = Renderer._get_column_list_from_evrs(validation_results)
         sections = [
             RenderedSectionContent(
-                **{
-                    "section_name": "Overview",
-                    "content_blocks": overview_content_blocks,
-                }
+                section_name="Overview",
+                content_blocks=overview_content_blocks,
             )
         ]
 
@@ -251,10 +245,8 @@ class ValidationResultsPageRenderer(Renderer):
         if self.run_info_at_end:
             sections += [
                 RenderedSectionContent(
-                    **{
-                        "section_name": "Run Info",
-                        "content_blocks": collapse_content_blocks,
-                    }
+                    section_name="Run Info",
+                    content_blocks=collapse_content_blocks,
                 )
             ]
 
@@ -362,51 +354,45 @@ class ValidationResultsPageRenderer(Renderer):
             html_success_icon = '<i class="fas fa-times text-danger" aria-hidden="true"></i>'
 
         return RenderedHeaderContent(
-            **{
-                "content_block_type": "header",
-                "header": RenderedStringTemplateContent(
-                    **{
-                        "content_block_type": "string_template",
-                        "string_template": {
-                            "template": "Overview",
-                            "tag": "h5",
-                            "styling": {"classes": ["m-0"]},
-                        },
-                    }
-                ),
-                "subheader": RenderedStringTemplateContent(
-                    **{
-                        "content_block_type": "string_template",
-                        "string_template": {
-                            "template": "${suite_title} ${expectation_suite_name}\n ${data_asset} ${data_asset_name}\n ${status_title} ${html_success_icon} ${success}",  # noqa: E501 # FIXME CoP
-                            "params": {
-                                "suite_title": "Expectation Suite:",
-                                "data_asset": "Data asset:",
-                                "data_asset_name": data_asset_name,
-                                "status_title": "Status:",
-                                "expectation_suite_name": expectation_suite_name,
-                                "success": success,
-                                "html_success_icon": html_success_icon,
-                            },
-                            "styling": {
-                                "params": {
-                                    "suite_title": {"classes": ["h6"]},
-                                    "status_title": {"classes": ["h6"]},
-                                    "expectation_suite_name": {
-                                        "tag": "a",
-                                        "attributes": {"href": expectation_suite_path},
-                                    },
-                                },
-                                "classes": ["mb-0", "mt-1"],
-                            },
-                        },
-                    }
-                ),
-                "styling": {
-                    "classes": ["col-12", "p-0"],
-                    "header": {"classes": ["alert", "alert-secondary"]},
+            content_block_type="header",
+            header=RenderedStringTemplateContent(
+                content_block_type="string_template",
+                string_template={
+                    "template": "Overview",
+                    "tag": "h5",
+                    "styling": {"classes": ["m-0"]},
                 },
-            }
+            ),
+            subheader=RenderedStringTemplateContent(
+                content_block_type="string_template",
+                string_template={
+                    "template": "${suite_title} ${expectation_suite_name}\n ${data_asset} ${data_asset_name}\n ${status_title} ${html_success_icon} ${success}",  # noqa: E501 # FIXME CoP
+                    "params": {
+                        "suite_title": "Expectation Suite:",
+                        "data_asset": "Data asset:",
+                        "data_asset_name": data_asset_name,
+                        "status_title": "Status:",
+                        "expectation_suite_name": expectation_suite_name,
+                        "success": success,
+                        "html_success_icon": html_success_icon,
+                    },
+                    "styling": {
+                        "params": {
+                            "suite_title": {"classes": ["h6"]},
+                            "status_title": {"classes": ["h6"]},
+                            "expectation_suite_name": {
+                                "tag": "a",
+                                "attributes": {"href": expectation_suite_path},
+                            },
+                        },
+                        "classes": ["mb-0", "mt-1"],
+                    },
+                },
+            ),
+            styling={
+                "classes": ["col-12", "p-0"],
+                "header": {"classes": ["alert", "alert-secondary"]},
+            },
         )
 
     @classmethod
@@ -433,34 +419,30 @@ class ValidationResultsPageRenderer(Renderer):
         ) or validation_results.meta.get("great_expectations.__version__")
 
         return RenderedTableContent(
-            **{
-                "content_block_type": "table",
-                "header": RenderedStringTemplateContent(
-                    **{
-                        "content_block_type": "string_template",
-                        "string_template": {
-                            "template": "Info",
-                            "tag": "h6",
-                            "styling": {"classes": ["m-0"]},
-                        },
-                    }
-                ),
-                "table": [
-                    ["Great Expectations Version", ge_version],
-                    ["Run Name", run_name],
-                    ["Run Time", run_time],
-                ],
-                "styling": {
-                    "classes": ["col-12", "table-responsive", "mt-1"],
-                    "body": {
-                        "classes": ["table", "table-sm"],
-                        "styles": {
-                            "margin-bottom": "0.5rem !important",
-                            "margin-top": "0.5rem !important",
-                        },
+            content_block_type="table",
+            header=RenderedStringTemplateContent(
+                content_block_type="string_template",
+                string_template={
+                    "template": "Info",
+                    "tag": "h6",
+                    "styling": {"classes": ["m-0"]},
+                },
+            ),
+            table=[
+                ["Great Expectations Version", ge_version],
+                ["Run Name", run_name],
+                ["Run Time", run_time],
+            ],
+            styling={
+                "classes": ["col-12", "table-responsive", "mt-1"],
+                "body": {
+                    "classes": ["table", "table-sm"],
+                    "styles": {
+                        "margin-bottom": "0.5rem !important",
+                        "margin-top": "0.5rem !important",
                     },
                 },
-            }
+            },
         )
 
     @classmethod
@@ -470,58 +452,52 @@ class ValidationResultsPageRenderer(Renderer):
             if not isinstance(value, (dict, OrderedDict)):
                 table_row = [
                     RenderedStringTemplateContent(
-                        **{
-                            "content_block_type": "string_template",
-                            "string_template": {
-                                "template": "$value",
-                                "params": {"value": str(kwarg)},
-                                "styling": {
-                                    "default": {"styles": {"word-break": "break-all"}},
-                                },
-                            },
+                        content_block_type="string_template",
+                        string_template={
+                            "template": "$value",
+                            "params": {"value": str(kwarg)},
                             "styling": {
-                                "parent": {
-                                    "classes": ["pr-3"],
-                                }
+                                "default": {"styles": {"word-break": "break-all"}},
                             },
-                        }
+                        },
+                        styling={
+                            "parent": {
+                                "classes": ["pr-3"],
+                            }
+                        },
                     ),
                     RenderedStringTemplateContent(
-                        **{
-                            "content_block_type": "string_template",
-                            "string_template": {
-                                "template": "$value",
-                                "params": {"value": str(value)},
-                                "styling": {
-                                    "default": {"styles": {"word-break": "break-all"}},
-                                },
-                            },
+                        content_block_type="string_template",
+                        string_template={
+                            "template": "$value",
+                            "params": {"value": str(value)},
                             "styling": {
-                                "parent": {
-                                    "classes": [],
-                                }
+                                "default": {"styles": {"word-break": "break-all"}},
                             },
-                        }
+                        },
+                        styling={
+                            "parent": {
+                                "classes": [],
+                            }
+                        },
                     ),
                 ]
             else:
                 table_row = [
                     RenderedStringTemplateContent(
-                        **{
-                            "content_block_type": "string_template",
-                            "string_template": {
-                                "template": "$value",
-                                "params": {"value": str(kwarg)},
-                                "styling": {
-                                    "default": {"styles": {"word-break": "break-all"}},
-                                },
-                            },
+                        content_block_type="string_template",
+                        string_template={
+                            "template": "$value",
+                            "params": {"value": str(kwarg)},
                             "styling": {
-                                "parent": {
-                                    "classes": ["pr-3"],
-                                }
+                                "default": {"styles": {"word-break": "break-all"}},
                             },
-                        }
+                        },
+                        styling={
+                            "parent": {
+                                "classes": ["pr-3"],
+                            }
+                        },
                     ),
                     cls._render_nested_table_from_dict(value, sub_table=True),
                 ]
@@ -531,41 +507,35 @@ class ValidationResultsPageRenderer(Renderer):
 
         if sub_table:
             return RenderedTableContent(
-                **{
-                    "content_block_type": "table",
-                    "table": table_rows,
-                    "styling": {
-                        "classes": ["col-6", "table-responsive"],
-                        "body": {"classes": ["table", "table-sm", "m-0"]},
-                        "parent": {"classes": ["pt-0", "pl-0", "border-top-0"]},
-                    },
-                }
+                content_block_type="table",
+                table=table_rows,
+                styling={
+                    "classes": ["col-6", "table-responsive"],
+                    "body": {"classes": ["table", "table-sm", "m-0"]},
+                    "parent": {"classes": ["pt-0", "pl-0", "border-top-0"]},
+                },
             )
         else:
             return RenderedTableContent(
-                **{
-                    "content_block_type": "table",
-                    "header": RenderedStringTemplateContent(
-                        **{
-                            "content_block_type": "string_template",
-                            "string_template": {
-                                "template": header,
-                                "tag": "h6",
-                                "styling": {"classes": ["m-0"]},
-                            },
-                        }
-                    ),
-                    "table": table_rows,
-                    "styling": {
-                        "body": {
-                            "classes": ["table", "table-sm"],
-                            "styles": {
-                                "margin-bottom": "0.5rem !important",
-                                "margin-top": "0.5rem !important",
-                            },
-                        }
+                content_block_type="table",
+                header=RenderedStringTemplateContent(
+                    content_block_type="string_template",
+                    string_template={
+                        "template": header,
+                        "tag": "h6",
+                        "styling": {"classes": ["m-0"]},
                     },
-                }
+                ),
+                table=table_rows,
+                styling={
+                    "body": {
+                        "classes": ["table", "table-sm"],
+                        "styles": {
+                            "margin-bottom": "0.5rem !important",
+                            "margin-top": "0.5rem !important",
+                        },
+                    }
+                },
             )
 
     @classmethod
@@ -589,30 +559,26 @@ class ValidationResultsPageRenderer(Renderer):
                     table_rows.append([value, statistics[key]])
 
         return RenderedTableContent(
-            **{
-                "content_block_type": "table",
-                "header": RenderedStringTemplateContent(
-                    **{
-                        "content_block_type": "string_template",
-                        "string_template": {
-                            "template": "Statistics",
-                            "tag": "h6",
-                            "styling": {"classes": ["m-0"]},
-                        },
-                    }
-                ),
-                "table": table_rows,
-                "styling": {
-                    "classes": ["col-6", "table-responsive", "mt-1", "p-1"],
-                    "body": {
-                        "classes": ["table", "table-sm"],
-                        "styles": {
-                            "margin-bottom": "0.5rem !important",
-                            "margin-top": "0.5rem !important",
-                        },
+            content_block_type="table",
+            header=RenderedStringTemplateContent(
+                content_block_type="string_template",
+                string_template={
+                    "template": "Statistics",
+                    "tag": "h6",
+                    "styling": {"classes": ["m-0"]},
+                },
+            ),
+            table=table_rows,
+            styling={
+                "classes": ["col-6", "table-responsive", "mt-1", "p-1"],
+                "body": {
+                    "classes": ["table", "table-sm"],
+                    "styles": {
+                        "margin-bottom": "0.5rem !important",
+                        "margin-top": "0.5rem !important",
                     },
                 },
-            }
+            },
         )
 
 
@@ -700,10 +666,8 @@ class ExpectationSuitePageRenderer(Renderer):
 
         sections = [
             RenderedSectionContent(
-                **{
-                    "section_name": "Overview",
-                    "content_blocks": overview_content_blocks,
-                }
+                section_name="Overview",
+                content_blocks=overview_content_blocks,
             )
         ]
 
@@ -713,13 +677,11 @@ class ExpectationSuitePageRenderer(Renderer):
             if column != "_nocolumn"
         ]
         return RenderedDocumentContent(
-            **{
-                "renderer_type": "ExpectationSuitePageRenderer",
-                "page_title": f"Expectations / {expectation_suite_name!s}",
-                "expectation_suite_name": expectation_suite_name,
-                "utm_medium": "expectation-suite-page",
-                "sections": sections,
-            }
+            renderer_type="ExpectationSuitePageRenderer",
+            page_title=f"Expectations / {expectation_suite_name!s}",
+            expectation_suite_name=expectation_suite_name,
+            utm_medium="expectation-suite-page",
+            sections=sections,
         )
 
     def _render_table_level_expectations(self, columns):
@@ -731,37 +693,31 @@ class ExpectationSuitePageRenderer(Renderer):
                 expectations=table_level_expectations
             ).content_blocks[1]
             expectation_bullet_list.header = RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": "Table-Level Expectations",
-                        "tag": "h6",
-                        "styling": {"classes": ["m-0"]},
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": "Table-Level Expectations",
+                    "tag": "h6",
+                    "styling": {"classes": ["m-0"]},
+                },
             )
             return expectation_bullet_list
 
     @classmethod
     def _render_expectation_suite_header(cls):
         return RenderedHeaderContent(
-            **{
-                "content_block_type": "header",
-                "header": RenderedStringTemplateContent(
-                    **{
-                        "content_block_type": "string_template",
-                        "string_template": {
-                            "template": "Overview",
-                            "tag": "h5",
-                            "styling": {"classes": ["m-0"]},
-                        },
-                    }
-                ),
-                "styling": {
-                    "classes": ["col-12"],
-                    "header": {"classes": ["alert", "alert-secondary"]},
+            content_block_type="header",
+            header=RenderedStringTemplateContent(
+                content_block_type="string_template",
+                string_template={
+                    "template": "Overview",
+                    "tag": "h5",
+                    "styling": {"classes": ["m-0"]},
                 },
-            }
+            ),
+            styling={
+                "classes": ["col-12"],
+                "header": {"classes": ["alert", "alert-secondary"]},
+            },
         )
 
     @classmethod
@@ -773,33 +729,29 @@ class ExpectationSuitePageRenderer(Renderer):
         )
 
         return RenderedTableContent(
-            **{
-                "content_block_type": "table",
-                "header": RenderedStringTemplateContent(
-                    **{
-                        "content_block_type": "string_template",
-                        "string_template": {
-                            "template": "Info",
-                            "tag": "h6",
-                            "styling": {"classes": ["m-0"]},
-                        },
-                    }
-                ),
-                "table": [
-                    ["Expectation Suite Name", expectation_suite_name],
-                    ["Great Expectations Version", ge_version],
-                ],
-                "styling": {
-                    "classes": ["col-12", "table-responsive", "mt-1"],
-                    "body": {
-                        "classes": ["table", "table-sm"],
-                        "styles": {
-                            "margin-bottom": "0.5rem !important",
-                            "margin-top": "0.5rem !important",
-                        },
+            content_block_type="table",
+            header=RenderedStringTemplateContent(
+                content_block_type="string_template",
+                string_template={
+                    "template": "Info",
+                    "tag": "h6",
+                    "styling": {"classes": ["m-0"]},
+                },
+            ),
+            table=[
+                ["Expectation Suite Name", expectation_suite_name],
+                ["Great Expectations Version", ge_version],
+            ],
+            styling={
+                "classes": ["col-12", "table-responsive", "mt-1"],
+                "body": {
+                    "classes": ["table", "table-sm"],
+                    "styles": {
+                        "margin-bottom": "0.5rem !important",
+                        "margin-top": "0.5rem !important",
                     },
                 },
-            }
+            },
         )
 
     # TODO: Update tests
@@ -826,21 +778,17 @@ class ExpectationSuitePageRenderer(Renderer):
             if isinstance(notes, str):
                 note_content = [
                     RenderedMarkdownContent(
-                        **{
-                            "content_block_type": "markdown",
-                            "markdown": notes,
-                            "styling": {"parent": {}},
-                        }
+                        content_block_type="markdown",
+                        markdown=notes,
+                        styling={"parent": {}},
                     )
                 ]
             elif isinstance(notes, list):
                 note_content = [
                     RenderedMarkdownContent(
-                        **{
-                            "content_block_type": "markdown",
-                            "markdown": note,
-                            "styling": {"parent": {}},
-                        }
+                        content_block_type="markdown",
+                        markdown=note,
+                        styling={"parent": {}},
                     )
                     for note in notes
                 ]
@@ -851,24 +799,20 @@ class ExpectationSuitePageRenderer(Renderer):
                 content += note_content
 
         return TextContent(
-            **{
-                "content_block_type": "text",
-                "header": RenderedStringTemplateContent(
-                    **{
-                        "content_block_type": "string_template",
-                        "string_template": {
-                            "template": "Notes",
-                            "tag": "h6",
-                            "styling": {"classes": ["m-0"]},
-                        },
-                    }
-                ),
-                "text": content,
-                "styling": {
-                    "classes": ["col-12", "table-responsive", "mt-1"],
-                    "body": {"classes": ["table", "table-sm"]},
+            content_block_type="text",
+            header=RenderedStringTemplateContent(
+                content_block_type="string_template",
+                string_template={
+                    "template": "Notes",
+                    "tag": "h6",
+                    "styling": {"classes": ["m-0"]},
                 },
-            }
+            ),
+            text=content,
+            styling={
+                "classes": ["col-12", "table-responsive", "mt-1"],
+                "body": {"classes": ["table", "table-sm"]},
+            },
         )
 
 
@@ -972,25 +916,21 @@ class ProfilingResultsPageRenderer(Renderer):
         page_title += f" / {run_time!s}"
 
         return RenderedDocumentContent(
-            **{
-                "renderer_type": "ProfilingResultsPageRenderer",
-                "page_title": page_title,
-                "expectation_suite_name": expectation_suite_name,
-                "utm_medium": "profiling-results-page",
-                "batch_kwargs": batch_kwargs if "batch_kwargs" in validation_results.meta else None,
-                "batch_spec": batch_kwargs if "batch_spec" in validation_results.meta else None,
-                "sections": [
-                    self._overview_section_renderer.render(
-                        validation_results, section_name="Overview"
-                    )
-                ]
-                + [
-                    self._column_section_renderer.render(
-                        columns[column],
-                        section_name=column,
-                        column_type=column_types.get(column),
-                    )
-                    for column in ordered_columns
-                ],
-            }
+            renderer_type="ProfilingResultsPageRenderer",
+            page_title=page_title,
+            expectation_suite_name=expectation_suite_name,
+            utm_medium="profiling-results-page",
+            batch_kwargs=batch_kwargs if "batch_kwargs" in validation_results.meta else None,
+            batch_spec=batch_kwargs if "batch_spec" in validation_results.meta else None,
+            sections=[
+                self._overview_section_renderer.render(validation_results, section_name="Overview")
+            ]
+            + [
+                self._column_section_renderer.render(
+                    columns[column],
+                    section_name=column,
+                    column_type=column_types.get(column),
+                )
+                for column in ordered_columns
+            ],
         )

--- a/great_expectations/render/renderer/profiling_results_overview_section_renderer.py
+++ b/great_expectations/render/renderer/profiling_results_overview_section_renderer.py
@@ -29,31 +29,25 @@ class ProfilingResultsOverviewSectionRenderer(Renderer):
         cls._render_warnings(evrs, content_blocks)
         cls._render_expectation_types(evrs, content_blocks)
 
-        return RenderedSectionContent(
-            **{"section_name": section_name, "content_blocks": content_blocks}
-        )
+        return RenderedSectionContent(section_name=section_name, content_blocks=content_blocks)
 
     @classmethod
     def _render_header(cls, evrs, content_blocks) -> None:
         content_blocks.append(
             RenderedHeaderContent(
-                **{
-                    "content_block_type": "header",
-                    "header": RenderedStringTemplateContent(
-                        **{
-                            "content_block_type": "string_template",
-                            "string_template": {
-                                "template": "Overview",
-                                "tag": "h5",
-                                "styling": {"classes": ["m-0"]},
-                            },
-                        }
-                    ),
-                    "styling": {
-                        "classes": ["col-12", "p-0"],
-                        "header": {"classes": ["alert", "alert-secondary"]},
+                content_block_type="header",
+                header=RenderedStringTemplateContent(
+                    content_block_type="string_template",
+                    string_template={
+                        "template": "Overview",
+                        "tag": "h5",
+                        "styling": {"classes": ["m-0"]},
                     },
-                }
+                ),
+                styling={
+                    "classes": ["col-12", "p-0"],
+                    "header": {"classes": ["alert", "alert-secondary"]},
+                },
             )
         )
 
@@ -74,14 +68,12 @@ class ProfilingResultsOverviewSectionRenderer(Renderer):
         table_rows.append(
             [
                 RenderedStringTemplateContent(
-                    **{
-                        "content_block_type": "string_template",
-                        "string_template": {
-                            "template": "Number of observations",
-                            "tooltip": {"content": "expect_table_row_count_to_be_between"},
-                            "params": {"tooltip_text": "Number of observations"},
-                        },
-                    }
+                    content_block_type="string_template",
+                    string_template={
+                        "template": "Number of observations",
+                        "tooltip": {"content": "expect_table_row_count_to_be_between"},
+                        "params": {"tooltip_text": "Number of observations"},
+                    },
                 ),
                 "--"
                 if not expect_table_row_count_to_be_between_evr
@@ -99,23 +91,19 @@ class ProfilingResultsOverviewSectionRenderer(Renderer):
 
         content_blocks.append(
             RenderedTableContent(
-                **{
-                    "content_block_type": "table",
-                    "header": RenderedStringTemplateContent(
-                        **{
-                            "content_block_type": "string_template",
-                            "string_template": {
-                                "template": "Dataset info",
-                                "tag": "h6",
-                            },
-                        }
-                    ),
-                    "table": table_rows,
-                    "styling": {
-                        "classes": ["col-6", "mt-1", "p-1"],
-                        "body": {"classes": ["table", "table-sm"]},
+                content_block_type="table",
+                header=RenderedStringTemplateContent(
+                    content_block_type="string_template",
+                    string_template={
+                        "template": "Dataset info",
+                        "tag": "h6",
                     },
-                }
+                ),
+                table=table_rows,
+                styling={
+                    "classes": ["col-6", "mt-1", "p-1"],
+                    "body": {"classes": ["table", "table-sm"]},
+                },
             )
         )
 
@@ -131,23 +119,19 @@ class ProfilingResultsOverviewSectionRenderer(Renderer):
 
         content_blocks.append(
             RenderedTableContent(
-                **{
-                    "content_block_type": "table",
-                    "header": RenderedStringTemplateContent(
-                        **{
-                            "content_block_type": "string_template",
-                            "string_template": {
-                                "template": "Variable types",
-                                "tag": "h6",
-                            },
-                        }
-                    ),
-                    "table": table_rows,
-                    "styling": {
-                        "classes": ["col-6", "table-responsive", "mt-1", "p-1"],
-                        "body": {"classes": ["table", "table-sm"]},
+                content_block_type="table",
+                header=RenderedStringTemplateContent(
+                    content_block_type="string_template",
+                    string_template={
+                        "template": "Variable types",
+                        "tag": "h6",
                     },
-                }
+                ),
+                table=table_rows,
+                styling={
+                    "classes": ["col-6", "table-responsive", "mt-1", "p-1"],
+                    "body": {"classes": ["table", "table-sm"]},
+                },
             )
         )
 
@@ -162,57 +146,51 @@ class ProfilingResultsOverviewSectionRenderer(Renderer):
 
         bullet_list_items = [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": "$expectation_type $expectation_count",
+                content_block_type="string_template",
+                string_template={
+                    "template": "$expectation_type $expectation_count",
+                    "params": {
+                        "expectation_type": tr[0],
+                        "expectation_count": tr[1],
+                    },
+                    "styling": {
+                        "classes": [
+                            "list-group-item",
+                            "d-flex",
+                            "justify-content-between",
+                            "align-items-center",
+                        ],
                         "params": {
-                            "expectation_type": tr[0],
-                            "expectation_count": tr[1],
-                        },
-                        "styling": {
-                            "classes": [
-                                "list-group-item",
-                                "d-flex",
-                                "justify-content-between",
-                                "align-items-center",
-                            ],
-                            "params": {
-                                "expectation_count": {
-                                    "classes": [
-                                        "badge",
-                                        "badge-secondary",
-                                        "badge-pill",
-                                    ],
-                                }
-                            },
+                            "expectation_count": {
+                                "classes": [
+                                    "badge",
+                                    "badge-secondary",
+                                    "badge-pill",
+                                ],
+                            }
                         },
                     },
-                    "styling": {"parent": {"styles": {"list-style-type": "none"}}},
-                }
+                },
+                styling={"parent": {"styles": {"list-style-type": "none"}}},
             )
             for tr in bullet_list_items
         ]
 
         bullet_list = RenderedBulletListContent(
-            **{
-                "content_block_type": "bullet_list",
-                "bullet_list": bullet_list_items,
-                "styling": {
-                    "classes": ["col-12", "mt-1"],
-                    "body": {
-                        "classes": ["list-group"],
-                    },
+            content_block_type="bullet_list",
+            bullet_list=bullet_list_items,
+            styling={
+                "classes": ["col-12", "mt-1"],
+                "body": {
+                    "classes": ["list-group"],
                 },
-            }
+            },
         )
 
         bullet_list_collapse = CollapseContent(
-            **{
-                "collapse_toggle_link": "Show Expectation Types...",
-                "collapse": [bullet_list],
-                "styling": {"classes": ["col-12", "p-1"]},
-            }
+            collapse_toggle_link="Show Expectation Types...",
+            collapse=[bullet_list],
+            styling={"classes": ["col-12", "p-1"]},
         )
 
         content_blocks.append(bullet_list_collapse)

--- a/great_expectations/render/renderer/site_index_page_renderer.py
+++ b/great_expectations/render/renderer/site_index_page_renderer.py
@@ -11,6 +11,7 @@ from dateutil.parser import parse
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.render import (
     RenderedBootstrapTableContent,
+    RenderedComponentContent,
     RenderedDocumentContent,
     RenderedHeaderContent,
     RenderedSectionContent,
@@ -368,7 +369,7 @@ class SiteIndexPageRenderer(Renderer):
         cta_object = index_links_dict.pop("cta_object", None)
 
         try:
-            content_blocks = []
+            content_blocks: list[RenderedComponentContent] = []
             # site name header
             site_name_header_block = RenderedHeaderContent(
                 content_block_type="header",

--- a/great_expectations/render/renderer/site_index_page_renderer.py
+++ b/great_expectations/render/renderer/site_index_page_renderer.py
@@ -61,20 +61,18 @@ class SiteIndexPageRenderer(Renderer):
             )
 
         return RenderedBootstrapTableContent(
-            **{
-                "table_columns": table_columns,
-                "table_data": table_data,
-                "table_options": table_options,
-                "styling": {
-                    "classes": ["col-12", "ge-index-page-table-container"],
-                    "body": {
-                        "classes": [
-                            "table-sm",
-                            "ge-index-page-expectation_suites-table",
-                        ]
-                    },
+            table_columns=table_columns,
+            table_data=table_data,
+            table_options=table_options,
+            styling={
+                "classes": ["col-12", "ge-index-page-table-container"],
+                "body": {
+                    "classes": [
+                        "table-sm",
+                        "ge-index-page-expectation_suites-table",
+                    ]
                 },
-            }
+            },
         )
 
     # TODO: deprecate dual batch api support in 0.14
@@ -149,15 +147,13 @@ class SiteIndexPageRenderer(Renderer):
             )
 
         return RenderedBootstrapTableContent(
-            **{
-                "table_columns": table_columns,
-                "table_data": table_data,
-                "table_options": table_options,
-                "styling": {
-                    "classes": ["col-12", "ge-index-page-table-container"],
-                    "body": {"classes": ["table-sm", "ge-index-page-profiling-results-table"]},
-                },
-            }
+            table_columns=table_columns,
+            table_data=table_data,
+            table_options=table_options,
+            styling={
+                "classes": ["col-12", "ge-index-page-table-container"],
+                "body": {"classes": ["table-sm", "ge-index-page-profiling-results-table"]},
+            },
         )
 
     # TODO: deprecate dual batch api support in 0.14
@@ -261,38 +257,34 @@ class SiteIndexPageRenderer(Renderer):
             )
 
         return RenderedBootstrapTableContent(
-            **{
-                "table_columns": table_columns,
-                "table_data": table_data,
-                "table_options": table_options,
-                "styling": {
-                    "classes": ["col-12", "ge-index-page-table-container"],
-                    "body": {
-                        "classes": [
-                            "table-sm",
-                            "ge-index-page-validation-results-table",
-                        ]
-                    },
+            table_columns=table_columns,
+            table_data=table_data,
+            table_options=table_options,
+            styling={
+                "classes": ["col-12", "ge-index-page-table-container"],
+                "body": {
+                    "classes": [
+                        "table-sm",
+                        "ge-index-page-validation-results-table",
+                    ]
                 },
-            }
+            },
         )
 
     @classmethod
     def _render_expectation_suite_cell(cls, expectation_suite_name, expectation_suite_path):
         return RenderedStringTemplateContent(
-            **{
-                "content_block_type": "string_template",
-                "string_template": {
-                    "template": "$link_text",
-                    "params": {"link_text": expectation_suite_name},
-                    "tag": "a",
-                    "styling": {
-                        "styles": {"word-break": "break-all"},
-                        "attributes": {"href": expectation_suite_path},
-                        "classes": ["ge-index-page-table-expectation-suite-link"],
-                    },
+            content_block_type="string_template",
+            string_template={
+                "template": "$link_text",
+                "params": {"link_text": expectation_suite_name},
+                "tag": "a",
+                "styling": {
+                    "styles": {"word-break": "break-all"},
+                    "attributes": {"href": expectation_suite_path},
+                    "classes": ["ge-index-page-table-expectation-suite-link"],
                 },
-            }
+            },
         )
 
     # TODO: deprecate dual batch api support in 0.14
@@ -305,17 +297,15 @@ class SiteIndexPageRenderer(Renderer):
             content_title = "Batch Spec"
             content = json.dumps(batch_spec, indent=2)
         return RenderedStringTemplateContent(
-            **{
-                "content_block_type": "string_template",
-                "string_template": {
-                    "template": str(batch_id),
-                    "tooltip": {
-                        "content": f"{content_title}:\n\n{content}",
-                        "placement": "top",
-                    },
-                    "styling": {"classes": ["m-0", "p-0"]},
+            content_block_type="string_template",
+            string_template={
+                "template": str(batch_id),
+                "tooltip": {
+                    "content": f"{content_title}:\n\n{content}",
+                    "placement": "top",
                 },
-            }
+                "styling": {"classes": ["m-0", "p-0"]},
+            },
         )
 
     @classmethod
@@ -343,34 +333,32 @@ class SiteIndexPageRenderer(Renderer):
     @classmethod
     def _render_validation_success_cell(cls, validation_success):
         return RenderedStringTemplateContent(
-            **{
-                "content_block_type": "string_template",
-                "string_template": {
-                    "template": "$validation_success",
-                    "params": {"validation_success": ""},
-                    "styling": {
-                        "params": {
-                            "validation_success": {
-                                "tag": "i",
-                                "classes": [
-                                    "fas",
-                                    "fa-check-circle",
-                                    "text-success",
-                                    "ge-success-icon",
-                                ]
-                                if validation_success
-                                else [
-                                    "fas",
-                                    "fa-times",
-                                    "text-danger",
-                                    "ge-failed-icon",
-                                ],
-                            }
-                        },
-                        "classes": ["ge-index-page-table-validation-links-item"],
+            content_block_type="string_template",
+            string_template={
+                "template": "$validation_success",
+                "params": {"validation_success": ""},
+                "styling": {
+                    "params": {
+                        "validation_success": {
+                            "tag": "i",
+                            "classes": [
+                                "fas",
+                                "fa-check-circle",
+                                "text-success",
+                                "ge-success-icon",
+                            ]
+                            if validation_success
+                            else [
+                                "fas",
+                                "fa-times",
+                                "text-danger",
+                                "ge-failed-icon",
+                            ],
+                        }
                     },
+                    "classes": ["ge-index-page-table-validation-links-item"],
                 },
-            }
+            },
         )
 
     @classmethod
@@ -383,26 +371,22 @@ class SiteIndexPageRenderer(Renderer):
             content_blocks = []
             # site name header
             site_name_header_block = RenderedHeaderContent(
-                **{
-                    "content_block_type": "header",
-                    "header": RenderedStringTemplateContent(
-                        **{
-                            "content_block_type": "string_template",
-                            "string_template": {
-                                "template": "$title_prefix | $site_name",
-                                "params": {
-                                    "site_name": index_links_dict.get("site_name"),
-                                    "title_prefix": "Data Docs",
-                                },
-                                "styling": {"params": {"title_prefix": {"tag": "strong"}}},
-                            },
-                        }
-                    ),
-                    "styling": {
-                        "classes": ["col-12", "ge-index-page-site-name-title"],
-                        "header": {"classes": ["alert", "alert-secondary"]},
+                content_block_type="header",
+                header=RenderedStringTemplateContent(
+                    content_block_type="string_template",
+                    string_template={
+                        "template": "$title_prefix | $site_name",
+                        "params": {
+                            "site_name": index_links_dict.get("site_name"),
+                            "title_prefix": "Data Docs",
+                        },
+                        "styling": {"params": {"title_prefix": {"tag": "strong"}}},
                     },
-                }
+                ),
+                styling={
+                    "classes": ["col-12", "ge-index-page-site-name-title"],
+                    "header": {"classes": ["alert", "alert-secondary"]},
+                },
             )
             content_blocks.append(site_name_header_block)
 
@@ -435,30 +419,24 @@ class SiteIndexPageRenderer(Renderer):
                 )
 
             tabs_content_block = RenderedTabsContent(
-                **{
-                    "tabs": tabs,
-                    "styling": {
-                        "classes": ["col-12", "ge-index-page-tabs-container"],
-                    },
-                }
+                tabs=tabs,
+                styling={
+                    "classes": ["col-12", "ge-index-page-tabs-container"],
+                },
             )
 
             content_blocks.append(tabs_content_block)
 
             section = RenderedSectionContent(
-                **{
-                    "section_name": index_links_dict.get("site_name"),
-                    "content_blocks": content_blocks,
-                }
+                section_name=index_links_dict.get("site_name"),
+                content_blocks=content_blocks,
             )
             sections.append(section)
 
             index_page_document = RenderedDocumentContent(
-                **{
-                    "renderer_type": "SiteIndexPageRenderer",
-                    "utm_medium": "index-page",
-                    "sections": sections,
-                }
+                renderer_type="SiteIndexPageRenderer",
+                utm_medium="index-page",
+                sections=sections,
             )
 
             if cta_object:

--- a/great_expectations/validator/computed_metric.py
+++ b/great_expectations/validator/computed_metric.py
@@ -1,21 +1,36 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any
 
-import numpy as np
-import pandas as pd
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
 
-MetricValue = Union[
-    Any,  # Encompasses deferred-query/execution plans ("SQLAlchemy" and "Spark") conditions and aggregation functions.  # noqa: E501 # FIXME CoP
-    List[Any],
-    Set[Any],
-    Tuple[Any, ...],
-    pd.DataFrame,
-    pd.Series,
-    np.ndarray,
-    int,
-    str,
-    float,
-    bool,
-    Dict[str, Any],
-]
+# A resolved metric value is backend-determined and dynamically typed: it may be a
+# scalar (int, str, float, bool), a container (list, set, tuple, dict), a pandas
+# DataFrame/Series, a numpy ndarray, or a deferred SQL/Spark expression object that
+# only resolves once its execution engine runs the query or job it represents.
+#
+# This alias previously spelled that set out as a Union whose first member was
+# already `Any` (the carrier for the deferred-expression case). A union containing
+# `Any` accepts every value on assignment -- `Any` always matches -- so the union
+# added no checking power over assignments the plain alias below also accepts.
+# What it did add was cost: every *read* of a `MetricValue`-typed attribute was
+# checked against each of the union's other members in turn, so one read produced
+# one diagnostic per non-`Any` member whenever the underlying static type couldn't
+# be proven to satisfy all of them -- multiplying a single real signal into many
+# duplicate, non-actionable ones. Spelling the alias as `Any` keeps every existing
+# annotation and every existing assignment valid, in both directions, while
+# collapsing that multiplication at its source instead of leaving each caller to
+# suppress it individually.
+#
+# The former member inventory, preserved for readers: Any, List[Any], Set[Any],
+# Tuple[Any, ...], pandas.DataFrame, pandas.Series, numpy.ndarray, int, str, float,
+# bool, Dict[str, Any].
+#
+# The name and import path are unchanged, and the alias stays re-exported from the
+# validation-graph module, but the object bound to the name is no longer a Union:
+# introspecting it at runtime (e.g. via `typing.get_args`) now
+# returns no members, where it previously returned twelve, and using it as a
+# validated field annotation on a data model would no longer validate anything.
+# Neither case occurs anywhere in this codebase today.
+MetricValue: TypeAlias = Any

--- a/tests/execution_engine/test_execution_engine.py
+++ b/tests/execution_engine/test_execution_engine.py
@@ -20,7 +20,10 @@ from great_expectations.expectations.legacy_row_conditions import (
 )
 
 # Testing ordinary process of adding column row condition
-from great_expectations.validator.metric_configuration import MetricConfiguration
+from great_expectations.validator.metric_configuration import (
+    MetricConfiguration,
+    MetricConfigurationID,
+)
 from tests.expectations.test_util import get_table_columns_metric
 
 if TYPE_CHECKING:
@@ -199,10 +202,10 @@ def test_resolve_metrics_with_aggregates_and_column_map():
     df = pd.DataFrame({"a": [1, 2, 3, None]})
     engine = PandasExecutionEngine(batch_data_dict={"my_id": df})
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
 
@@ -278,10 +281,10 @@ def test_resolve_metrics_with_extraneous_value_key():
     df = pd.DataFrame({"a": [1, 2, 3, None]})
     engine = PandasExecutionEngine(batch_data_dict={"my_id": df})
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
 
@@ -310,7 +313,14 @@ def test_resolve_metrics_with_extraneous_value_key():
     metrics.update(results)
 
     # Ensuring extraneous value key did not change computation
-    assert metrics[("column.standard_deviation", "column=a", "value_set=[1, 2, 3, 4, 5]")] == 1.0
+    assert (
+        metrics[
+            MetricConfigurationID(
+                "column.standard_deviation", "column=a", "value_set=[1, 2, 3, 4, 5]"
+            )
+        ]
+        == 1.0
+    )
 
 
 # Testing that metric resolution also works with metric partial function

--- a/tests/execution_engine/test_pandas_execution_engine.py
+++ b/tests/execution_engine/test_pandas_execution_engine.py
@@ -1,5 +1,5 @@
 import os
-from typing import TYPE_CHECKING, Dict, Tuple
+from typing import TYPE_CHECKING, Dict
 from unittest import mock
 
 import pandas as pd
@@ -23,7 +23,10 @@ from great_expectations.expectations.row_conditions import (
     OrCondition,
 )
 from great_expectations.util import is_library_loadable
-from great_expectations.validator.metric_configuration import MetricConfiguration
+from great_expectations.validator.metric_configuration import (
+    MetricConfiguration,
+    MetricConfigurationID,
+)
 from tests.expectations.test_util import get_table_columns_metric
 
 if TYPE_CHECKING:
@@ -378,10 +381,10 @@ def test_resolve_metric_bundle():
     # Building engine and configurations in attempt to resolve metrics
     engine = PandasExecutionEngine(batch_data_dict={"made-up-id": df})
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -407,8 +410,10 @@ def test_resolve_metric_bundle():
     metrics.update(results)
 
     # Ensuring metrics have been properly resolved
-    assert metrics[("column.mean", "column=a", ())] == 2.0, "mean metric not properly computed"
-    assert metrics[("column.standard_deviation", "column=a", ())] == 1.0, (
+    assert metrics[MetricConfigurationID("column.mean", "column=a", ())] == 2.0, (
+        "mean metric not properly computed"
+    )
+    assert metrics[MetricConfigurationID("column.standard_deviation", "column=a", ())] == 1.0, (
         "standard deviation metric not properly computed"
     )
 

--- a/tests/execution_engine/test_sparkdf_execution_engine.py
+++ b/tests/execution_engine/test_sparkdf_execution_engine.py
@@ -1,6 +1,6 @@
 import datetime
 import logging
-from typing import TYPE_CHECKING, Dict, Tuple
+from typing import TYPE_CHECKING, Dict
 
 import numpy as np
 import pandas as pd
@@ -26,7 +26,10 @@ from great_expectations.expectations.row_conditions import (
     OrCondition,
 )
 from great_expectations.self_check.util import build_spark_engine
-from great_expectations.validator.metric_configuration import MetricConfiguration
+from great_expectations.validator.metric_configuration import (
+    MetricConfiguration,
+    MetricConfigurationID,
+)
 from tests.expectations.test_util import get_table_columns_metric
 from tests.test_utils import create_files_in_directory
 
@@ -641,10 +644,10 @@ def test_sparkdf_batch_aggregate_metrics(caplog, spark_session):
         batch_id="1234",
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
 
@@ -1056,10 +1059,10 @@ def test_resolve_metric_bundle_with_compute_domain_kwargs_json_serialization(
         batch_id="my_id",
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)

--- a/tests/execution_engine/test_sqlalchemy_execution_engine.py
+++ b/tests/execution_engine/test_sqlalchemy_execution_engine.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import TYPE_CHECKING, Dict, Tuple, cast
+from typing import TYPE_CHECKING, Dict, cast
 
 import pandas as pd
 import pytest
@@ -42,7 +42,10 @@ from great_expectations.expectations.row_conditions import (
 )
 from great_expectations.self_check.util import build_sa_execution_engine
 from great_expectations.util import get_sqlalchemy_domain_data
-from great_expectations.validator.metric_configuration import MetricConfiguration
+from great_expectations.validator.metric_configuration import (
+    MetricConfiguration,
+    MetricConfigurationID,
+)
 from great_expectations.validator.validator import Validator
 from tests.expectations.test_util import get_table_columns_metric
 from tests.test_utils import (
@@ -271,10 +274,10 @@ def test_sa_batch_aggregate_metrics(caplog, sa):
         pd.DataFrame({"a": [1, 2, 1, 2, 3, 3], "b": [4, 4, 4, 4, 4, 4]}), sa
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=execution_engine)
     metrics.update(results)
@@ -977,10 +980,10 @@ def test_resolve_metric_bundle_with_compute_domain_kwargs_json_serialization(sa)
         batch_id="1234",
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=execution_engine)
     metrics.update(results)
@@ -1060,10 +1063,10 @@ def test_sa_batch_unexpected_condition_temp_table(caplog, sa):
         pd.DataFrame({"a": [1, 2, 1, 2, 3, 3], "b": [4, 4, 4, 4, 4, 4]}), sa
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=execution_engine)
     metrics.update(results)

--- a/tests/expectations/fixtures/expect_column_values_to_equal_three.py
+++ b/tests/expectations/fixtures/expect_column_values_to_equal_three.py
@@ -167,14 +167,12 @@ class ExpectColumnValuesToEqualThree__ThirdIteration(
 
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]
 

--- a/tests/expectations/metrics/column_map_metrics/test_unexpected_indices_and_query.py
+++ b/tests/expectations/metrics/column_map_metrics/test_unexpected_indices_and_query.py
@@ -14,7 +14,10 @@ from great_expectations.self_check.util import (
     build_sa_execution_engine,
     build_spark_engine,
 )
-from great_expectations.validator.metric_configuration import MetricConfiguration
+from great_expectations.validator.metric_configuration import (
+    MetricConfiguration,
+    MetricConfigurationID,
+)
 from tests.expectations.test_util import get_table_columns_metric
 
 # Spark 4 changed Column's string grammar from infix ("(a AND b)", "a IN (...)") to a
@@ -98,11 +101,11 @@ def _build_table_columns_and_unexpected(
         Tuple with MetricConfigurations corresponding to unexpected_condition and table_columns metric, as well as metrics dict.
 
     """  # noqa: E501 # FIXME CoP
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     # get table_columns_metric
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
 
@@ -151,7 +154,7 @@ def test_pd_unexpected_index_list_metric_without_id_pk(animal_table_df):
         "unexpected_condition": unexpected_columns_metric,
         "table.columns": table_columns_metric,
     }
-    results: Dict[Tuple[str, str, str], MetricValue] = engine.resolve_metrics(
+    results: Dict[MetricConfigurationID, MetricValue] = engine.resolve_metrics(
         metrics_to_resolve=(desired_metric,), metrics=metrics
     )
     for key, val in results.items():
@@ -190,7 +193,7 @@ def test_pd_unexpected_index_list_metric_without_id_pk_without_column_values(
         "unexpected_condition": unexpected_columns_metric,
         "table.columns": table_columns_metric,
     }
-    results: Dict[Tuple[str, str, str], MetricValue] = engine.resolve_metrics(
+    results: Dict[MetricConfigurationID, MetricValue] = engine.resolve_metrics(
         metrics_to_resolve=(desired_metric,), metrics=metrics
     )
     for key, val in results.items():
@@ -218,7 +221,7 @@ def test_pd_unexpected_index_list_metric_with_id_pk(metric_value_kwargs_complete
         "unexpected_condition": unexpected_columns_metric,
         "table.columns": table_columns_metric,
     }
-    results: Dict[Tuple[str, str, str], MetricValue] = engine.resolve_metrics(
+    results: Dict[MetricConfigurationID, MetricValue] = engine.resolve_metrics(
         metrics_to_resolve=(unexpected_index_list,), metrics=metrics
     )
     for key, val in results.items():
@@ -262,7 +265,7 @@ def test_pd_unexpected_index_list_metric_with_id_pk_without_column_values(
         "unexpected_condition": unexpected_columns_metric,
         "table.columns": table_columns_metric,
     }
-    results: Dict[Tuple[str, str, str], MetricValue] = engine.resolve_metrics(
+    results: Dict[MetricConfigurationID, MetricValue] = engine.resolve_metrics(
         metrics_to_resolve=(unexpected_index_list,), metrics=metrics
     )
     for key, val in results.items():
@@ -294,7 +297,7 @@ def test_sa_unexpected_index_list_metric_with_id_pk(
         "unexpected_condition": unexpected_columns_metric,
         "table.columns": table_columns_metric,
     }
-    results: Dict[Tuple[str, str, str], MetricValue] = engine.resolve_metrics(
+    results: Dict[MetricConfigurationID, MetricValue] = engine.resolve_metrics(
         metrics_to_resolve=(unexpected_index_list,), metrics=metrics
     )
     for key, val in results.items():
@@ -338,7 +341,7 @@ def test_sa_unexpected_index_list_metric_with_id_pk_without_column_values(
         "unexpected_condition": unexpected_columns_metric,
         "table.columns": table_columns_metric,
     }
-    results: Dict[Tuple[str, str, str], MetricValue] = engine.resolve_metrics(
+    results: Dict[MetricConfigurationID, MetricValue] = engine.resolve_metrics(
         metrics_to_resolve=(unexpected_index_list,), metrics=metrics
     )
     for key, val in results.items():
@@ -376,7 +379,7 @@ def test_sa_unexpected_index_list_metric_without_id_pk(sa, animal_table_df):
         "unexpected_condition": unexpected_columns_metric,
         "table.columns": table_columns_metric,
     }
-    results: Dict[Tuple[str, str, str], MetricValue] = engine.resolve_metrics(
+    results: Dict[MetricConfigurationID, MetricValue] = engine.resolve_metrics(
         metrics_to_resolve=(unexpected_index_list,), metrics=metrics
     )
     assert list(results.values())[0] is None
@@ -412,7 +415,7 @@ def test_sa_unexpected_index_list_metric_without_id_pk_without_column_values(sa,
         "unexpected_condition": unexpected_columns_metric,
         "table.columns": table_columns_metric,
     }
-    results: Dict[Tuple[str, str, str], MetricValue] = engine.resolve_metrics(
+    results: Dict[MetricConfigurationID, MetricValue] = engine.resolve_metrics(
         metrics_to_resolve=(unexpected_index_list,), metrics=metrics
     )
     assert list(results.values())[0] is None
@@ -440,7 +443,7 @@ def test_sa_unexpected_index_query_metric_with_id_pk(
         "unexpected_condition": unexpected_columns_metric,
         "table.columns": table_columns_metric,
     }
-    results: Dict[Tuple[str, str, str], MetricValue] = engine.resolve_metrics(
+    results: Dict[MetricConfigurationID, MetricValue] = engine.resolve_metrics(
         metrics_to_resolve=(unexpected_index_query,), metrics=metrics
     )
     for key, val in results.items():
@@ -480,7 +483,7 @@ def test_sa_unexpected_index_query_metric_without_id_pk(sa, animal_table_df):
         "unexpected_condition": unexpected_columns_metric,
         "table.columns": table_columns_metric,
     }
-    results: Dict[Tuple[str, str, str], MetricValue] = engine.resolve_metrics(
+    results: Dict[MetricConfigurationID, MetricValue] = engine.resolve_metrics(
         metrics_to_resolve=(unexpected_index_query,), metrics=metrics
     )
     for key, val in results.items():
@@ -514,7 +517,7 @@ def test_spark_unexpected_index_list_metric_with_id_pk(
         "unexpected_condition": unexpected_columns_metric,
         "table.columns": table_columns_metric,
     }
-    results: Dict[Tuple[str, str, str], MetricValue] = engine.resolve_metrics(
+    results: Dict[MetricConfigurationID, MetricValue] = engine.resolve_metrics(
         metrics_to_resolve=(unexpected_index_list,), metrics=metrics
     )
     for val in results.values():
@@ -560,7 +563,7 @@ def test_spark_unexpected_index_list_metric_with_id_pk_without_column_values(
         "unexpected_condition": unexpected_columns_metric,
         "table.columns": table_columns_metric,
     }
-    results: Dict[Tuple[str, str, str], MetricValue] = engine.resolve_metrics(
+    results: Dict[MetricConfigurationID, MetricValue] = engine.resolve_metrics(
         metrics_to_resolve=(unexpected_index_list,), metrics=metrics
     )
     for val in results.values():
@@ -599,7 +602,7 @@ def test_spark_unexpected_index_list_metric_without_id_pk(spark_session, animal_
         "unexpected_condition": unexpected_columns_metric,
         "table.columns": table_columns_metric,
     }
-    results: Dict[Tuple[str, str, str], MetricValue] = engine.resolve_metrics(
+    results: Dict[MetricConfigurationID, MetricValue] = engine.resolve_metrics(
         metrics_to_resolve=(unexpected_index_list,), metrics=metrics
     )
     assert list(results.values())[0] is None
@@ -638,7 +641,7 @@ def test_spark_unexpected_index_list_metric_without_id_pk_without_column_values(
         "unexpected_condition": unexpected_columns_metric,
         "table.columns": table_columns_metric,
     }
-    results: Dict[Tuple[str, str, str], MetricValue] = engine.resolve_metrics(
+    results: Dict[MetricConfigurationID, MetricValue] = engine.resolve_metrics(
         metrics_to_resolve=(unexpected_index_list,), metrics=metrics
     )
     assert list(results.values())[0] is None
@@ -664,7 +667,7 @@ def test_pd_unexpected_index_query_metric_with_id_pk(animal_table_df, metric_val
         "unexpected_condition": unexpected_columns_metric,
         "table.columns": table_columns_metric,
     }
-    results: Dict[Tuple[str, str, str], MetricValue] = engine.resolve_metrics(
+    results: Dict[MetricConfigurationID, MetricValue] = engine.resolve_metrics(
         metrics_to_resolve=(unexpected_index_query,), metrics=metrics
     )
     for val in results.values():
@@ -701,7 +704,7 @@ def test_pd_unexpected_index_query_metric_without_id_pk(
         "unexpected_condition": unexpected_columns_metric,
         "table.columns": table_columns_metric,
     }
-    results: Dict[Tuple[str, str, str], MetricValue] = engine.resolve_metrics(
+    results: Dict[MetricConfigurationID, MetricValue] = engine.resolve_metrics(
         metrics_to_resolve=(unexpected_index_query,), metrics=metrics
     )
     for val in results.values():
@@ -731,7 +734,7 @@ def test_spark_unexpected_index_query_metric_with_id_pk(
         "unexpected_condition": unexpected_columns_metric,
         "table.columns": table_columns_metric,
     }
-    results: Dict[Tuple[str, str, str], MetricValue] = engine.resolve_metrics(
+    results: Dict[MetricConfigurationID, MetricValue] = engine.resolve_metrics(
         metrics_to_resolve=(unexpected_index_query,), metrics=metrics
     )
     for val in results.values():
@@ -770,7 +773,7 @@ def test_spark_unexpected_index_query_metric_without_id_pk(
         "unexpected_condition": unexpected_columns_metric,
         "table.columns": table_columns_metric,
     }
-    results: Dict[Tuple[str, str, str], MetricValue] = engine.resolve_metrics(
+    results: Dict[MetricConfigurationID, MetricValue] = engine.resolve_metrics(
         metrics_to_resolve=(unexpected_index_query,), metrics=metrics
     )
     for val in results.values():

--- a/tests/expectations/metrics/test_core.py
+++ b/tests/expectations/metrics/test_core.py
@@ -2,7 +2,7 @@ import copy
 import datetime
 import logging
 from decimal import Decimal
-from typing import TYPE_CHECKING, Dict, Tuple, Union
+from typing import TYPE_CHECKING, Dict, Union
 
 import numpy as np
 import pandas as pd
@@ -38,7 +38,10 @@ from great_expectations.self_check.util import (
     build_spark_engine,
 )
 from great_expectations.util import isclose
-from great_expectations.validator.metric_configuration import MetricConfiguration
+from great_expectations.validator.metric_configuration import (
+    MetricConfiguration,
+    MetricConfigurationID,
+)
 from tests.expectations.test_util import get_table_columns_metric
 
 if TYPE_CHECKING:
@@ -56,10 +59,10 @@ def test_basic_metric_pd():
     batch = Batch(data=df)
     engine = PandasExecutionEngine(batch_data_dict={batch.id: batch.data})
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -97,10 +100,10 @@ def test_basic_metric_pd():
 def test_column_sum_metric_pd(build_engine, dataframe, expected_result):
     engine = build_engine(df=dataframe)
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -135,10 +138,10 @@ def test_column_sum_metric_pd(build_engine, dataframe, expected_result):
 def test_column_sum_metric_spark(spark_session, dataframe, expected_result):
     engine = build_spark_engine(spark=spark_session, df=dataframe, batch_id="my_id")
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -249,10 +252,10 @@ def test_column_sum_metric_spark_longtype_overflow_does_not_raise(spark_session)
 def test_column_mean_metric_pd(dataframe, expected_result):
     engine = build_pandas_engine(dataframe)
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -284,10 +287,10 @@ def test_column_mean_metric_pd(dataframe, expected_result):
 def test_column_mean_metric_spark(spark_session, dataframe, expected_result):
     engine = build_spark_engine(spark=spark_session, df=dataframe, batch_id="my_id")
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -336,10 +339,10 @@ def test_column_mean_metric_spark(spark_session, dataframe, expected_result):
 def test_column_standard_deviation_metric_pd(build_engine, dataframe, expected_result):
     engine = build_engine(df=dataframe)
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -376,10 +379,10 @@ def test_column_value_lengths_min_metric_pd():
         )
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -417,10 +420,10 @@ def test_column_quoted_name_type_sa(sa):
         sa,
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -430,7 +433,7 @@ def test_column_quoted_name_type_sa(sa):
         metric_domain_kwargs={},
         metric_value_kwargs=None,
     )
-    table_columns_metric_id: Tuple[str, str, str] = table_columns_metric.id
+    table_columns_metric_id: MetricConfigurationID = table_columns_metric.id
     batch_column_list = metrics[table_columns_metric_id]
 
     column_name: str
@@ -499,10 +502,10 @@ def test_column_quoted_name_type_sa_handles_explicit_string_identifiers(sa):
         sa,
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -512,7 +515,7 @@ def test_column_quoted_name_type_sa_handles_explicit_string_identifiers(sa):
         metric_domain_kwargs={},
         metric_value_kwargs=None,
     )
-    table_columns_metric_id: Tuple[str, str, str] = table_columns_metric.id
+    table_columns_metric_id: MetricConfigurationID = table_columns_metric.id
     batch_column_list = metrics[table_columns_metric_id]
 
     for column_name in [
@@ -548,10 +551,10 @@ def test_column_value_lengths_min_metric_sa(sa):
         sa,
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -602,10 +605,10 @@ def test_column_value_lengths_min_metric_spark(spark_session):
         batch_id="my_id",
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -654,10 +657,10 @@ def test_column_value_lengths_max_metric_pd():
         )
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -695,10 +698,10 @@ def test_column_value_lengths_max_metric_sa(sa):
         sa,
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -749,10 +752,10 @@ def test_column_value_lengths_max_metric_spark(spark_session):
         batch_id="my_id",
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -786,10 +789,10 @@ def test_column_value_lengths_max_metric_spark(spark_session):
 def test_quantiles_metric_pd():
     engine = build_pandas_engine(pd.DataFrame({"a": [1, 2, 3, 4]}))
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -814,10 +817,10 @@ def test_quantiles_metric_pd():
 def test_quantiles_metric_sa(sa):
     engine = build_sa_execution_engine(pd.DataFrame({"a": [1, 2, 3, 4]}), sa)
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -895,10 +898,10 @@ def test_quantiles_metric_spark(spark_session):
         batch_id="my_id",
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -939,10 +942,10 @@ def test_column_histogram_metric_pd():
         )
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -996,10 +999,10 @@ def test_column_histogram_metric_sa(sa):
         sa,
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -1056,10 +1059,10 @@ def test_column_histogram_metric_spark(spark_session):
         batch_id="my_id",
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -1127,10 +1130,10 @@ def test_column_partition_metric_pd():
     idx: int
     element: Union[float, pd.Timestamp]
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     # Test using standard numeric column.
 
@@ -1289,10 +1292,10 @@ def test_column_partition_metric_sa(sa):  # noqa: PLR0915 # FIXME CoP
     idx: int
     element: Union[float, pd.Timestamp]
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     # Test using standard numeric column.
 
@@ -1512,10 +1515,10 @@ def test_column_partition_metric_spark(spark_session):  # noqa: PLR0915 # FIXME 
     idx: int
     element: Union[float, pd.Timestamp]
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     # Test using standard numeric column.
 
@@ -1684,10 +1687,10 @@ def test_max_metric_column_exists_pd():
     batch = Batch(data=df)
     engine = PandasExecutionEngine(batch_data_dict={batch.id: batch.data})
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -1711,10 +1714,10 @@ def test_max_metric_column_does_not_exist_pd():
     batch = Batch(data=df)
     engine = PandasExecutionEngine(batch_data_dict={batch.id: batch.data})
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -1739,10 +1742,10 @@ def test_max_metric_column_does_not_exist_pd():
 def test_max_metric_column_exists_sa(sa):
     engine = build_sa_execution_engine(pd.DataFrame({"a": [1, 2, 1, None]}), sa)
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -1778,10 +1781,10 @@ def test_max_metric_column_exists_sa(sa):
 def test_max_metric_column_does_not_exist_sa(sa):
     engine = build_sa_execution_engine(pd.DataFrame({"a": [1, 2, 1, None]}), sa)
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -1810,10 +1813,10 @@ def test_max_metric_column_exists_spark(spark_session):
         batch_id="my_id",
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -1853,10 +1856,10 @@ def test_max_metric_column_does_not_exist_spark(spark_session):
         batch_id="my_id",
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -1881,10 +1884,10 @@ def test_max_metric_column_does_not_exist_spark(spark_session):
 def test_map_value_set_sa(sa):
     engine = build_sa_execution_engine(pd.DataFrame({"a": [1, 2, 3, 3, None]}), sa)
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -1954,10 +1957,10 @@ def test_map_value_set_spark(spark_session, basic_spark_df_execution_engine):
         batch_id="my_id",
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -2056,10 +2059,10 @@ def test_map_value_set_spark(spark_session, basic_spark_df_execution_engine):
 def test_map_column_value_lengths_between_pd():
     engine = build_pandas_engine(pd.DataFrame({"a": ["a", "aaa", "bcbc", "defgh", None]}))
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -2102,10 +2105,10 @@ def test_map_column_values_increasing_pd():
         )
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -2178,10 +2181,10 @@ def test_map_column_values_increasing_spark(spark_session):
         batch_id="my_id",
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -2251,7 +2254,7 @@ def test_map_column_values_increasing_spark(spark_session):
 
 def _resolve_strictly_monotonic_unexpected_count(engine, metric_stem: str):
     """Resolve the unexpected count for a strictly increasing/decreasing metric."""
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -2339,7 +2342,7 @@ def test_map_column_values_between_spark_string_column_string_bounds(spark_sessi
     spark_df = spark_session.createDataFrame([("a",), ("b",), ("c",), ("d",)], schema=schema)
     engine = build_spark_engine(spark=spark_session, df=spark_df, batch_id="my_id")
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -2411,10 +2414,10 @@ def test_map_column_values_decreasing_pd():
         )
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -2487,10 +2490,10 @@ def test_map_column_values_decreasing_spark(spark_session):
         batch_id="my_id",
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -2560,10 +2563,10 @@ def test_map_column_values_decreasing_spark(spark_session):
 def test_map_unique_column_exists_pd():
     engine = build_pandas_engine(pd.DataFrame({"a": [1, 2, 3, 3, 4, None]}))
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -2619,10 +2622,10 @@ def test_map_unique_column_exists_pd():
 def test_map_unique_column_does_not_exist_pd():
     engine = build_pandas_engine(pd.DataFrame({"a": [1, 2, 3, 3, None]}))
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -2649,10 +2652,10 @@ def test_map_unique_column_exists_sa(sa):
         sa,
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -2748,10 +2751,10 @@ def test_map_unique_column_does_not_exist_sa(sa):
         sa,
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -2993,10 +2996,10 @@ def test_map_unique_column_exists_spark(spark_session):
         batch_id="my_id",
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -3086,10 +3089,10 @@ def test_map_unique_column_does_not_exist_spark(spark_session):
         batch_id="my_id",
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -3114,10 +3117,10 @@ def test_z_score_under_threshold_pd():
     df = pd.DataFrame({"a": [1, 2, 3, None]})
     engine = PandasExecutionEngine(batch_data_dict={"my_id": df})
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -3197,10 +3200,10 @@ def test_z_score_under_threshold_spark(spark_session):
         batch_id="my_id",
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -3309,7 +3312,7 @@ def test_z_score_under_threshold_spark_constant_column(spark_session):
         batch_id="my_id",
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -3434,10 +3437,10 @@ def test_map_column_pairs_equal_metric_pd():  # noqa: PLR0915 # FIXME CoP
         )
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -3673,10 +3676,10 @@ def test_map_column_pairs_equal_metric_sa(sa):  # noqa: PLR0915 # FIXME CoP
         sa,
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -3881,10 +3884,10 @@ def test_map_column_pairs_equal_metric_spark(spark_session):  # noqa: PLR0915 # 
         batch_id="my_id",
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -4081,10 +4084,10 @@ def test_map_column_pairs_greater_metric_pd():
     df = pd.DataFrame({"a": [2, 3, 4, None, 3, None], "b": [1, 2, 3, None, 3, 5]})
     engine = PandasExecutionEngine(batch_data_dict={"my_id": df})
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -4159,10 +4162,10 @@ def test_map_column_pairs_greater_metric_sa(sa):
         sa,
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -4232,10 +4235,10 @@ def test_map_column_pairs_greater_metric_spark(spark_session):
         batch_id="my_id",
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -4297,10 +4300,10 @@ def test_map_column_pairs_in_set_metric_pd():
     df = pd.DataFrame({"a": [10, 3, 4, None, 3, None], "b": [1, 2, 3, None, 3, 5]})
     engine = PandasExecutionEngine(batch_data_dict={"my_id": df})
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -4339,10 +4342,10 @@ def test_map_column_pairs_in_set_metric_sa(sa):
         sa,
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -4462,10 +4465,10 @@ def test_map_column_pairs_in_set_metric_spark(spark_session):
         batch_id="my_id",
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -4615,10 +4618,10 @@ def test_column_median_metric_pd():
         )
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -4656,10 +4659,10 @@ def test_column_median_metric_sa(sa, dataframe: pd.DataFrame, median: int):
         sa,
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -4770,10 +4773,10 @@ def test_column_median_metric_spark(spark_session):
 def test_value_counts_metric_pd():
     engine = build_pandas_engine(pd.DataFrame({"a": [1, 2, 1, 2, 3, 3]}))
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -4878,10 +4881,10 @@ def test_distinct_metric_spark(
         batch_id="my_id",
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -4966,10 +4969,10 @@ def test_distinct_metric_sa(
         sa,
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -5045,10 +5048,10 @@ def test_distinct_metric_sa(
 def test_distinct_metric_pd():
     engine = build_pandas_engine(pd.DataFrame({"a": [1, 2, 1, 2, 3, 3]}))
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -5131,10 +5134,10 @@ def test_batch_aggregate_metrics_pd():
         )
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -5195,10 +5198,10 @@ def test_batch_aggregate_metrics_sa(caplog, sa):
         pd.DataFrame({"a": [1, 2, 1, 2, 3, 3], "b": [4, 4, 4, 4, 4, 4]}), sa
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -5323,10 +5326,10 @@ def test_batch_aggregate_metrics_spark(caplog, spark_session):
         batch_id="my_id",
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -5440,10 +5443,10 @@ def test_map_multicolumn_sum_equal_pd():  # noqa: PLR0915 # FIXME CoP
         pd.DataFrame(data={"a": [0, 1, 2], "b": [5, 4, 3], "c": [0, 0, 1], "d": [7, 8, 9]})
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -5641,10 +5644,10 @@ def test_map_multicolumn_sum_equal_sa(sa):  # noqa: PLR0915 # FIXME CoP
         sa,
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -5834,10 +5837,10 @@ def test_map_multicolumn_sum_equal_spark(spark_session):  # noqa: PLR0915 # FIXM
         batch_id="my_id",
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -6023,7 +6026,7 @@ def test_map_multicolumn_sum_equal_spark(spark_session):  # noqa: PLR0915 # FIXM
 
 def _resolve_multicolumn_sum_equal_unexpected_count(engine, column_list, sum_total):
     """Resolve the unexpected count for multicolumn_sum.equal over the given columns."""
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -6106,10 +6109,10 @@ def test_map_compound_columns_unique_pd():  # noqa: PLR0915 # FIXME CoP
         pd.DataFrame(data={"a": [0, 1, 1], "b": [1, 2, 3], "c": [0, 2, 2]})
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -6303,10 +6306,10 @@ def test_map_compound_columns_unique_sa(sa):  # noqa: PLR0915 # FIXME CoP
         sa,
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -6534,10 +6537,10 @@ def test_map_compound_columns_unique_spark(spark_session):  # noqa: PLR0915 # FI
         batch_id="my_id",
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -6732,10 +6735,10 @@ def test_map_select_column_values_unique_within_record_pd():  # noqa: PLR0915 # 
         )
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -6970,10 +6973,10 @@ def test_map_select_column_values_unique_within_record_sa(sa):  # noqa: PLR0915 
         sa,
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)
@@ -7182,10 +7185,10 @@ def test_map_select_column_values_unique_within_record_spark(  # noqa: PLR0915 #
         batch_id="my_id",
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    metrics: Dict[MetricConfigurationID, MetricValue] = {}
 
     table_columns_metric: MetricConfiguration
-    results: Dict[Tuple[str, str, str], MetricValue]
+    results: Dict[MetricConfigurationID, MetricValue]
 
     table_columns_metric, results = get_table_columns_metric(execution_engine=engine)
     metrics.update(results)

--- a/tests/expectations/test_util.py
+++ b/tests/expectations/test_util.py
@@ -129,14 +129,12 @@ def test_prescriptive_renderer_no_decorator(
         template_str = "$column minimum value must be greater than or equal to $min_value and less than or equal to $max_value"  # noqa: E501 # FIXME CoP
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]
 
@@ -195,14 +193,12 @@ def test_prescriptive_renderer_with_decorator(
         template_str = "$column minimum value must be greater than or equal to $min_value and less than or equal to $max_value"  # noqa: E501 # FIXME CoP
         return [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]
 

--- a/tests/integration/fluent/integration_test_utils.py
+++ b/tests/integration/fluent/integration_test_utils.py
@@ -197,7 +197,7 @@ def run_batch_head(  # noqa: C901 # FIXME CoP
             assert isinstance(head_data, HeadData)
             assert len(head_data.data.index) == 5
 
-        assert set(metrics[table_columns_metric.id]) == expected_columns  # type: ignore[arg-type] # FIXME CoP
+        assert set(metrics[table_columns_metric.id]) == expected_columns
 
     else:
         with pytest.raises(ValidationError) as e:

--- a/tests/render/test_default_jinja_view.py
+++ b/tests/render/test_default_jinja_view.py
@@ -65,32 +65,26 @@ def test_render_DefaultJinjaPageView_meta_info():
 
 def test_render_section_page():
     section = RenderedSectionContent(
-        **{
-            "section_name": None,
-            "content_blocks": [
-                RenderedHeaderContent(
-                    **{
-                        "content_block_type": "header",
-                        "header": "Overview",
-                    }
-                ),
-                RenderedTableContent(
-                    **{
-                        "content_block_type": "table",
-                        "header": "Dataset info",
-                        "table": [
-                            ["Number of variables", "12"],
-                            ["Number of observations", "891"],
-                        ],
-                        "styling": {
-                            "classes": ["col-6", "table-responsive"],
-                            "styles": {"margin-top": "20px"},
-                            "body": {"classes": ["table", "table-sm"]},
-                        },
-                    }
-                ),
-            ],
-        }
+        section_name=None,
+        content_blocks=[
+            RenderedHeaderContent(
+                content_block_type="header",
+                header="Overview",
+            ),
+            RenderedTableContent(
+                content_block_type="table",
+                header="Dataset info",
+                table=[
+                    ["Number of variables", "12"],
+                    ["Number of observations", "891"],
+                ],
+                styling={
+                    "classes": ["col-6", "table-responsive"],
+                    "styles": {"margin-top": "20px"},
+                    "body": {"classes": ["table", "table-sm"]},
+                },
+            ),
+        ],
     ).to_json_dict()
 
     rendered_doc = gx.render.view.view.DefaultJinjaSectionView().render(
@@ -148,11 +142,8 @@ def test_render_section_page():
 
 def test_rendering_components_without_section_loop_index():
     header_component_content = RenderedHeaderContent(
-        **{
-            # "component_type": "header",
-            "content_block_type": "header",
-            "header": "Overview",
-        }
+        content_block_type="header",
+        header="Overview",
     ).to_json_dict()
     rendered_doc = gx.render.view.view.DefaultJinjaComponentView().render(
         {
@@ -224,67 +215,61 @@ def test_rendering_components_with_styling():
     # Medium-complicated example to verify that all the things are correctly piped to all the places
 
     header_component_content = RenderedTableContent(
-        **{
-            "content_block_type": "table",
-            "header": RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": "$var1 $var2 $var3",
-                        "params": {
-                            "var1": "AAA",
-                            "var2": "BBB",
-                            "var3": "CCC",
-                        },
-                        "styling": {
-                            "default": {"classes": ["x"]},
-                            "params": {"var1": {"classes": ["y"]}},
-                        },
-                    },
-                }
-            ),
-            "subheader": RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": "$var1 $var2 $var3",
-                        "params": {
-                            "var1": "aaa",
-                            "var2": "bbb",
-                            "var3": "ccc",
-                        },
-                        "styling": {
-                            "default": {"classes": ["xx"]},
-                            "params": {"var1": {"classes": ["yy"]}},
-                        },
-                    },
-                }
-            ),
-            "table": [
-                ["Mean", "446"],
-                ["Minimum", "1"],
-            ],
-            "styling": {
-                "classes": ["root_foo"],
-                "styles": {"root": "bar"},
-                "attributes": {"root": "baz"},
-                "header": {
-                    "classes": ["header_foo"],
-                    "styles": {"header": "bar"},
-                    "attributes": {"header": "baz"},
+        content_block_type="table",
+        header=RenderedStringTemplateContent(
+            content_block_type="string_template",
+            string_template={
+                "template": "$var1 $var2 $var3",
+                "params": {
+                    "var1": "AAA",
+                    "var2": "BBB",
+                    "var3": "CCC",
                 },
-                "subheader": {
-                    "classes": ["subheader_foo"],
-                    "styles": {"subheader": "bar"},
-                    "attributes": {"subheader": "baz"},
-                },
-                "body": {
-                    "classes": ["body_foo"],
-                    "styles": {"body": "bar"},
-                    "attributes": {"body": "baz"},
+                "styling": {
+                    "default": {"classes": ["x"]},
+                    "params": {"var1": {"classes": ["y"]}},
                 },
             },
-        }
+        ),
+        subheader=RenderedStringTemplateContent(
+            content_block_type="string_template",
+            string_template={
+                "template": "$var1 $var2 $var3",
+                "params": {
+                    "var1": "aaa",
+                    "var2": "bbb",
+                    "var3": "ccc",
+                },
+                "styling": {
+                    "default": {"classes": ["xx"]},
+                    "params": {"var1": {"classes": ["yy"]}},
+                },
+            },
+        ),
+        table=[
+            ["Mean", "446"],
+            ["Minimum", "1"],
+        ],
+        styling={
+            "classes": ["root_foo"],
+            "styles": {"root": "bar"},
+            "attributes": {"root": "baz"},
+            "header": {
+                "classes": ["header_foo"],
+                "styles": {"header": "bar"},
+                "attributes": {"header": "baz"},
+            },
+            "subheader": {
+                "classes": ["subheader_foo"],
+                "styles": {"subheader": "bar"},
+                "attributes": {"subheader": "baz"},
+            },
+            "body": {
+                "classes": ["body_foo"],
+                "styles": {"body": "bar"},
+                "attributes": {"body": "baz"},
+            },
+        },
     ).to_json_dict()
     rendered_doc = gx.render.view.view.DefaultJinjaComponentView().render(
         {
@@ -340,11 +325,8 @@ def test_rendering_components_with_styling():
 # Test all the component types ###
 def test_render_header_component():
     header_component_content = RenderedHeaderContent(
-        **{
-            # "component_type": "header",
-            "content_block_type": "header",
-            "header": "Overview",
-        }
+        content_block_type="header",
+        header="Overview",
     ).to_json_dict()
     rendered_doc = gx.render.view.view.DefaultJinjaComponentView().render(
         {
@@ -372,17 +354,15 @@ def test_render_header_component():
 
 def test_render_table_component():
     table_component_content = RenderedTableContent(
-        **{
-            "content_block_type": "table",
-            "header": "Overview",
-            "table": [
-                ["Mean", "446"],
-                ["Minimum", "1"],
-            ],
-            "styling": {
-                "classes": ["col-4"],
-            },
-        }
+        content_block_type="table",
+        header="Overview",
+        table=[
+            ["Mean", "446"],
+            ["Minimum", "1"],
+        ],
+        styling={
+            "classes": ["col-4"],
+        },
     ).to_json_dict()
     rendered_doc = gx.render.view.view.DefaultJinjaComponentView().render(
         {
@@ -428,29 +408,27 @@ def test_render_table_component():
 
 def test_render_value_list():
     value_list_component_content = ValueListContent(
-        **{
-            "content_block_type": "value_list",
-            "header": "Example values",
-            "value_list": [
-                {
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": "$value",
-                        "params": {"value": "0"},
-                        "styling": {"default": {"classes": ["badge", "badge-info"]}},
-                    },
+        content_block_type="value_list",
+        header="Example values",
+        value_list=[
+            {
+                "content_block_type": "string_template",
+                "string_template": {
+                    "template": "$value",
+                    "params": {"value": "0"},
+                    "styling": {"default": {"classes": ["badge", "badge-info"]}},
                 },
-                {
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": "$value",
-                        "params": {"value": "1"},
-                        "styling": {"default": {"classes": ["badge", "badge-info"]}},
-                    },
+            },
+            {
+                "content_block_type": "string_template",
+                "string_template": {
+                    "template": "$value",
+                    "params": {"value": "1"},
+                    "styling": {"default": {"classes": ["badge", "badge-info"]}},
                 },
-            ],
-            "styling": {"classes": ["col-4"], "styles": {"margin-top": "20px"}},
-        }
+            },
+        ],
+        styling={"classes": ["col-4"], "styles": {"margin-top": "20px"}},
     ).to_json_dict()
 
     rendered_doc = gx.render.view.view.DefaultJinjaComponentView().render(
@@ -487,12 +465,10 @@ def test_render_value_list():
 
 def test_render_graph():
     graph_component_content = RenderedGraphContent(
-        **{
-            "content_block_type": "graph",
-            "header": "Histogram",
-            "graph": '{"$schema": "https://vega.github.io/schema/vega-lite/v2.6.0.json", "autosize": "fit", "config": {"view": {"height": 300, "width": 400}}, "data": {"name": "data-a681d02fb484e64eadd9721b37015d5b"}, "datasets": {"data-a681d02fb484e64eadd9721b37015d5b": [{"bins": 3.7, "weights": 5.555555555555555}, {"bins": 10.8, "weights": 3.439153439153439}, {"bins": 17.9, "weights": 17.857142857142858}, {"bins": 25.0, "weights": 24.206349206349206}, {"bins": 32.0, "weights": 16.137566137566136}, {"bins": 39.1, "weights": 12.3015873015873}, {"bins": 46.2, "weights": 9.788359788359788}, {"bins": 53.3, "weights": 5.423280423280423}, {"bins": 60.4, "weights": 3.439153439153439}, {"bins": 67.5, "weights": 1.8518518518518516}]}, "encoding": {"x": {"field": "bins", "type": "ordinal"}, "y": {"field": "weights", "type": "quantitative"}}, "height": 200, "mark": "bar", "width": 200}',  # noqa: E501 # FIXME CoP
-            "styling": {"classes": ["col-4"]},
-        }
+        content_block_type="graph",
+        header="Histogram",
+        graph='{"$schema": "https://vega.github.io/schema/vega-lite/v2.6.0.json", "autosize": "fit", "config": {"view": {"height": 300, "width": 400}}, "data": {"name": "data-a681d02fb484e64eadd9721b37015d5b"}, "datasets": {"data-a681d02fb484e64eadd9721b37015d5b": [{"bins": 3.7, "weights": 5.555555555555555}, {"bins": 10.8, "weights": 3.439153439153439}, {"bins": 17.9, "weights": 17.857142857142858}, {"bins": 25.0, "weights": 24.206349206349206}, {"bins": 32.0, "weights": 16.137566137566136}, {"bins": 39.1, "weights": 12.3015873015873}, {"bins": 46.2, "weights": 9.788359788359788}, {"bins": 53.3, "weights": 5.423280423280423}, {"bins": 60.4, "weights": 3.439153439153439}, {"bins": 67.5, "weights": 1.8518518518518516}]}, "encoding": {"x": {"field": "bins", "type": "ordinal"}, "y": {"field": "weights", "type": "quantitative"}}, "height": 200, "mark": "bar", "width": 200}',  # noqa: E501 # FIXME CoP
+        styling={"classes": ["col-4"]},
     ).to_json_dict()
 
     rendered_doc = gx.render.view.view.DefaultJinjaComponentView().render(
@@ -533,12 +509,10 @@ def test_render_graph():
 
 def test_render_text():
     text_component_content = TextContent(
-        **{
-            "content_block_type": "text",
-            "header": "Histogram",
-            "text": ["hello"],
-            "styling": {"classes": ["col-4"]},
-        }
+        content_block_type="text",
+        header="Histogram",
+        text=["hello"],
+        styling={"classes": ["col-4"]},
     ).to_json_dict()
 
     rendered_doc = gx.render.view.view.DefaultJinjaComponentView().render(
@@ -569,12 +543,10 @@ def test_render_text():
     )
 
     text_component_content = TextContent(
-        **{
-            "content_block_type": "text",
-            "header": "Histogram",
-            "text": ["hello", "goodbye"],
-            "styling": {"classes": ["col-4"]},
-        }
+        content_block_type="text",
+        header="Histogram",
+        text=["hello", "goodbye"],
+        styling={"classes": ["col-4"]},
     ).to_json_dict()
 
     rendered_doc = gx.render.view.view.DefaultJinjaComponentView().render(

--- a/tests/render/test_default_markdown_view.py
+++ b/tests/render/test_default_markdown_view.py
@@ -53,32 +53,26 @@ def expectation_suite_to_render_with_notes():
 
 def test_render_section_page():
     section = RenderedSectionContent(
-        **{
-            "section_name": None,
-            "content_blocks": [
-                RenderedHeaderContent(
-                    **{
-                        "content_block_type": "header",
-                        "header": "Overview",
-                    }
-                ),
-                RenderedTableContent(
-                    **{
-                        "content_block_type": "table",
-                        "header": "Dataset info",
-                        "table": [
-                            ["Number of variables", "12"],
-                            ["Number of observations", "891"],
-                        ],
-                        "styling": {
-                            "classes": ["col-6", "table-responsive"],
-                            "styles": {"margin-top": "20px"},
-                            "body": {"classes": ["table", "table-sm"]},
-                        },
-                    }
-                ),
-            ],
-        }
+        section_name=None,
+        content_blocks=[
+            RenderedHeaderContent(
+                content_block_type="header",
+                header="Overview",
+            ),
+            RenderedTableContent(
+                content_block_type="table",
+                header="Dataset info",
+                table=[
+                    ["Number of variables", "12"],
+                    ["Number of observations", "891"],
+                ],
+                styling={
+                    "classes": ["col-6", "table-responsive"],
+                    "styles": {"margin-top": "20px"},
+                    "body": {"classes": ["table", "table-sm"]},
+                },
+            ),
+        ],
     )
 
     rendered_doc = gx.render.view.view.DefaultMarkdownPageView().render(

--- a/tests/render/test_render_ValidationResultsTableContentBlockRenderer.py
+++ b/tests/render/test_render_ValidationResultsTableContentBlockRenderer.py
@@ -273,42 +273,38 @@ def test_ValidationResultsTableContentBlockRenderer_get_content_block_fn(evr_suc
     content_block_fn_expected_output = [
         [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": "$icon",
-                        "params": {"icon": "", "markdown_status_icon": "✅"},
-                        "styling": {
-                            "params": {
-                                "icon": {
-                                    "classes": [
-                                        "fas",
-                                        "fa-check-circle",
-                                        "text-success",
-                                    ],
-                                    "tag": "i",
-                                }
+                content_block_type="string_template",
+                string_template={
+                    "template": "$icon",
+                    "params": {"icon": "", "markdown_status_icon": "✅"},
+                    "styling": {
+                        "params": {
+                            "icon": {
+                                "classes": [
+                                    "fas",
+                                    "fa-check-circle",
+                                    "text-success",
+                                ],
+                                "tag": "i",
                             }
-                        },
+                        }
                     },
-                    "styling": {"parent": {"classes": ["hide-succeeded-validation-target-child"]}},
-                }
+                },
+                styling={"parent": {"classes": ["hide-succeeded-validation-target-child"]}},
             ),
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": "Must have greater than or equal to $min_value rows.",
-                        "params": {
-                            "min_value": 0,
-                            "max_value": None,
-                            "result_format": "SUMMARY",
-                            "strict_max": None,
-                            "strict_min": None,
-                        },
-                        "styling": None,
+                content_block_type="string_template",
+                string_template={
+                    "template": "Must have greater than or equal to $min_value rows.",
+                    "params": {
+                        "min_value": 0,
+                        "max_value": None,
+                        "result_format": "SUMMARY",
+                        "strict_max": None,
+                        "strict_min": None,
                     },
-                }
+                    "styling": None,
+                },
             ),
             "1,313",
         ]
@@ -318,43 +314,39 @@ def test_ValidationResultsTableContentBlockRenderer_get_content_block_fn(evr_suc
     content_block_fn_expected_output = [
         [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": "$icon",
-                        "params": {"icon": "", "markdown_status_icon": "✅"},
-                        "styling": {
-                            "params": {
-                                "icon": {
-                                    "classes": [
-                                        "fas",
-                                        "fa-check-circle",
-                                        "text-success",
-                                    ],
-                                    "tag": "i",
-                                }
+                content_block_type="string_template",
+                string_template={
+                    "template": "$icon",
+                    "params": {"icon": "", "markdown_status_icon": "✅"},
+                    "styling": {
+                        "params": {
+                            "icon": {
+                                "classes": [
+                                    "fas",
+                                    "fa-check-circle",
+                                    "text-success",
+                                ],
+                                "tag": "i",
                             }
-                        },
+                        }
                     },
-                    "styling": {"parent": {"classes": ["hide-succeeded-validation-target-child"]}},
-                }
+                },
+                styling={"parent": {"classes": ["hide-succeeded-validation-target-child"]}},
             ),
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": "Must have greater than or equal to $min_value rows.",
-                        "params": {
-                            "meta_properties_to_render": {},
-                            "min_value": 0,
-                            "max_value": None,
-                            "result_format": "SUMMARY",
-                            "strict_max": None,
-                            "strict_min": None,
-                        },
-                        "styling": None,
+                content_block_type="string_template",
+                string_template={
+                    "template": "Must have greater than or equal to $min_value rows.",
+                    "params": {
+                        "meta_properties_to_render": {},
+                        "min_value": 0,
+                        "max_value": None,
+                        "result_format": "SUMMARY",
+                        "strict_max": None,
+                        "strict_min": None,
                     },
-                }
+                    "styling": None,
+                },
             ),
             "1,313",
         ]
@@ -379,43 +371,39 @@ def test_ValidationResultsTableContentBlockRenderer_get_content_block_fn(evr_suc
     content_block_fn_expected_output = [
         [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": "$icon",
-                        "params": {"icon": "", "markdown_status_icon": "✅"},
-                        "styling": {
-                            "params": {
-                                "icon": {
-                                    "classes": [
-                                        "fas",
-                                        "fa-check-circle",
-                                        "text-success",
-                                    ],
-                                    "tag": "i",
-                                }
+                content_block_type="string_template",
+                string_template={
+                    "template": "$icon",
+                    "params": {"icon": "", "markdown_status_icon": "✅"},
+                    "styling": {
+                        "params": {
+                            "icon": {
+                                "classes": [
+                                    "fas",
+                                    "fa-check-circle",
+                                    "text-success",
+                                ],
+                                "tag": "i",
                             }
-                        },
+                        }
                     },
-                    "styling": {"parent": {"classes": ["hide-succeeded-validation-target-child"]}},
-                }
+                },
+                styling={"parent": {"classes": ["hide-succeeded-validation-target-child"]}},
             ),
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": "Must have greater than or equal to $min_value rows.",
-                        "params": {
-                            "meta_properties_to_render": {"property_that_doesnt_exist": "property"},
-                            "min_value": 0,
-                            "max_value": None,
-                            "result_format": "SUMMARY",
-                            "strict_max": None,
-                            "strict_min": None,
-                        },
-                        "styling": None,
+                content_block_type="string_template",
+                string_template={
+                    "template": "Must have greater than or equal to $min_value rows.",
+                    "params": {
+                        "meta_properties_to_render": {"property_that_doesnt_exist": "property"},
+                        "min_value": 0,
+                        "max_value": None,
+                        "result_format": "SUMMARY",
+                        "strict_max": None,
+                        "strict_min": None,
                     },
-                }
+                    "styling": None,
+                },
             ),
             "1,313",
             ["N/A"],
@@ -435,46 +423,42 @@ def test_ValidationResultsTableContentBlockRenderer_get_content_block_fn(evr_suc
     content_block_fn_expected_output = [
         [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": "$icon",
-                        "params": {"icon": "", "markdown_status_icon": "✅"},
-                        "styling": {
-                            "params": {
-                                "icon": {
-                                    "classes": [
-                                        "fas",
-                                        "fa-check-circle",
-                                        "text-success",
-                                    ],
-                                    "tag": "i",
-                                }
+                content_block_type="string_template",
+                string_template={
+                    "template": "$icon",
+                    "params": {"icon": "", "markdown_status_icon": "✅"},
+                    "styling": {
+                        "params": {
+                            "icon": {
+                                "classes": [
+                                    "fas",
+                                    "fa-check-circle",
+                                    "text-success",
+                                ],
+                                "tag": "i",
                             }
-                        },
+                        }
                     },
-                    "styling": {"parent": {"classes": ["hide-succeeded-validation-target-child"]}},
-                }
+                },
+                styling={"parent": {"classes": ["hide-succeeded-validation-target-child"]}},
             ),
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": "Must have greater than or equal to $min_value rows.",
-                        "params": {
-                            "meta_properties_to_render": {
-                                "property_that_exists": "property",
-                                "other existing prop": "nested.property",
-                            },
-                            "min_value": 0,
-                            "max_value": None,
-                            "result_format": "SUMMARY",
-                            "strict_max": None,
-                            "strict_min": None,
+                content_block_type="string_template",
+                string_template={
+                    "template": "Must have greater than or equal to $min_value rows.",
+                    "params": {
+                        "meta_properties_to_render": {
+                            "property_that_exists": "property",
+                            "other existing prop": "nested.property",
                         },
-                        "styling": None,
+                        "min_value": 0,
+                        "max_value": None,
+                        "result_format": "SUMMARY",
+                        "strict_max": None,
+                        "strict_min": None,
                     },
-                }
+                    "styling": None,
+                },
             ),
             "1,313",
             ["this is nested"],
@@ -536,39 +520,35 @@ def test_ValidationResultsTableContentBlockRenderer_get_content_block_fn_with_v2
     content_block_fn_expected_output = [
         [
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": "$icon",
-                        "params": {"icon": "", "markdown_status_icon": "✅"},
-                        "styling": {
-                            "params": {
-                                "icon": {
-                                    "classes": [
-                                        "fas",
-                                        "fa-check-circle",
-                                        "text-success",
-                                    ],
-                                    "tag": "i",
-                                }
+                content_block_type="string_template",
+                string_template={
+                    "template": "$icon",
+                    "params": {"icon": "", "markdown_status_icon": "✅"},
+                    "styling": {
+                        "params": {
+                            "icon": {
+                                "classes": [
+                                    "fas",
+                                    "fa-check-circle",
+                                    "text-success",
+                                ],
+                                "tag": "i",
                             }
-                        },
+                        }
                     },
-                    "styling": {"parent": {"classes": ["hide-succeeded-validation-target-child"]}},
-                }
+                },
+                styling={"parent": {"classes": ["hide-succeeded-validation-target-child"]}},
             ),
             RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": custom_expectation_template,
-                        "params": {
-                            "column": "a_column_name",
-                            "result_format": "SUMMARY",
-                        },
-                        "styling": None,
+                content_block_type="string_template",
+                string_template={
+                    "template": custom_expectation_template,
+                    "params": {
+                        "column": "a_column_name",
+                        "result_format": "SUMMARY",
                     },
-                }
+                    "styling": None,
+                },
             ),
             custom_expectation_observed_value,
         ]
@@ -738,19 +718,17 @@ def test_ValidationResultsTableContentBlockRenderer_get_unexpected_statement(
     )[1](result=evr_failed)
     assert output_2 == [
         RenderedStringTemplateContent(
-            **{
-                "content_block_type": "string_template",
-                "string_template": {
-                    "template": "\n\n$unexpected_count unexpected values found. $unexpected_percent of $element_count total rows.",  # noqa: E501 # FIXME CoP
-                    "params": {
-                        "unexpected_count": "3",
-                        "unexpected_percent": "≈0.2285%",
-                        "element_count": "1,313",
-                    },
-                    "tag": "strong",
-                    "styling": {"classes": ["text-danger"]},
+            content_block_type="string_template",
+            string_template={
+                "template": "\n\n$unexpected_count unexpected values found. $unexpected_percent of $element_count total rows.",  # noqa: E501 # FIXME CoP
+                "params": {
+                    "unexpected_count": "3",
+                    "unexpected_percent": "≈0.2285%",
+                    "element_count": "1,313",
                 },
-            }
+                "tag": "strong",
+                "styling": {"classes": ["text-danger"]},
+            },
         )
     ]
 

--- a/tests/validator/test_validation_graph.py
+++ b/tests/validator/test_validation_graph.py
@@ -1,6 +1,6 @@
 import sys
 import uuid
-from typing import TYPE_CHECKING, Dict, Iterable, Optional, Set, Tuple, Union, cast
+from typing import TYPE_CHECKING, Dict, Iterable, Optional, Set, Union, cast
 from unittest import mock
 
 import pytest
@@ -13,7 +13,10 @@ from great_expectations.expectations.expectation_configuration import (
 )
 from great_expectations.validator.computed_metric import MetricValue
 from great_expectations.validator.exception_info import ExceptionInfo
-from great_expectations.validator.metric_configuration import MetricConfiguration
+from great_expectations.validator.metric_configuration import (
+    MetricConfiguration,
+    MetricConfigurationID,
+)
 from great_expectations.validator.validation_graph import (
     MAX_METRIC_COMPUTATION_RETRIES,
     ExpectationValidationGraph,
@@ -34,9 +37,9 @@ def pandas_execution_engine_fake(
         @staticmethod
         def resolve_metrics(
             metrics_to_resolve: Iterable[MetricConfiguration],
-            metrics: Optional[Dict[Tuple[str, str, str], MetricConfiguration]] = None,
+            metrics: Optional[Dict[MetricConfigurationID, MetricConfiguration]] = None,
             runtime_configuration: Optional[dict] = None,
-        ) -> Dict[Tuple[str, str, str], MetricValue]:
+        ) -> Dict[MetricConfigurationID, MetricValue]:
             """
             This stub method implementation insures that specified "MetricConfiguration", designed to fail, will cause
             appropriate exception to be raised, while its dependencies resolve to actual values ("my_value" is used here
@@ -296,7 +299,7 @@ def test_ExpectationValidationGraph_get_exception_info(
 def test_parse_validation_graph(
     expect_column_value_z_scores_to_be_less_than_expectation_validation_graph: ValidationGraph,
 ):
-    available_metrics: Dict[Tuple[str, str, str], MetricValue]
+    available_metrics: Dict[MetricConfigurationID, MetricValue]
 
     # Parse input "ValidationGraph" object and confirm the numbers of ready and still needed metrics.  # noqa: E501 # FIXME CoP
     available_metrics = {}
@@ -309,7 +312,7 @@ def test_parse_validation_graph(
     assert len(ready_metrics) == 2 and len(needed_metrics) == 9
 
     # Show that including "nonexistent" metric in dictionary of resolved metrics does not increase ready_metrics count.  # noqa: E501 # FIXME CoP
-    available_metrics = {("nonexistent", "nonexistent", "nonexistent"): "NONE"}
+    available_metrics = {MetricConfigurationID("nonexistent", "nonexistent", "nonexistent"): "NONE"}
     (
         ready_metrics,
         needed_metrics,
@@ -381,9 +384,9 @@ def test_resolve_validation_graph_with_bad_config_catch_exceptions_true(
         runtime_configuration=runtime_configuration,
     )
 
-    resolved_metrics: Dict[Tuple[str, str, str], MetricValue]
+    resolved_metrics: Dict[MetricConfigurationID, MetricValue]
     aborted_metrics_info: Dict[
-        Tuple[str, str, str],
+        MetricConfigurationID,
         Dict[str, Union[MetricConfiguration, Set[ExceptionInfo], int]],
     ]
     _resolved_metrics, aborted_metrics_info = graph.resolve(
@@ -470,9 +473,9 @@ def test_progress_bar_config(
             )
 
         graph = ValidationGraph(execution_engine=execution_engine)
-        resolved_metrics: Dict[Tuple[str, str, str], MetricValue]
+        resolved_metrics: Dict[MetricConfigurationID, MetricValue]
         aborted_metrics_info: Dict[
-            Tuple[str, str, str],
+            MetricConfigurationID,
             Dict[str, Union[MetricConfiguration, Set[ExceptionInfo], int]],
         ]
         # noinspection PyUnusedLocal


### PR DESCRIPTION
## Summary

Tightens four narrow but widely-repeated type declarations to what they actually admit, without changing any runtime behavior:

- `MetricValue` (a resolved metric value, in `validator/computed_metric.py`) is now spelled as the dynamic type it always effectively was, instead of a closed `Union` that every call site had to re-narrow before doing anything with it.
- The render-content constructors in `render/components.py` now declare the parameter shapes their callers legitimately pass (widened, never narrowed).
- 168 call sites across 52 files that built render-content objects by splatting a literal dict now pass the same arguments directly as keywords, so each argument is checked on its own rather than being erased into one dict type.
- A handful of test call sites that built metric-cache keys as bare tuples now build them with the named identifier type the metric interfaces already declare.
- The two base renderer declarations now document the contract the dispatcher actually offers: it invokes renderers with different argument sets on different branches, which is why both parameters are optional. **No renderer body changes in this PR** — see below.

## Why

A union wide enough to accept every assignment and permissive enough to satisfy every read checks nothing — it just multiplies the number of places a real defect could hide. Once metric values and render-content payloads are described accurately, the type checker can tell the difference between a legitimate call and a genuine mistake, instead of forcing every caller to defeat the checker with a local suppression.

None of these are behavior changes: every widened parameter accepts a strict superset of what it accepted before, every changed key construction produces the same runtime value as the bare tuple it replaces (the named identifier type is a `NamedTuple`, so it compares and hashes equal), no renderer signature changed, and no renderer body changed behaviorally (many of the call-site rewrites above sit inside renderer methods, but each is the same call written differently).

## Known residue, deliberately not fixed here

Writing the dispatch contract down made it clear that a number of renderers read `configuration` or `result` unconditionally, even though the dispatcher has reachable branches that omit either one. Those methods raise when they hit such a branch. **These are pre-existing defects, not introduced here**, and they are left alone deliberately: adding a guard would change what happens on those paths, which is a behavior change and does not belong in a typing PR. They are tracked for separate follow-up, along with one render view whose signature is narrower than its own body and docstring allow.

Because those defects are unfixed, this PR does not drive the renderer-nullability diagnostics to zero. That residue is expected and accounted for.

## User impact

None beyond fewer false type-checker diagnostics for anyone type-checking code that calls into these APIs. No public name moved, no parameter was removed or renamed, no already-declared parameter type was narrowed, and no renderer's declared signature changed in any way — parameter names, order, and defaults are byte-identical before and after, verified by an automated before/after signature comparison across every render-content class the render package exports and every renderer method this change touches.

## How to review

- `great_expectations/validator/computed_metric.py` — the `MetricValue` redefinition and its compatibility rationale in the comment above it, including what changes at runtime (introspecting the alias's members now returns none) and why nothing in this repository does that.
- `great_expectations/render/components.py` — the four widened constructor parameters (`table`, `header`, `header_row`, `collapse_toggle_link`); confirm each widening is a strict superset of the prior type.
- The call-site changes (splat → direct keyword arguments) are mechanical and account for most of the diff. Reviewer effort is best spent spot-checking a few for argument-order and value fidelity rather than reading all 168.
- `great_expectations/expectations/expectation.py` — the two added docstrings on the base renderer declarations. These are documentation only; the commit adds 24 lines and deletes none.
- Suppression comments are removed, never added: 20 `# type: ignore` comments became unused once the declarations were corrected, and the type-check configuration rejects unused ignores.
