### PR TITLE
[MAINTENANCE] Run the Azure Blob docs tests against live storage again

### DIFF
--- a/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_pandas.py
+++ b/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_pandas.py
@@ -11,8 +11,6 @@ import great_expectations as gx
 
 context = gx.get_context()
 
-os.environ["AZURE_STORAGE_ACCOUNT_URL"] = "superconductivetesting.blob.core.windows.net"
-
 # Python
 # <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_pandas.py define_add_pandas_abs_args">
 datasource_name = "my_datasource"
@@ -32,7 +30,7 @@ datasource = context.data_sources.add_pandas_abs(
 assert datasource_name in context.data_sources.all()
 
 asset_name = "my_taxi_data_asset"
-abs_container = "superconductive-public"
+abs_container = os.environ["AZURE_CONTAINER"]
 abs_name_starts_with = "data/taxi_yellow_tripdata_samples/"
 batching_regex = r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv"
 

--- a/tasks.py
+++ b/tasks.py
@@ -1037,10 +1037,15 @@ MARKER_DEPENDENCY_MAP: Final[Mapping[str, TestDependencies]] = {
             # aborts the whole session rather than skipping its tests. Add one only once
             # its marker leg is green.
             #
-            # Two are deliberately left out, for different reasons.
+            # --azure has no marker leg to be green: nothing carries an azure marker, and
+            # the docs fixtures are the only tests that reach Blob Storage at all. Its
+            # collection check is also weaker than the others -- build_test_backends_list
+            # only asserts that one of AZURE_CREDENTIAL / AZURE_ACCESS_KEY /
+            # AZURE_CONNECTION_STRING is non-empty, and opens no connection -- so a
+            # credential that is present but wrong (an expired SAS, say) surfaces as a
+            # fixture failure here rather than as a collection error.
             #
-            # --azure: its dependencies are installed for imports, but there is no storage
-            # account or credential to connect to, so requesting it would abort collection.
+            # One is deliberately left out.
             #
             # --snowflake: collection connects fine, but both Snowflake docs fixtures then
             # fail loading their test data into the test database. That failure is not
@@ -1049,6 +1054,7 @@ MARKER_DEPENDENCY_MAP: Final[Mapping[str, TestDependencies]] = {
             # so it needs someone who can run it against Snowflake directly. The marker
             # leg is green, so this is a fixture/permissions gap, not a dead backend.
             "--aws",
+            "--azure",
             "--bigquery",
             "--gcs",
             "--redshift",

--- a/tests/integration/test_definitions/abs/partitioned_on_datetime.py
+++ b/tests/integration/test_definitions/abs/partitioned_on_datetime.py
@@ -7,9 +7,13 @@ context = gx.get_context()
 
 datasource_name = "ABS datasource"
 
-CREDENTIAL = os.getenv("AZURE_CREDENTIAL", "")
-ACCOUNT_URL = "superconductivetesting.blob.core.windows.net"
-CONTAINER = "superconductive-public"
+# All three come from the environment, and all three raise rather than default:
+# the account holding this data is not the one these tests were written against,
+# and a silently empty credential or a stale hardcoded host fails later, in the
+# datasource, as an authentication error that says nothing about configuration.
+CREDENTIAL = os.environ["AZURE_CREDENTIAL"]
+ACCOUNT_URL = os.environ["AZURE_STORAGE_ACCOUNT_URL"]
+CONTAINER = os.environ["AZURE_CONTAINER"]
 NAME_STARTS_WITH = "data/taxi_yellow_tripdata_samples/"
 
 

--- a/tests/integration/test_definitions/abs/select_batch_by_path.py
+++ b/tests/integration/test_definitions/abs/select_batch_by_path.py
@@ -6,9 +6,13 @@ context = gx.get_context()
 
 datasource_name = "ABS datasource"
 
-CREDENTIAL = os.getenv("AZURE_CREDENTIAL", "")
-ACCOUNT_URL = "superconductivetesting.blob.core.windows.net"
-CONTAINER = "superconductive-public"
+# All three come from the environment, and all three raise rather than default:
+# the account holding this data is not the one these tests were written against,
+# and a silently empty credential or a stale hardcoded host fails later, in the
+# datasource, as an authentication error that says nothing about configuration.
+CREDENTIAL = os.environ["AZURE_CREDENTIAL"]
+ACCOUNT_URL = os.environ["AZURE_STORAGE_ACCOUNT_URL"]
+CONTAINER = os.environ["AZURE_CONTAINER"]
 NAME_STARTS_WITH = "data/taxi_yellow_tripdata_samples/"
 
 

--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -582,11 +582,6 @@ def _check_for_skipped_tests(  # noqa: C901, PLR0912 # FIXME CoP
     dependencies = integration_test_fixture.backend_dependencies
     if not dependencies:
         return
-    # TEMPORARY: Tests backed by Azure Blob are unconditionally skipped during the CI
-    # transition -- there is no storage account or live credential to run against yet.
-    # Remove this block once that infrastructure is restored.
-    elif BackendDependencies.AZURE in dependencies:
-        pytest.skip("CI TRANSITION")
     elif BackendDependencies.POSTGRESQL in dependencies and (
         not pytest_args.postgresql or pytest_args.no_sqlalchemy
     ):


### PR DESCRIPTION
The Azure Blob fixtures have been skipped unconditionally since the CI transition — there was no storage account or credential to run them against. That infrastructure now exists, so this removes the skip and requests `--azure` alongside the other live backends.

## What comes back

Five pandas fixtures, all in the `docs-snippets (docs-creds-needed)` leg:

| Fixture | Needs live Blob Storage |
|---|---|
| `partition_data_on_datetime_azure_pandas` | yes — lists and reads |
| `azure_pandas_by_path` | yes — lists and reads |
| `how_to_connect_to_data_on_azure_blob_storage_using_pandas` | yes — lists and reads |
| `create_a_data_asset_filesystem_abs_file_asset` | yes — lists |
| `create_a_data_source_filesystem_abs_pandas` | no — only constructs the Data Source |

## Why three files stopped hardcoding a host

The storage account these fixtures were written against is gone, and Azure storage account names are globally unique, so it cannot be recreated. The account URL and container therefore come from `AZURE_STORAGE_ACCOUNT_URL` and `AZURE_CONTAINER`, which `ci.yml` already maps into this job — no workflow change is needed.

Container names are scoped to their account rather than global, so the container name is unchanged and **no published docs snippet moves**. The one guide that hardcoded a host set it via `os.environ[...] = ...` outside any `<snippet>` block, overriding the very value the workflow supplies; that line is deleted.

The reads use `os.environ[...]` rather than `.getenv(..., "")`, matching the S3 and GCS fixtures. A blank credential does not fail where the mistake is — it fails inside the datasource as an authentication error that says nothing about configuration.

## What stays off, and why

The three Spark ABS fixtures. They require `--spark` and `--azure` in the same leg, which no leg passes: `docs-creds-needed` has the credentials and no Spark, `docs-spark` has Spark and neither the Azure SDK nor the credentials. Reading blobs from Spark also needs the `hadoop-azure` connector on the JVM classpath, which is configured nowhere in the repo, and `how_to_connect_to_data_on_azure_blob_storage_using_spark.py` passes `account_url` with no credential, which requires anonymous blob read. That is CI infrastructure work plus a snippet fix, not a flag — the same reason the GCS Spark fixtures are still off.

One stale reference is left in place deliberately: the Spark guide still assigns the retired account host to `AZURE_STORAGE_ACCOUNT_URL` in-process. It is dead code in a fixture that cannot run, and it belongs with the Spark work rather than with a change that cannot exercise it.

Nothing else in the suite reaches Blob Storage: no test carries an `azure` marker, and the datasource and data-connector unit tests are fully mocked.

## Verification

- Locally, with a deliberately invalid SAS: the five fixtures now **run** instead of skipping — four fail at `ClientAuthenticationError` and the fifth passes, exactly as expected when only the last one avoids the network. The three Spark fixtures skip with "Skipping spark tests".
- `invoke type-check --ci` clean (780 source files, plus the stub-source pass); `ruff check` and `ruff format --check` clean.
- A `workflow_dispatch` run against this branch exercises `docs-snippets (docs-creds-needed)` with real credentials — a draft PR does not, since the cloud legs gate on `draft == false`.

Marking ready once that run is green.

