### PR TITLE
[BUGFIX] Wrap a query asset's SQL on a fresh line so a trailing comment can't swallow it

### DIFF
--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -90,6 +90,7 @@ from great_expectations.execution_engine.partition_and_sample.data_partitioner i
 from great_expectations.execution_engine.partition_and_sample.sqlalchemy_data_partitioner import (
     SqlAlchemyDataPartitioner,
 )
+from great_expectations.util import ensure_sql_text_ends_on_new_line
 
 if TYPE_CHECKING:
     # We re-import sqlalchemy here to make type-checking and our compatability layer
@@ -1142,7 +1143,9 @@ class QueryAsset(_SQLAsset):
 
         This can be used in a subselect FROM clause for queries against this data.
         """
-        return sa.select(sa.text(self.query.lstrip()[6:])).subquery()
+        return sa.select(
+            sa.text(ensure_sql_text_ends_on_new_line(self.query.lstrip()[6:]))
+        ).subquery()
 
     @override
     def _create_batch_spec_kwargs(self) -> Dict[str, Any]:

--- a/great_expectations/execution_engine/sqlalchemy_batch_data.py
+++ b/great_expectations/execution_engine/sqlalchemy_batch_data.py
@@ -10,7 +10,10 @@ from great_expectations.compatibility.sqlalchemy import (
 )
 from great_expectations.core.batch import BatchData
 from great_expectations.execution_engine.sqlalchemy_dialect import GXSqlDialect
-from great_expectations.util import generate_temporary_table_name
+from great_expectations.util import (
+    ensure_sql_text_ends_on_new_line,
+    generate_temporary_table_name,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -379,7 +382,7 @@ class SqlAlchemyBatchData(BatchData):
             sqlalchemy.Table: SqlAlchemy Table that is Selectable or a TextClause.
         """  # noqa: E501 # FIXME CoP
         if not create_temp_table:
