### PR TITLE
[BUGFIX] Drop the taxi test table by name instead of scanning the database

### DIFF
--- a/tests/integration/db/taxi_data_utils.py
+++ b/tests/integration/db/taxi_data_utils.py
@@ -9,7 +9,7 @@ import great_expectations as gx
 from tests.test_utils import (
     LoadedTable,
     add_datasource,
-    clean_up_tables_with_prefix,
+    drop_table,
     load_and_concatenate_csvs,
     load_data_into_test_database,
 )
@@ -85,9 +85,9 @@ def loaded_table(dialect: str, connection_string: str) -> LoadedTable:
     finally:
         if not _is_dialect_athena(dialect):
             print("Cleaning up created loaded table")
-            clean_up_tables_with_prefix(
+            drop_table(
                 connection_string=connection_string,
-                table_prefix=loaded_table.table_name,
+                table_name=loaded_table.table_name,
             )
 
 

--- a/tests/test_the_utils_in_test_utils.py
+++ b/tests/test_the_utils_in_test_utils.py
@@ -45,42 +45,19 @@ def test_get_clickhouse_sqlalchemy_potential_type():
         )
 
 
-def _introspect_db_with_mocked_inspector(mocker, **kwargs):
-    """Run introspect_db against a mocked inspector, returning the schemas it visited."""
-    from tests.test_utils import introspect_db
-
-    inspector = mocker.Mock()
-    inspector.get_schema_names.return_value = ["schema_a", "schema_b", "INFORMATION_SCHEMA"]
-    inspector.get_table_names.return_value = ["some_table"]
-    inspector.get_view_names.return_value = []
-    mocker.patch("tests.test_utils.sa.inspect", return_value=inspector)
-
-    introspect_db(execution_engine=mocker.Mock(), **kwargs)
-
-    visited = [call.kwargs["schema"] for call in inspector.get_table_names.call_args_list]
-    return visited, inspector
-
-
 @pytest.mark.unit
-def test_introspect_db_scopes_to_requested_schema(mocker):
-    visited, inspector = _introspect_db_with_mocked_inspector(mocker, schema_name="schema_b")
+def test_drop_table_issues_a_single_drop_statement(mocker):
+    """Teardown knows the table it created, so it should not introspect the database.
 
-    assert visited == ["schema_b"]
-    # Listing every schema on the server is the expensive call this scoping avoids.
-    inspector.get_schema_names.assert_not_called()
+    Discovering the table instead of dropping it by name means listing every schema on
+    the server, which on BigQuery enumerates every dataset in the project.
+    """
+    from tests.test_utils import drop_table
 
+    engine = mocker.patch("tests.test_utils.SqlAlchemyExecutionEngine").return_value
 
-@pytest.mark.unit
-def test_introspect_db_skips_information_schemas(mocker):
-    visited, _ = _introspect_db_with_mocked_inspector(mocker)
+    drop_table(connection_string="postgresql://user@host/db", table_name="taxi_data_abc123")
 
-    assert visited == ["schema_a", "schema_b"]
-
-
-@pytest.mark.unit
-def test_introspect_db_includes_information_schemas_when_not_ignored(mocker):
-    visited, _ = _introspect_db_with_mocked_inspector(
-        mocker, ignore_information_schemas_and_system_tables=False
-    )
-
-    assert visited == ["schema_a", "schema_b", "INFORMATION_SCHEMA"]
+    engine.execute_query_in_transaction.assert_called_once()
+    statement = str(engine.execute_query_in_transaction.call_args.args[0])
+    assert statement == "DROP TABLE IF EXISTS taxi_data_abc123"

--- a/tests/test_the_utils_in_test_utils.py
+++ b/tests/test_the_utils_in_test_utils.py
@@ -43,3 +43,44 @@ def test_get_clickhouse_sqlalchemy_potential_type():
             get_clickhouse_sqlalchemy_potential_type(clickhouse_sqlalchemy.drivers.base, pair[0])
             == pair[1]
         )
