### PR TITLE
[MAINTENANCE] Add a marshmallow 4 CI lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -910,6 +910,32 @@ jobs:
       - name: Run the tests
         run: invoke ci-tests -m unit --xdist --slowest=10  --timeout=2.0
 
+  marshmallow4-test:
+    needs: [unit-tests, static-analysis, check-actor-permissions]
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.3.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: reqs/requirements-dev-test.txt
+
+      - name: Install dependencies
+        run: pip install . -c ci/constraints-test/marshmallow4-install.txt -r reqs/requirements-dev-test.txt
+
+      - name: Confirm the lane resolved marshmallow 4
+        run: python -c "import marshmallow, sys; from importlib.metadata import version; v = version('marshmallow'); print(v); sys.exit(0 if v.startswith('4.') else 1)"
+
+      - name: Run the tests
+        run: invoke ci-tests -m unit --xdist --slowest=10  --timeout=2.0
+
   airflow-min-versions:
     needs: [unit-tests, static-analysis, check-actor-permissions]
     runs-on: ubuntu-latest

--- a/ci/constraints-test/marshmallow4-install.txt
+++ b/ci/constraints-test/marshmallow4-install.txt
@@ -1,0 +1,5 @@
+# Lane pin for the dedicated marshmallow-4 CI job. requirements.txt carries no
+# upper bound on marshmallow, so the default install resolves to whichever major
+# is current; this file forces the 4.x line so the 3.x-vs-4.x differences stay
+# covered. Floats within 4.x.
+marshmallow>=4.0.0,<5.0.0


### PR DESCRIPTION
## Summary

Adds a `marshmallow4-test` CI lane that installs against the Marshmallow 4.x line and runs the unit suite, plus the `ci/constraints-test/marshmallow4-install.txt` file that selects it.

The job is modeled on the existing `pydantic-v1` and `pandas2-test` lanes: same runner, same Python version, same test invocation. One extra step asserts that the lane actually resolved Marshmallow 4, so a resolution that quietly lands on 3.x cannot report as coverage.

No RFC needed: this adds a CI lane, not backend support.

## Why

Once the Marshmallow 4 support change lands, `requirements.txt` carries no upper bound on Marshmallow. A default install then resolves to whichever major is current, and nothing exercises the other one.

That gap hides a specific class of regression. Marshmallow 4 ignores a validator's return value, so a bounds check written as `validate=lambda x: 0 < x < 100` silently accepts every input under 4.x while still failing correctly under 3.x. Measured against exactly that mutation: the dedicated tests fail 4/4 on Marshmallow 4 and pass 10/10 on Marshmallow 3, and the full unit suite is green on Marshmallow 3 with the broken validator in place. A lane pinned to 4.x is the only thing that sees it.

## User impact

None. CI configuration only — no library code, no dependency ranges, no behavior change.

## How to review

Two things are worth your attention.

**Ordering.** This lane cannot pass until Marshmallow 4 support lands. On `develop` today the install step is unsatisfiable:

```
Because great-expectations depends on marshmallow>=3.7.1,<4.0.0 and
marshmallow>=4.0.0,<5.0.0 ... requirements are unsatisfiable
```

It is therefore deliberately **not** added to `ci-required` in this PR. Until support merges it will show red on open pull requests without blocking them. Wiring it into the required set is a one-line follow-up afterwards.

Merging this before the support change is also deliberate: `ci` runs on `pull_request_target`, so a workflow definition takes effect from the base branch. A PR cannot run a lane it adds itself, so the lane has to be on `develop` first for the support PR to be checked by it.

**The lane does not run on this PR,** for the same `pull_request_target` reason. It was rehearsed locally instead — all three steps verbatim against a tree carrying the support change: install resolved, the guard step printed `4.3.1`, and `invoke ci-tests -m unit --xdist --slowest=10 --timeout=2.0` reported 4938 passed, 250 skipped, 0 failed.

The constraints file floats within 4.x rather than pinning a patch release, matching how `pyspark4-install.txt` handles its line.