-            return sa.text(query)
+            return sa.text(ensure_sql_text_ends_on_new_line(query))
         _, temp_table_name = self._create_temporary_table(
             dialect=dialect,
             query=query,

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -98,6 +98,7 @@ from great_expectations.expectations.row_conditions import (
     deserialize_row_condition,
 )
 from great_expectations.util import (
+    ensure_sql_text_ends_on_new_line,
     filter_properties_dict,
     get_sqlalchemy_selectable,
     get_sqlalchemy_url,
@@ -1328,7 +1329,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
             and "partitioner_method" not in batch_spec
             and partition_clause is sa.true()
         ):
-            return sa.text(batch_spec["query"])
+            return sa.text(ensure_sql_text_ends_on_new_line(batch_spec["query"]))
 
         selectable: sqlalchemy.Selectable = self._subselectable(batch_spec)
         sampling_method: Optional[str] = batch_spec.get("sampling_method")
@@ -1371,7 +1372,11 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
                 raise ValueError(f"SQL query should be a str but got {query}")  # noqa: TRY003 # FIXME CoP
             # Query is a valid SELECT query that begins with r"\w+select\w"
             selectable = sa.select(
-                sa.text(query.lstrip()[6:].strip().rstrip(";").rstrip())
+                sa.text(
+                    ensure_sql_text_ends_on_new_line(
+                        query.lstrip()[6:].strip().rstrip(";").rstrip()
+                    )
+                )
             ).subquery()
 
         return selectable

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -921,6 +921,22 @@ def get_sqlalchemy_selectable(
     return selectable
 
 
+def ensure_sql_text_ends_on_new_line(query: str) -> str:
+    """Return ``query`` guaranteed to end on a fresh line.
+
+    Great Expectations embeds a user's raw SQL text in wrapping syntax, ``(<query>) AS anon_1``,
+    that SQLAlchemy compiles onto a single line, reproducing the text as an opaque blob. When the
+    text ends in a line comment (``-- ...``, or ``#...`` on MySQL), the appended closing paren and
+    alias land inside that comment, the statement is never terminated, and the database rejects it.
+
+    SQLAlchemy cannot know that a dialect-specific comment is still open at the end of a text
+    fragment, so the newline has to come from our side. Ending the text on a fresh line puts
+    whatever is appended past the comment on every dialect, and needs no SQL parsing. Text that
+    already ends in a newline is returned unchanged.
+    """
+    return query if query.endswith("\n") else query + "\n"
+
+
 def get_sqlalchemy_subquery_type():
     """
     Beginning from SQLAlchemy 1.4, `sqlalchemy.sql.Alias` has been deprecated in favor of `sqlalchemy.sql.Subquery`.

--- a/tests/datasource/fluent/data_asset/test_sql_asset.py
+++ b/tests/datasource/fluent/data_asset/test_sql_asset.py
@@ -12,6 +12,7 @@ from great_expectations.core.partitioners import (
 )
 from great_expectations.datasource.fluent import SQLDatasource
 from great_expectations.datasource.fluent.sql_datasource import (
+    QueryAsset,
     SqlAddBatchDefinitionError,
     TableAsset,
     _SQLAsset,
@@ -350,3 +351,19 @@ def test_validate_batch_definition(
 # Tests I considered adding for test_validate_batch_definition but have not.
 # 1. Engine dies on connect
 # 2. Connection dies on execute
+
+
+@pytest.mark.unit
+def test_query_asset_as_selectable_wraps_a_trailing_line_comment_on_a_fresh_line():
+    """`as_selectable` renders the asset as a subselect for use in a FROM clause. Appending the
+    wrapping syntax to text that ends in a line comment would comment the wrapping out.
+
+    See https://github.com/fivetran/great_expectations/issues/12122.
+    """
+    asset = QueryAsset(name="query_asset", query="SELECT col_a FROM t -- only what we need")
+
+    rendered = str(sqlalchemy.sql.select(sqlalchemy.text("*")).select_from(asset.as_selectable()))
+
+    assert not any(
+        "--" in line and line.index("--") < line.rfind(")") for line in rendered.splitlines()
+    )

--- a/tests/execution_engine/test_sqlalchemy_query_comments.py
+++ b/tests/execution_engine/test_sqlalchemy_query_comments.py
@@ -1,0 +1,63 @@
+"""SQL ending in a line comment must not swallow the syntax GX appends when wrapping it.
+
+A query asset's raw SQL is reproduced verbatim inside ``(<query>) AS anon_1``, which SQLAlchemy
+compiles onto a single line. When the text ends in a line comment, the appended closing paren and
+alias land inside that comment and the statement is never terminated, so the database rejects it.
+
+See https://github.com/fivetran/great_expectations/issues/12122.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.dialects import (  # noqa: F401 # registers sa.dialects.<name>
+    mssql,
+    mysql,
+    oracle,
+    postgresql,
+)
+
+from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
+from great_expectations.core.batch_spec import RuntimeQueryBatchSpec
+from great_expectations.execution_engine.sqlalchemy_execution_engine import (
+    SqlAlchemyExecutionEngine,
+)
+from tests.sqlalchemy_test_doubles import MockSaEngine
+
+QUERY_ENDING_IN_LINE_COMMENT = "SELECT col_a FROM test_table -- only the rows we care about"
+
+
+def _appended_sql_is_commented_out(compiled: str) -> bool:
+    """Whether a line comment in `compiled` runs over SQL that follows it on the same line."""
+    return any(
+        "--" in line and line.index("--") < line.rfind(")") for line in compiled.splitlines()
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("dialect_name", ["postgresql", "mysql", "mssql", "oracle"])
+def test_text_clause_batch_is_wrapped_on_a_fresh_line(dialect_name: str) -> None:
+    """Every dialect but SQLite gets the query back as a TextClause, which `get_domain_records`
+    wraps with `.columns().subquery()` before running metrics against it."""
+    dialect = getattr(sa.dialects, dialect_name).dialect()
+    engine = SqlAlchemyExecutionEngine(engine=MockSaEngine(dialect=dialect))
+
+    selectable = engine._build_selectable_from_batch_spec(
+        batch_spec=RuntimeQueryBatchSpec(query=QUERY_ENDING_IN_LINE_COMMENT)
+    )
+    wrapped = sa.select(sa.func.count()).select_from(selectable.columns().subquery())
+
+    assert not _appended_sql_is_commented_out(str(wrapped.compile(dialect=dialect)))
+
+
+@pytest.mark.sqlite
+def test_sqlite_subselect_batch_is_wrapped_on_a_fresh_line() -> None:
+    """SQLite takes the other branch, where `_subselectable` wraps the query into a subselect
+    immediately rather than handing it back as a TextClause."""
+    engine = SqlAlchemyExecutionEngine(connection_string="sqlite://")
+
+    selectable = engine._build_selectable_from_batch_spec(
+        batch_spec=RuntimeQueryBatchSpec(query=QUERY_ENDING_IN_LINE_COMMENT)
+    )
+
+    assert not _appended_sql_is_commented_out(str(selectable))

--- a/tests/integration/data_sources_and_expectations/data_sources/test_query_asset_sql_comments.py
+++ b/tests/integration/data_sources_and_expectations/data_sources/test_query_asset_sql_comments.py
@@ -1,0 +1,83 @@
+"""Query assets whose SQL carries a comment.
+
+Great Expectations wraps a query asset's SQL in a subquery, ``(<query>) AS anon_1``, before
+running metrics against it, appending the wrapping syntax to the user's raw text. SQL that ends
+in a line comment therefore used to put the appended closing paren and alias *inside* that
+comment, leaving the statement unterminated and rejected by the database on every SQL backend.
+
+See https://github.com/fivetran/great_expectations/issues/12122.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+import great_expectations.expectations as gxe
+from great_expectations.datasource.fluent.sql_datasource import SQLDatasource, TableAsset
+from tests.integration.conftest import parameterize_batch_for_data_sources
+from tests.integration.test_utils.data_source_config import SQL_DATA_SOURCES
+
+if TYPE_CHECKING:
+    from great_expectations.core.expectation_validation_result import (
+        ExpectationValidationResult,
+    )
+    from great_expectations.datasource.fluent.interfaces import Batch
+
+COL_A = "col_a"
+
+DATA = pd.DataFrame({COL_A: ["x", "y"]})
+
+
+def _validate_query_asset(batch: Batch, name: str, query: str) -> ExpectationValidationResult:
+    """Validate `query` as a query asset on the same datasource as `batch`."""
+    datasource = batch.datasource
+    assert isinstance(datasource, SQLDatasource)
+
+    query_asset = datasource.add_query_asset(name=name, query=query)
+    query_batch = query_asset.add_batch_definition_whole_table(f"{name}_bd").get_batch()
+    return query_batch.validate(gxe.ExpectColumnValuesToNotBeNull(column=COL_A))
+
+
+def _table_name(batch: Batch) -> str:
+    asset = batch.data_asset
+    assert isinstance(asset, TableAsset)
+    return asset.table_name
+
+
+@parameterize_batch_for_data_sources(data_source_configs=SQL_DATA_SOURCES, data=DATA)
+def test_query_asset_sql_ending_in_line_comment(batch_for_datasource: Batch) -> None:
+    """A trailing line comment does not change what a query selects, so it must not change the
+    result of validating a batch from that query."""
+    table = _table_name(batch_for_datasource)
+
+    without_comment = _validate_query_asset(
+        batch_for_datasource,
+        name="no_trailing_comment_asset",
+        query=f"SELECT {COL_A} FROM {table}",
+    )
+    with_comment = _validate_query_asset(
+        batch_for_datasource,
+        name="trailing_comment_asset",
+        query=f"SELECT {COL_A} FROM {table} -- only the rows we care about",
+    )
+
+    assert with_comment.success, with_comment.exception_info
+    assert with_comment.success == without_comment.success
+    assert with_comment.result == without_comment.result
+
+
+@parameterize_batch_for_data_sources(data_source_configs=SQL_DATA_SOURCES, data=DATA)
+def test_query_asset_sql_with_comment_before_the_end(batch_for_datasource: Batch) -> None:
+    """A comment that is followed by more SQL was never affected by the subquery wrapping, and
+    stays unaffected."""
+    table = _table_name(batch_for_datasource)
+
+    result = _validate_query_asset(
+        batch_for_datasource,
+        name="interior_comment_asset",
+        query=f"SELECT {COL_A} -- the only column we need\nFROM {table}",
+    )
+
+    assert result.success, result.exception_info

--- a/tests/test_ge_utils.py
+++ b/tests/test_ge_utils.py
@@ -12,6 +12,7 @@ from great_expectations.util import (
     convert_ndarray_float_to_datetime_tuple,
     convert_ndarray_to_datetime_dtype_best_effort,
     deep_filter_properties_iterable,
+    ensure_sql_text_ends_on_new_line,
     filter_properties_dict,
     hyphen,
     is_ndarray_datetime_dtype,
@@ -563,3 +564,32 @@ def test_convert_ndarray_float_to_datetime_tuple(
 def test_hyphen():
     txt: str = "validation_result"
     assert hyphen(txt=txt) == "validation-result"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "query",
+    [
+        pytest.param("SELECT a FROM t -- trailing comment", id="trailing_line_comment"),
+        pytest.param("SELECT a FROM t", id="no_comment"),
+        pytest.param("SELECT a FROM t  ", id="trailing_whitespace"),
+        pytest.param("", id="empty"),
+    ],
+)
+def test_ensure_sql_text_ends_on_new_line_appends_a_newline(query: str):
+    terminated = ensure_sql_text_ends_on_new_line(query)
+    assert terminated == query + "\n"
+    assert terminated.startswith(query)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "query",
+    [
+        pytest.param("SELECT a FROM t -- trailing comment\n", id="line_comment"),
+        pytest.param("SELECT a FROM t\n", id="no_comment"),
+        pytest.param("SELECT a FROM t\r\n", id="windows_line_ending"),
+    ],
+)
+def test_ensure_sql_text_ends_on_new_line_leaves_terminated_text_alone(query: str):
+    assert ensure_sql_text_ends_on_new_line(query) == query


### PR DESCRIPTION
Closes #12122

No RFC needed: a bug fix to existing subquery wrapping, not new data source or execution engine support.

### The bug

A query asset whose SQL ends in a line comment failed at validation time with a syntax error from the database, on every SQL backend. GX reproduces the user's raw text verbatim inside `(<text>) AS anon_1`, and SQLAlchemy compiles that onto a single line, so the closing paren and alias ended up *inside* the comment and the statement was never terminated:

```
sqlite:  (sqlite3.OperationalError) incomplete input
[SQL: SELECT count(*) AS "table.row_count"
FROM (SELECT *
FROM (SELECT col_a FROM t -- only the rows we care about) AS anon_1
WHERE 1 = 1) AS anon_1]
```

### The fix

`ensure_sql_text_ends_on_new_line` makes sure the query text ends on a fresh line before GX embeds it. SQLAlchemy treats a text fragment as an opaque blob, so it has no way to know a dialect-specific comment is still open at the end of one. That means the newline has to come from our side. No SQL parsing is involved, and it works the same on every dialect, since they all end a line comment at the newline.

I applied it at the four places GX turns a user's raw SQL into text it will embed, rather than at the three wrap sites, so the guarantee holds for everything downstream of that text:

| Site | Path |
| --- | --- |
| `SqlAlchemyExecutionEngine._build_selectable_from_batch_spec` | the `TextClause` every dialect but SQLite gets back, later wrapped by `get_domain_records`, `resolve_metric_bundle` and `_count_query_parameters` |
| `SqlAlchemyExecutionEngine._subselectable` | the branch SQLite takes, which wraps into a subselect right away |
| `QueryAsset.as_selectable` | the subselect used in a FROM clause for queries against the asset |
| `SqlAlchemyBatchData._generate_selectable_from_query` | the runtime-query path when no temp table is created |

`add_query_asset`'s signature and accepted inputs are untouched, and the asset's stored `query` is unchanged. Only what gets handed to `sa.text` differs, so serialized configuration round-trips exactly as it did before.

### Verification

I reproduced the failure first, on `1.21.0` (`80898f4`), then fixed it. SQLite and PostgreSQL are both exercised end to end locally, which between them cover the two branches the engine takes: SQLite wraps into a subselect immediately, and PostgreSQL is handed the query back as a `TextClause`.

* **End to end, SQLite and PostgreSQL.** A query asset ending in `-- ...` fails before the change and passes after it, on both. A query with a comment before the end, one with a terminated `/* ... */` at the end, and one with no comment all passed before and after. The wrapping only ever collided with a comment that ran to the end of the text.
* **Every new test fails without the source change and passes with it** (6 unit tests, plus the trailing-comment integration test on both backends). I checked by stashing the `great_expectations/` diff and re-running. The interior-comment integration test passes either way, which is the point of including it.
* **Cross-dialect compilation.** I checked the compiled wrap against the PostgreSQL, MySQL, SQL Server, Oracle and SQLite dialect compilers. In all five, the appended alias sits on the comment line before the change and on its own line after it.
* **No regressions.** `tests/execution_engine`, `tests/datasource/fluent` and `tests/expectations/metrics/query_metrics` under `-m "unit or sqlite"`: 1705 passed, 0 failed. The `-m sqlite` integration lane: 201 passed. Everything marked `postgresql` across `tests/integration/data_sources_and_expectations`, `tests/execution_engine`, `tests/datasource`, `tests/expectations`, `tests/validator` and `tests/core`: 406 passed, 10 skipped, 0 failed. `invoke lint` (`ruff format` plus `ruff check`) is clean.

What I could not run: MySQL, SQL Server, BigQuery, Databricks, Redshift and Snowflake. The first two need a container I have no Docker for, and the rest need live warehouse credentials. The wrapping code is dialect-agnostic and shared by every `SqlDatasource`, the two branches through it are both covered above, and the new integration tests run against every backend in `SQL_DATA_SOURCES`, so CI picks up the remainder. `invoke type-check --ci` also didn't run to completion for me, because the type-checking environment pulls in Spark, Azure and cloud extras that wouldn't install, so mypy is left to CI as well.

One case this deliberately doesn't fix: an **unterminated** `/* ...` block comment still fails, before and after. That text isn't valid SQL on its own, and a trailing newline can't make it so.

### Tests

* `tests/integration/data_sources_and_expectations/data_sources/test_query_asset_sql_comments.py`, new, parameterized over `SQL_DATA_SOURCES`. One test asserts a trailing line comment produces the same validation result as the identical query without it. The other asserts a comment followed by more SQL is unaffected.
* `tests/execution_engine/test_sqlalchemy_query_comments.py`, new. Covers both engine branches: the `TextClause` path against the PostgreSQL, MySQL, SQL Server and Oracle dialects, and the SQLite `_subselectable` path.
* `tests/datasource/fluent/data_asset/test_sql_asset.py` covers `QueryAsset.as_selectable`.
* `tests/test_ge_utils.py` covers the helper, including that it leaves text alone when it already ends in a newline.

### Checklist

- [x] Description of PR changes above includes a link to an existing GitHub issue
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] This change is below the RFC threshold
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated
- [x] For any behavioral change to a data source, validation mechanic, or Expectation, at least one integration test exists in `tests/integration/data_sources_and_expectations`
- [x] If this PR proposes adopting or recommending a particular third-party library or service, any affiliation with it is disclosed above. Not applicable here, no new dependencies.