+
+
+def _introspect_db_with_mocked_inspector(mocker, **kwargs):
+    """Run introspect_db against a mocked inspector, returning the schemas it visited."""
+    from tests.test_utils import introspect_db
+
+    inspector = mocker.Mock()
+    inspector.get_schema_names.return_value = ["schema_a", "schema_b", "INFORMATION_SCHEMA"]
+    inspector.get_table_names.return_value = ["some_table"]
+    inspector.get_view_names.return_value = []
+    mocker.patch("tests.test_utils.sa.inspect", return_value=inspector)
+
+    introspect_db(execution_engine=mocker.Mock(), **kwargs)
+
+    visited = [call.kwargs["schema"] for call in inspector.get_table_names.call_args_list]
+    return visited, inspector
+
+
+@pytest.mark.unit
+def test_introspect_db_scopes_to_requested_schema(mocker):
+    visited, inspector = _introspect_db_with_mocked_inspector(mocker, schema_name="schema_b")
+
+    assert visited == ["schema_b"]
+    # Listing every schema on the server is the expensive call this scoping avoids.
+    inspector.get_schema_names.assert_not_called()
+
+
+@pytest.mark.unit
+def test_introspect_db_skips_information_schemas(mocker):
+    visited, _ = _introspect_db_with_mocked_inspector(mocker)
+
+    assert visited == ["schema_a", "schema_b"]
+
+
+@pytest.mark.unit
+def test_introspect_db_includes_information_schemas_when_not_ignored(mocker):
+    visited, _ = _introspect_db_with_mocked_inspector(
+        mocker, ignore_information_schemas_and_system_tables=False
+    )
+
+    assert visited == ["schema_a", "schema_b", "INFORMATION_SCHEMA"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -774,17 +774,20 @@ def introspect_db(  # noqa: C901, PLR0912 # FIXME CoP
     engine: sqlalchemy.Engine = execution_engine.engine
     inspector: sqlalchemy.Inspector = sa.inspect(engine)
 
-    selected_schema_name = schema_name
-
     tables: List[Dict[str, str]] = []
-    all_schema_names: List[str] = inspector.get_schema_names()
-    for schema in all_schema_names:
-        if ignore_information_schemas_and_system_tables and schema_name in information_schemas:
-            continue
+    if schema_name is not None:
+        # Listing every schema on the server is expensive - on BigQuery it enumerates
+        # every dataset in the project - so skip that call entirely when the caller
+        # has already named the schema it cares about.
+        schema_names_to_introspect: List[str] = [schema_name]
+    else:
+        schema_names_to_introspect = [
+            schema
+            for schema in inspector.get_schema_names()
+            if not (ignore_information_schemas_and_system_tables and schema in information_schemas)
+        ]
 
-        if selected_schema_name is not None and schema_name != selected_schema_name:
-            continue
-
+    for schema in schema_names_to_introspect:
         try:
             table_names: List[str] = inspector.get_table_names(schema=schema)
         except ProgrammingError:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,13 +1,11 @@
 import logging
 import os
 import uuid
-import warnings
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Dict, List, Literal, Optional, Tuple, Union, cast
+from typing import List, Literal, Optional, Tuple, Union, cast
 
 import pandas as pd
-from sqlalchemy.exc import ProgrammingError
 
 import great_expectations.exceptions as gx_exceptions
 from great_expectations.alias_types import PathStr
@@ -33,7 +31,6 @@ from great_expectations.data_context.types.resource_identifiers import (
 )
 from great_expectations.datasource.fluent.sql_datasource import SQLDatasource
 from great_expectations.execution_engine import SqlAlchemyExecutionEngine
-from great_expectations.execution_engine.sqlalchemy_dialect import GXSqlDialect
 
 logger = logging.getLogger(__name__)
 yaml_handler = YAMLHandler()
@@ -713,146 +710,19 @@ def load_dataframe_into_test_athena_database_as_table(
     )
 
 
-def clean_up_tables_with_prefix(connection_string: str, table_prefix: str) -> List[str]:
-    """Drop all tables starting with the provided table_prefix.
-    Note: Uses private method InferredAssetSqlDataConnector._introspect_db()
-    to get the table names to not duplicate code, but should be refactored in the
-    future to not use a private method.
+def drop_table(connection_string: str, table_name: str) -> None:
+    """Drop the named table, if it exists.
 
     Args:
         connection_string: To connect to the database.
-        table_prefix: First characters of the tables you want to remove.
-
-    Returns:
-        List of deleted tables.
+        table_name: Name of the table to drop. Resolved against the schema the
+            connection string points at.
     """
     execution_engine: SqlAlchemyExecutionEngine = SqlAlchemyExecutionEngine(
         connection_string=connection_string, **_engine_kwargs_for(connection_string)
     )
-    introspection_output = introspect_db(execution_engine=execution_engine)
-
-    tables_to_drop: List[str] = []
-    tables_dropped: List[str] = []
-
-    for table in introspection_output:
-        if table["table_name"].startswith(table_prefix):
-            tables_to_drop.append(table["table_name"])
-
-    for table_name in tables_to_drop:
-        print(f"Dropping table {table_name}")
-        execution_engine.execute_query_in_transaction(sa.text(f"DROP TABLE IF EXISTS {table_name}"))
-        tables_dropped.append(table_name)
-
-    tables_skipped: List[str] = list(set(tables_to_drop) - set(tables_dropped))
-    if len(tables_skipped) > 0:
-        warnings.warn(f"Warning: Tables skipped: {tables_skipped}")
-
-    return tables_dropped
-
-
-def introspect_db(  # noqa: C901, PLR0912 # FIXME CoP
-    execution_engine: SqlAlchemyExecutionEngine,
-    schema_name: Union[str, None] = None,
-    ignore_information_schemas_and_system_tables: bool = True,
-    information_schemas: Optional[List[str]] = None,
-    system_tables: Optional[List[str]] = None,
-    include_views=True,
-) -> List[Dict[str, str]]:
-    # This code was broken out from the InferredAssetSqlDataConnector when it was removed
-    if information_schemas is None:
-        information_schemas = [
-            "INFORMATION_SCHEMA",  # snowflake, SQL Server, mysql, oracle
-            "information_schema",  # postgres, redshift, mysql
-            "performance_schema",  # mysql
-            "sys",  # mysql
-            "mysql",  # mysql
-        ]
-
-    if system_tables is None:
-        system_tables = ["sqlite_master"]  # sqlite
-
-    engine: sqlalchemy.Engine = execution_engine.engine
-    inspector: sqlalchemy.Inspector = sa.inspect(engine)
-
-    tables: List[Dict[str, str]] = []
-    if schema_name is not None:
-        # Listing every schema on the server is expensive - on BigQuery it enumerates
-        # every dataset in the project - so skip that call entirely when the caller
-        # has already named the schema it cares about.
-        schema_names_to_introspect: List[str] = [schema_name]
-    else:
-        schema_names_to_introspect = [
-            schema
-            for schema in inspector.get_schema_names()
-            if not (ignore_information_schemas_and_system_tables and schema in information_schemas)
-        ]
-
-    for schema in schema_names_to_introspect:
-        try:
-            table_names: List[str] = inspector.get_table_names(schema=schema)
-        except ProgrammingError:
-            # Likely another test already cleaned up this schema.
-            # TODO: Make tests only clean up after themselves
-            continue
-        for table_name in table_names:
-            if ignore_information_schemas_and_system_tables and (table_name in system_tables):
-                continue
-
-            tables.append(
-                {
-                    "schema_name": schema,
-                    "table_name": table_name,
-                    "type": "table",
-                }
-            )
-
-        # Note Abe 20201112: This logic is currently untested.
-        if include_views:
-            # Note: this is not implemented for bigquery
-            try:
-                view_names = inspector.get_view_names(schema=schema)
-            except NotImplementedError:
-                # Not implemented by Athena dialect
-                pass
-            else:
-                for view_name in view_names:
-                    if ignore_information_schemas_and_system_tables and (
-                        view_name in system_tables
-                    ):
-                        continue
-
-                    tables.append(
-                        {
-                            "schema_name": schema,
-                            "table_name": view_name,
-                            "type": "view",
-                        }
-                    )
-
-    # SQLAlchemy's introspection does not list "external tables" in Redshift Spectrum (tables whose data is stored on S3).  # noqa: E501 # FIXME CoP
-    # The following code fetches the names of external schemas and tables from a special table
-    # 'svv_external_tables'.
-    try:
-        if engine.dialect.name.lower() == GXSqlDialect.REDSHIFT:
-            # noinspection SqlDialectInspection,SqlNoDataSourceInspection
-            result = execution_engine.execute_query(
-                sa.text("select schemaname, tablename from svv_external_tables")
-            ).fetchall()
-            for row in result:
-                tables.append(
-                    {
-                        "schema_name": row[0],
-                        "table_name": row[1],
-                        "type": "table",
-                    }
-                )
-    except Exception as e:
-        # Our testing shows that 'svv_external_tables' table is present in all Redshift clusters. This means that this  # noqa: E501 # FIXME CoP
-        # exception is highly unlikely to fire.
-        if "UndefinedTable" not in str(e):
-            raise e  # noqa: TRY201 # FIXME CoP
-
-    return tables
+    print(f"Dropping table {table_name}")
+    execution_engine.execute_query_in_transaction(sa.text(f"DROP TABLE IF EXISTS {table_name}"))
 
 
 def check_athena_table_count(


### PR DESCRIPTION
The `docs-snippets (docs-creds-needed)` job intermittently burns its full 30-minute budget and gets cancelled. The two BigQuery taxi partitioning tests are where it stalls — in run 33198426247 the job went silent for 18 minutes after `deployment_patterns_redshift` and was killed before either reported.

The cost is in teardown, not the test. `loaded_table`'s `finally:` block called `clean_up_tables_with_prefix`, which dropped the table it had created by *rediscovering* it: `introspect_db` listed every schema on the server and then issued one `get_table_names` round trip per schema, keeping the rows whose table name started with the prefix. On BigQuery `get_schema_names()` is `list_datasets()` over the whole project, and the 503s that draws get retried until `google.api_core`'s 600s deadline expires:

```
Timeout of 600.0s exceeded, last exception: 503 GET
https://bigquery.googleapis.com/bigquery/v2/projects/***/datasets?prettyPrint=false
```

Two tests × 600s accounts for the observed stall. The same signature appeared earlier on an unrelated branch (run 33169711675), so it is not branch-specific.

None of that discovery was needed. `table_prefix` is `loaded_table.table_name`, which already carries a `uuid4[:8]` suffix from `_load_data`, so the scan enumerated an entire project to find the one table name the caller was already holding.

**Change:** teardown drops that table directly — the same `DROP TABLE IF EXISTS` it issued before, minus the discovery. `introspect_db` and `clean_up_tables_with_prefix` each had exactly one caller and no remaining use, so both are removed; a small `drop_table` helper replaces them.

While reading `introspect_db` to confirm the call graph: both of its skip guards tested the `schema_name` *parameter* rather than the `schema` loop variable, so the information-schema skip evaluated a constant and the selected-schema guard reduced to `x is not None and x != x`. Its `schema_name` argument scoped nothing. That is moot now that the function is gone, but it is why no earlier reader spotted the scan as scoped-and-cheap.

Test-infrastructure only; no shipped code path is touched. A unit test in `tests/test_the_utils_in_test_utils.py` pins that teardown issues one `DROP TABLE IF EXISTS` for the named table and does not introspect.

No RFC needed: bug fix to test infrastructure, no new backend support.

- [ ] Description of PR changes above includes a link to an existing GitHub issue — no public issue filed; observed directly in CI (runs 33198426247 and 33169711675)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] This change is below the RFC threshold
- [x] Code is linted - run `invoke lint`
- [x] Appropriate tests and docs have been updated
- [x] For any behavioral change to a data source, validation mechanic, or Expectation, at least one integration test exists in `tests/integration/data_sources_and_expectations` — n/a, test-infrastructure change; the BigQuery partitioning integration tests exercise the changed teardown
- [x] If this PR proposes adopting or recommending a particular third-party library or service, any affiliation with it is disclosed above — n/a
