### PR TITLE
[MAINTENANCE] Pin the fluent datasource management API with a per-type CRUD contract suite

### DIFF
--- a/great_expectations/datasource/fluent/sources.pyi
+++ b/great_expectations/datasource/fluent/sources.pyi
@@ -24,9 +24,13 @@ from great_expectations.data_context import (
 )
 from great_expectations.datasource.datasource_dict import DatasourceDict
 from great_expectations.datasource.fluent import (
+    AlloyDatasource,
+    AuroraDatasource,
     BigQueryDatasource,
+    CitusDatasource,
     DatabricksSQLDatasource,
     FabricPowerBIDatasource,
+    NeonDatasource,
     PandasAzureBlobStorageDatasource,
     PandasDatasource,
     PandasDBFSDatasource,
@@ -364,6 +368,130 @@ class DataSourceManager:
         create_temp_table: bool = True,
     ) -> PostgresDatasource: ...
     def delete_postgres(
+        self,
+        name: str,
+    ) -> None: ...
+    def add_alloy(
+        self,
+        name_or_datasource: Optional[Union[str, Datasource]] = None,
+        name: Optional[str] = None,
+        datasource: Optional[Datasource] = None,
+        *,
+        connection_string: Union[ConfigStr, pydantic.networks.PostgresDsn, str] = ...,
+        create_temp_table: bool = True,
+    ) -> AlloyDatasource: ...
+    def update_alloy(
+        self,
+        name_or_datasource: Optional[Union[str, Datasource]] = None,
+        name: Optional[str] = None,
+        datasource: Optional[Datasource] = None,
+        *,
+        connection_string: Union[ConfigStr, pydantic.networks.PostgresDsn, str] = ...,
+        create_temp_table: bool = True,
+    ) -> AlloyDatasource: ...
+    def add_or_update_alloy(
+        self,
+        name_or_datasource: Optional[Union[str, Datasource]] = None,
+        name: Optional[str] = None,
+        datasource: Optional[Datasource] = None,
+        *,
+        connection_string: Union[ConfigStr, pydantic.networks.PostgresDsn, str] = ...,
+        create_temp_table: bool = True,
+    ) -> AlloyDatasource: ...
+    def delete_alloy(
+        self,
+        name: str,
+    ) -> None: ...
+    def add_aurora(
+        self,
+        name_or_datasource: Optional[Union[str, Datasource]] = None,
+        name: Optional[str] = None,
+        datasource: Optional[Datasource] = None,
+        *,
+        connection_string: Union[ConfigStr, pydantic.networks.PostgresDsn, str] = ...,
+        create_temp_table: bool = True,
+    ) -> AuroraDatasource: ...
+    def update_aurora(
+        self,
+        name_or_datasource: Optional[Union[str, Datasource]] = None,
+        name: Optional[str] = None,
+        datasource: Optional[Datasource] = None,
+        *,
+        connection_string: Union[ConfigStr, pydantic.networks.PostgresDsn, str] = ...,
+        create_temp_table: bool = True,
+    ) -> AuroraDatasource: ...
+    def add_or_update_aurora(
+        self,
+        name_or_datasource: Optional[Union[str, Datasource]] = None,
+        name: Optional[str] = None,
+        datasource: Optional[Datasource] = None,
+        *,
+        connection_string: Union[ConfigStr, pydantic.networks.PostgresDsn, str] = ...,
+        create_temp_table: bool = True,
+    ) -> AuroraDatasource: ...
+    def delete_aurora(
+        self,
+        name: str,
+    ) -> None: ...
+    def add_citus(
+        self,
+        name_or_datasource: Optional[Union[str, Datasource]] = None,
+        name: Optional[str] = None,
+        datasource: Optional[Datasource] = None,
+        *,
+        connection_string: Union[ConfigStr, pydantic.networks.PostgresDsn, str] = ...,
+        create_temp_table: bool = True,
+    ) -> CitusDatasource: ...
+    def update_citus(
+        self,
+        name_or_datasource: Optional[Union[str, Datasource]] = None,
+        name: Optional[str] = None,
+        datasource: Optional[Datasource] = None,
+        *,
+        connection_string: Union[ConfigStr, pydantic.networks.PostgresDsn, str] = ...,
+        create_temp_table: bool = True,
+    ) -> CitusDatasource: ...
+    def add_or_update_citus(
+        self,
+        name_or_datasource: Optional[Union[str, Datasource]] = None,
+        name: Optional[str] = None,
+        datasource: Optional[Datasource] = None,
+        *,
+        connection_string: Union[ConfigStr, pydantic.networks.PostgresDsn, str] = ...,
+        create_temp_table: bool = True,
+    ) -> CitusDatasource: ...
+    def delete_citus(
+        self,
+        name: str,
+    ) -> None: ...
+    def add_neon(
+        self,
+        name_or_datasource: Optional[Union[str, Datasource]] = None,
+        name: Optional[str] = None,
+        datasource: Optional[Datasource] = None,
+        *,
+        connection_string: Union[ConfigStr, pydantic.networks.PostgresDsn, str] = ...,
+        create_temp_table: bool = True,
+    ) -> NeonDatasource: ...
+    def update_neon(
+        self,
+        name_or_datasource: Optional[Union[str, Datasource]] = None,
+        name: Optional[str] = None,
+        datasource: Optional[Datasource] = None,
+        *,
+        connection_string: Union[ConfigStr, pydantic.networks.PostgresDsn, str] = ...,
+        create_temp_table: bool = True,
+    ) -> NeonDatasource: ...
+    def add_or_update_neon(
+        self,
+        name_or_datasource: Optional[Union[str, Datasource]] = None,
+        name: Optional[str] = None,
+        datasource: Optional[Datasource] = None,
+        *,
+        connection_string: Union[ConfigStr, pydantic.networks.PostgresDsn, str] = ...,
+        create_temp_table: bool = True,
+    ) -> NeonDatasource: ...
+    def delete_neon(
         self,
         name: str,
     ) -> None: ...
@@ -1062,6 +1190,26 @@ class DataSourceManager:
         workspace: Optional[Union[uuid.UUID, str]] = None,
         dataset: Union[uuid.UUID, str] = ...,
     ) -> FabricPowerBIDatasource: ...
+    def update_fabric_powerbi(
+        self,
+        name: Optional[str] = None,
+        datasource: Optional[FabricPowerBIDatasource] = None,
+        *,
+        workspace: Optional[Union[uuid.UUID, str]] = None,
+        dataset: Union[uuid.UUID, str] = ...,
+    ) -> FabricPowerBIDatasource: ...
+    def add_or_update_fabric_powerbi(
+        self,
+        name: Optional[str] = None,
+        datasource: Optional[FabricPowerBIDatasource] = None,
+        *,
+        workspace: Optional[Union[uuid.UUID, str]] = None,
+        dataset: Union[uuid.UUID, str] = ...,
+    ) -> FabricPowerBIDatasource: ...
+    def delete_fabric_powerbi(
+        self,
+        name: str,
+    ) -> None: ...
     def all(self) -> DatasourceDict: ...
     def delete(self, name: str) -> None: ...
     def get(self, name: str) -> Datasource: ...

--- a/tests/datasource/fluent/crud_contract.py
+++ b/tests/datasource/fluent/crud_contract.py
@@ -29,8 +29,8 @@ behaviors through its create, update and create-or-update factories:
 - ``create_or_update_persists_one_entry`` — after create then create-or-update against a
   file-backed context, the persisted project holds exactly one entry for that name.
 
-Two of the eight — ``update_replaces_configuration`` and
-``create_or_update_replaces_when_present`` — depend on an update overlay: arguments that
+Three of the eight — ``update_replaces_configuration``, ``create_or_update_replaces_when_present``
+and ``create_or_update_persists_one_entry`` — depend on an update overlay: arguments that
 produce a materially different datasource of the same type. A type whose model has no field
 an update could change cannot run them, and must say so through an exclusion rather than
 running a weaker assertion.
@@ -115,6 +115,7 @@ OVERLAY_DEPENDENT_CASE_KEYS: FrozenSet[str] = frozenset(
     {
         UPDATE_REPLACES_CONFIGURATION,
         CREATE_OR_UPDATE_REPLACES_WHEN_PRESENT,
+        CREATE_OR_UPDATE_PERSISTS_ONE_ENTRY,
     }
 )
 """The subset of case keys that require an update overlay to run.
@@ -408,6 +409,7 @@ CONTRACT_PARAMETERS: Mapping[str, FluentTypeContractParameters] = {
         case_exclusions={
             UPDATE_REPLACES_CONFIGURATION: _PANDAS_EXCLUSION_REASON,
             CREATE_OR_UPDATE_REPLACES_WHEN_PRESENT: _PANDAS_EXCLUSION_REASON,
+            CREATE_OR_UPDATE_PERSISTS_ONE_ENTRY: _PANDAS_EXCLUSION_REASON,
         },
     ),
 }

--- a/tests/datasource/fluent/crud_contract.py
+++ b/tests/datasource/fluent/crud_contract.py
@@ -78,7 +78,7 @@ from __future__ import annotations
 import pathlib
 import types
 from dataclasses import dataclass, field
-from typing import Callable, FrozenSet, Mapping, Optional
+from typing import Callable, Final, FrozenSet, Mapping, Optional
 
 # ---------------------------------------------------------------------------
 # Contract vocabulary
@@ -483,7 +483,7 @@ def case_exclusions_by_type() -> Mapping[str, Mapping[str, str]]:
 # generator needs a plain import surface rather than a pytest module.
 # ---------------------------------------------------------------------------
 
-FLUENT_TYPES_NAMED_BY_NO_RECORD: FrozenSet[str] = frozenset(
+FLUENT_TYPES_NAMED_BY_NO_RECORD: Final[FrozenSet[str]] = frozenset(
     {
         "spark",  # the Spark DataFrame data source; the only Spark record names the filesystem type
         "pandas_dbfs",  # Databricks File System paths; the public reference names Databricks SQL, not DBFS  # noqa: E501
@@ -492,7 +492,12 @@ FLUENT_TYPES_NAMED_BY_NO_RECORD: FrozenSet[str] = frozenset(
     }
 )
 
-RECORDS_COVERED_BUT_UNABLE_TO_CLAIM: FrozenSet[str] = frozenset(
+# Every fluent type each of these records is reached through is covered by the table above,
+# so the contract itself is not what holds them back: each declares neither a test marker nor
+# a continuous-integration lane, and a record with no lane has nothing running that could earn
+# the claim. The remedy is the same for all six — declare a marker and a lane, and the record
+# can claim the tier and leave this set.
+RECORDS_COVERED_BUT_UNABLE_TO_CLAIM: Final[FrozenSet[str]] = frozenset(
     {
         "azure-blob-storage",
         "alloydb",

--- a/tests/datasource/fluent/crud_contract.py
+++ b/tests/datasource/fluent/crud_contract.py
@@ -1,0 +1,502 @@
+"""The standard CRUD contract applied to every registered fluent datasource type.
+
+This module declares, and only declares: the named cases that make up the contract, the
+per-type table of arguments that exercise those cases, and the accessors a test module reads
+instead of touching the table's internals directly.
+
+**The contract.** Every registered fluent datasource type is expected to support eight
+behaviors through its create, update and create-or-update factories:
+
+- ``create`` — the returned object is an instance of the class the registry holds for the
+  type, carries the requested name, and is the object the context returns for that name
+  afterwards.
+- ``create_rejects_duplicate_name`` — a second create with the same name raises the data
+  context's duplicate-name error naming the datasource, and the stored datasource is left
+  byte-identical to the one stored before the attempt.
+- ``update_replaces_configuration`` — after update with a materially different set of
+  arguments, the stored datasource's configuration reflects those arguments, and the
+  identifier seeded at creation is preserved.
+- ``update_rejects_absent_name`` — update against a name that was never created raises a
+  value error naming that name, and no datasource is created as a side effect.
+- ``create_or_update_creates_when_absent`` — against a fresh name it creates, and the result
+  is retrievable by that name.
+- ``create_or_update_replaces_when_present`` — against an existing name it replaces rather
+  than raising, the stored configuration reflects the new arguments, and the seeded
+  identifier is preserved.
+- ``configuration_round_trips`` — against a file-backed context, discarding the context and
+  re-reading the project from disk yields a datasource whose full configuration equals the
+  one created.
+- ``create_or_update_persists_one_entry`` — after create then create-or-update against a
+  file-backed context, the persisted project holds exactly one entry for that name.
+
+Two of the eight — ``update_replaces_configuration`` and
+``create_or_update_replaces_when_present`` — depend on an update overlay: arguments that
+produce a materially different datasource of the same type. A type whose model has no field
+an update could change cannot run them, and must say so through an exclusion rather than
+running a weaker assertion.
+
+Every case in the contract runs with connection testing neutralized at the concrete
+registered class, for every type, including types that override connection testing
+themselves. A passing case is therefore evidence about the CRUD contract, not about whether
+any service is reachable — that neutralization is what makes the same contract meaningful for
+a type that needs a running Spark cluster and one that needs nothing but a name.
+
+**The parameter table.** One entry per registered fluent type, giving the keyword arguments
+that create a datasource of that type from a scratch directory, an optional overlay of
+arguments producing a materially different datasource of the same type, and any declared
+exclusions. Creation arguments are produced by a callable rather than stored as a literal
+because several types need a directory that exists first; the scratch directory is created by
+the caller, not by this table, so the table stays a pure declaration.
+
+Every value in the table is synthetic: no credential, no real hostname, no account identifier
+and no bucket that exists appears anywhere in it.
+
+**The rule for choosing an update overlay:** it must change a field that survives
+serialization to a plain scalar or a path, because the persistence cases in the suite read
+the overlay's effect back off disk. A field that pydantic excludes from serialization, or
+that only affects runtime behavior, cannot serve as an overlay.
+
+**The rule for declaring an exclusion:** declare one only where a case genuinely cannot be
+driven — where the type's model has no field an update could change, for instance — and state
+the property of the type that makes it so, not the difficulty of writing the case. An
+exclusion always carries a case key drawn from ``CONTRACT_CASE_KEYS`` and a non-empty reason;
+a type must never be excluded from every case, because a type excluded from the whole
+contract is not covered and must not read as covered.
+
+**Where a type accepts more than one shape of creation arguments** — Snowflake, SQL Server
+and Fabric each do — this table declares exactly one shape. The remaining shapes are that
+type's own module's subject; this table does not become a second home for per-type
+validation coverage.
+
+This module imports nothing beyond the standard library, and nothing from the package under
+test or from any test harness. That is what keeps it importable in the fastest lane a
+maintainer's change will run through.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import types
+from dataclasses import dataclass, field
+from typing import Callable, FrozenSet, Mapping, Optional
+
+# ---------------------------------------------------------------------------
+# Contract vocabulary
+# ---------------------------------------------------------------------------
+
+CREATE = "create"
+CREATE_REJECTS_DUPLICATE_NAME = "create_rejects_duplicate_name"
+UPDATE_REPLACES_CONFIGURATION = "update_replaces_configuration"
+UPDATE_REJECTS_ABSENT_NAME = "update_rejects_absent_name"
+CREATE_OR_UPDATE_CREATES_WHEN_ABSENT = "create_or_update_creates_when_absent"
+CREATE_OR_UPDATE_REPLACES_WHEN_PRESENT = "create_or_update_replaces_when_present"
+CONFIGURATION_ROUND_TRIPS = "configuration_round_trips"
+CREATE_OR_UPDATE_PERSISTS_ONE_ENTRY = "create_or_update_persists_one_entry"
+
+CONTRACT_CASE_KEYS: FrozenSet[str] = frozenset(
+    {
+        CREATE,
+        CREATE_REJECTS_DUPLICATE_NAME,
+        UPDATE_REPLACES_CONFIGURATION,
+        UPDATE_REJECTS_ABSENT_NAME,
+        CREATE_OR_UPDATE_CREATES_WHEN_ABSENT,
+        CREATE_OR_UPDATE_REPLACES_WHEN_PRESENT,
+        CONFIGURATION_ROUND_TRIPS,
+        CREATE_OR_UPDATE_PERSISTS_ONE_ENTRY,
+    }
+)
+"""Every case key the contract publishes.
+
+An exclusion in the parameter table is checked against this set, and a downstream reader
+uses it to name a case rather than inventing a string.
+"""
+
+OVERLAY_DEPENDENT_CASE_KEYS: FrozenSet[str] = frozenset(
+    {
+        UPDATE_REPLACES_CONFIGURATION,
+        CREATE_OR_UPDATE_REPLACES_WHEN_PRESENT,
+    }
+)
+"""The subset of case keys that require an update overlay to run.
+
+A type whose table entry declares no overlay obliges an exclusion for every key in this set.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Per-type parameter table
+# ---------------------------------------------------------------------------
+
+CreationArguments = Callable[[pathlib.Path], Mapping[str, object]]
+"""A callable that, given a scratch directory that already exists, returns the keyword
+arguments (excluding the datasource name) that create a datasource of one fluent type."""
+
+
+@dataclass(frozen=True)
+class FluentTypeContractParameters:
+    """The declared shape of CRUD coverage for one registered fluent datasource type."""
+
+    creation_arguments: CreationArguments
+    """Keyword arguments that create a datasource of this type, given a scratch directory."""
+
+    update_overlay: Optional[CreationArguments] = None
+    """Arguments merged over ``creation_arguments`` to produce a materially different
+    datasource of the same type.
+
+    ``None`` declares that the type has no field an update could change, which obliges an
+    exclusion for every key in ``OVERLAY_DEPENDENT_CASE_KEYS``.
+    """
+
+    case_exclusions: Mapping[str, str] = field(default_factory=dict)
+    """Case key to reason. A case declared here is reported as skipped with that reason."""
+
+    def __post_init__(self) -> None:
+        # Coerce to an immutable mapping regardless of what was passed in, so every entry's
+        # case_exclusions is uniformly a live-reference-proof view rather than trusting each
+        # call site in CONTRACT_PARAMETERS to have wrapped its own dict.
+        object.__setattr__(
+            self, "case_exclusions", types.MappingProxyType(dict(self.case_exclusions))
+        )
+
+
+def _no_arguments(_scratch_directory: pathlib.Path) -> Mapping[str, object]:
+    return {}
+
+
+def _connection_string(url: str) -> CreationArguments:
+    def _build(_scratch_directory: pathlib.Path) -> Mapping[str, object]:
+        return {"connection_string": url}
+
+    return _build
+
+
+def _connection_string_overlay(url: str, *, create_temp_table: bool) -> CreationArguments:
+    def _build(_scratch_directory: pathlib.Path) -> Mapping[str, object]:
+        return {"connection_string": url, "create_temp_table": create_temp_table}
+
+    return _build
+
+
+def _sqlite_connection_string(*, overlay: bool) -> CreationArguments:
+    def _build(scratch_directory: pathlib.Path) -> Mapping[str, object]:
+        db_file = scratch_directory / ("overlay.db" if overlay else "contract.db")
+        return {
+            "connection_string": f"sqlite:///{db_file}",
+            "create_temp_table": overlay,
+        }
+
+    return _build
+
+
+def _sql_server_flat(*, schema: str) -> CreationArguments:
+    def _build(_scratch_directory: pathlib.Path) -> Mapping[str, object]:
+        return {
+            "host": "sql-server.contract-suite.invalid",
+            "database": "contract_db",
+            "schema": schema,
+            "username": "contract_user",
+            "password": "contract_password",
+        }
+
+    return _build
+
+
+def _fabric_flat(*, schema: str) -> CreationArguments:
+    def _build(_scratch_directory: pathlib.Path) -> Mapping[str, object]:
+        return {
+            "host": "contract-suite.datawarehouse.fabric.microsoft.com",
+            "database": "contract_db",
+            "schema": schema,
+            "tenant_id": "00000000-0000-0000-0000-000000000001",
+            "client_id": "00000000-0000-0000-0000-000000000002",
+            "client_secret": "contract_secret",
+        }
+
+    return _build
+
+
+def _base_directory(subdirectory: str) -> CreationArguments:
+    def _build(scratch_directory: pathlib.Path) -> Mapping[str, object]:
+        directory = scratch_directory / subdirectory
+        directory.mkdir(parents=True, exist_ok=True)
+        return {"base_directory": str(directory)}
+
+    return _build
+
+
+def _bucket(*, key: str, name: str) -> CreationArguments:
+    def _build(_scratch_directory: pathlib.Path) -> Mapping[str, object]:
+        return {key: name}
+
+    return _build
+
+
+def _azure_options(account_url: str) -> CreationArguments:
+    def _build(_scratch_directory: pathlib.Path) -> Mapping[str, object]:
+        return {"azure_options": {"account_url": account_url}}
+
+    return _build
+
+
+def _fabric_powerbi(*, dataset: str, workspace: Optional[str] = None) -> CreationArguments:
+    def _build(_scratch_directory: pathlib.Path) -> Mapping[str, object]:
+        arguments: dict[str, object] = {"dataset": dataset}
+        if workspace is not None:
+            arguments["workspace"] = workspace
+        return arguments
+
+    return _build
+
+
+def _spark_overlay(*, persist: bool) -> CreationArguments:
+    def _build(_scratch_directory: pathlib.Path) -> Mapping[str, object]:
+        return {"persist": persist}
+
+    return _build
+
+
+_POSTGRES_FORM_URL = (
+    "postgresql://contract_user:contract_password@db.contract-suite.invalid:5432/contract_db"
+)
+
+_PANDAS_EXCLUSION_REASON = (
+    "PandasDatasource declares no field beyond name, type, identifier and assets, so no "
+    "update of its configuration can be observed to have replaced anything."
+)
+
+CONTRACT_PARAMETERS: Mapping[str, FluentTypeContractParameters] = {
+    # Connection string, PostgreSQL-form URL, `create_temp_table` flipped.
+    "alloy": FluentTypeContractParameters(
+        creation_arguments=_connection_string(_POSTGRES_FORM_URL),
+        update_overlay=_connection_string_overlay(_POSTGRES_FORM_URL, create_temp_table=True),
+    ),
+    "aurora": FluentTypeContractParameters(
+        creation_arguments=_connection_string(_POSTGRES_FORM_URL),
+        update_overlay=_connection_string_overlay(_POSTGRES_FORM_URL, create_temp_table=True),
+    ),
+    "citus": FluentTypeContractParameters(
+        creation_arguments=_connection_string(_POSTGRES_FORM_URL),
+        update_overlay=_connection_string_overlay(_POSTGRES_FORM_URL, create_temp_table=True),
+    ),
+    "neon": FluentTypeContractParameters(
+        creation_arguments=_connection_string(_POSTGRES_FORM_URL),
+        update_overlay=_connection_string_overlay(_POSTGRES_FORM_URL, create_temp_table=True),
+    ),
+    "postgres": FluentTypeContractParameters(
+        creation_arguments=_connection_string(_POSTGRES_FORM_URL),
+        update_overlay=_connection_string_overlay(_POSTGRES_FORM_URL, create_temp_table=True),
+    ),
+    "sql": FluentTypeContractParameters(
+        creation_arguments=_connection_string(_POSTGRES_FORM_URL),
+        update_overlay=_connection_string_overlay(_POSTGRES_FORM_URL, create_temp_table=True),
+    ),
+    # Connection string, dialect-specific URL form, `create_temp_table` flipped.
+    "bigquery": FluentTypeContractParameters(
+        creation_arguments=_connection_string("bigquery://contract-project/contract_dataset"),
+        update_overlay=_connection_string_overlay(
+            "bigquery://contract-project/contract_dataset", create_temp_table=True
+        ),
+    ),
+    "databricks_sql": FluentTypeContractParameters(
+        creation_arguments=_connection_string(
+            "databricks://token:contract-token@databricks.contract-suite.invalid:443"
+            "?http_path=/sql/1.0/warehouses/contract&catalog=contract_catalog"
+            "&schema=contract_schema"
+        ),
+        update_overlay=_connection_string_overlay(
+            "databricks://token:contract-token@databricks.contract-suite.invalid:443"
+            "?http_path=/sql/1.0/warehouses/contract&catalog=contract_catalog"
+            "&schema=contract_schema",
+            create_temp_table=True,
+        ),
+    ),
+    "redshift": FluentTypeContractParameters(
+        creation_arguments=_connection_string(
+            "redshift+psycopg2://contract_user:contract_password"
+            "@redshift.contract-suite.invalid:5439/contract_db"
+        ),
+        update_overlay=_connection_string_overlay(
+            "redshift+psycopg2://contract_user:contract_password"
+            "@redshift.contract-suite.invalid:5439/contract_db",
+            create_temp_table=True,
+        ),
+    ),
+    "snowflake": FluentTypeContractParameters(
+        creation_arguments=_connection_string(
+            "snowflake://contract_user:contract_password@contract_account"
+            "/contract_db/contract_schema?warehouse=contract_wh&role=contract_role"
+        ),
+        update_overlay=_connection_string_overlay(
+            "snowflake://contract_user:contract_password@contract_account"
+            "/contract_db/contract_schema?warehouse=contract_wh&role=contract_role",
+            create_temp_table=True,
+        ),
+    ),
+    "sqlite": FluentTypeContractParameters(
+        creation_arguments=_sqlite_connection_string(overlay=False),
+        update_overlay=_sqlite_connection_string(overlay=True),
+    ),
+    # Structured connection details, flat keyword form. `schema` changed on overlay.
+    "sql_server": FluentTypeContractParameters(
+        creation_arguments=_sql_server_flat(schema="dbo"),
+        update_overlay=_sql_server_flat(schema="contract_schema"),
+    ),
+    "fabric": FluentTypeContractParameters(
+        creation_arguments=_fabric_flat(schema="dbo"),
+        update_overlay=_fabric_flat(schema="contract_schema"),
+    ),
+    # Directory. A second scratch subdirectory on overlay.
+    "pandas_filesystem": FluentTypeContractParameters(
+        creation_arguments=_base_directory("pandas_filesystem"),
+        update_overlay=_base_directory("pandas_filesystem_overlay"),
+    ),
+    "spark_filesystem": FluentTypeContractParameters(
+        creation_arguments=_base_directory("spark_filesystem"),
+        update_overlay=_base_directory("spark_filesystem_overlay"),
+    ),
+    "pandas_dbfs": FluentTypeContractParameters(
+        creation_arguments=_base_directory("pandas_dbfs"),
+        update_overlay=_base_directory("pandas_dbfs_overlay"),
+    ),
+    "spark_dbfs": FluentTypeContractParameters(
+        creation_arguments=_base_directory("spark_dbfs"),
+        update_overlay=_base_directory("spark_dbfs_overlay"),
+    ),
+    # Bucket. A second placeholder name on overlay.
+    "pandas_s3": FluentTypeContractParameters(
+        creation_arguments=_bucket(key="bucket", name="contract-suite-bucket"),
+        update_overlay=_bucket(key="bucket", name="contract-suite-bucket-overlay"),
+    ),
+    "spark_s3": FluentTypeContractParameters(
+        creation_arguments=_bucket(key="bucket", name="contract-suite-bucket"),
+        update_overlay=_bucket(key="bucket", name="contract-suite-bucket-overlay"),
+    ),
+    "pandas_gcs": FluentTypeContractParameters(
+        creation_arguments=_bucket(key="bucket_or_name", name="contract-suite-bucket"),
+        update_overlay=_bucket(key="bucket_or_name", name="contract-suite-bucket-overlay"),
+    ),
+    "spark_gcs": FluentTypeContractParameters(
+        creation_arguments=_bucket(key="bucket_or_name", name="contract-suite-bucket"),
+        update_overlay=_bucket(key="bucket_or_name", name="contract-suite-bucket-overlay"),
+    ),
+    # Object-store options. A second placeholder account URL on overlay.
+    "pandas_abs": FluentTypeContractParameters(
+        creation_arguments=_azure_options("https://contractsuiteaccount.blob.core.windows.net"),
+        update_overlay=_azure_options("https://contractsuiteaccountoverlay.blob.core.windows.net"),
+    ),
+    "spark_abs": FluentTypeContractParameters(
+        creation_arguments=_azure_options("https://contractsuiteaccount.blob.core.windows.net"),
+        update_overlay=_azure_options("https://contractsuiteaccountoverlay.blob.core.windows.net"),
+    ),
+    # Semantic model. `workspace` set on overlay.
+    "fabric_powerbi": FluentTypeContractParameters(
+        creation_arguments=_fabric_powerbi(dataset="00000000-0000-0000-0000-0000000000f1"),
+        update_overlay=_fabric_powerbi(
+            dataset="00000000-0000-0000-0000-0000000000f1",
+            workspace="00000000-0000-0000-0000-0000000000f2",
+        ),
+    ),
+    # None. `persist` flipped on overlay.
+    "spark": FluentTypeContractParameters(
+        creation_arguments=_no_arguments,
+        update_overlay=_spark_overlay(persist=False),
+    ),
+    # None. No field an update could change.
+    "pandas": FluentTypeContractParameters(
+        creation_arguments=_no_arguments,
+        update_overlay=None,
+        case_exclusions={
+            UPDATE_REPLACES_CONFIGURATION: _PANDAS_EXCLUSION_REASON,
+            CREATE_OR_UPDATE_REPLACES_WHEN_PRESENT: _PANDAS_EXCLUSION_REASON,
+        },
+    ),
+}
+CONTRACT_PARAMETERS = types.MappingProxyType(CONTRACT_PARAMETERS)
+
+
+# ---------------------------------------------------------------------------
+# Accessors
+# ---------------------------------------------------------------------------
+
+
+def contract_parameters_for(fluent_type: str) -> FluentTypeContractParameters:
+    """The table entry for a fluent datasource type.
+
+    Raises:
+        KeyError: naming the type and stating that ``crud_contract.py`` must declare, for
+            that type, creation arguments and either an update overlay or an exclusion for
+            every key in ``OVERLAY_DEPENDENT_CASE_KEYS``.
+    """
+    try:
+        return CONTRACT_PARAMETERS[fluent_type]
+    except KeyError:
+        raise KeyError(
+            f"No CRUD contract parameters are declared for fluent datasource type "
+            f"{fluent_type!r}. Add an entry for {fluent_type!r} to CONTRACT_PARAMETERS in "
+            f"tests/datasource/fluent/crud_contract.py. The entry must declare "
+            f"creation_arguments (a callable taking a scratch directory and returning the "
+            f"keyword arguments that create a datasource of this type) and either "
+            f"update_overlay (a callable of the same shape whose result, merged over "
+            f"creation_arguments, produces a materially different datasource of the same "
+            f"type) or a case_exclusions entry with a non-empty reason for every key in "
+            f"OVERLAY_DEPENDENT_CASE_KEYS."
+        ) from None
+
+
+def exclusion_reason(fluent_type: str, case_key: str) -> Optional[str]:
+    """The declared reason this type does not run this case, or ``None`` when it does."""
+    return contract_parameters_for(fluent_type).case_exclusions.get(case_key)
+
+
+def covered_fluent_types() -> FrozenSet[str]:
+    """Every fluent datasource type the table declares an entry for."""
+    return frozenset(CONTRACT_PARAMETERS.keys())
+
+
+def case_exclusions_by_type() -> Mapping[str, Mapping[str, str]]:
+    """Every declared exclusion, keyed by fluent type and then by case key.
+
+    The bulk form of ``exclusion_reason``. A consumer that needs to know which cases a type
+    sits out — a generated compatibility reference qualifying a row, for example — reads this
+    instead of crossing ``covered_fluent_types()`` against ``CONTRACT_CASE_KEYS`` and calling
+    ``exclusion_reason`` once per pair, which would rebuild this mapping a second time.
+
+    Returns the table's own declarations, copied into an immutable mapping, and consults
+    nothing else.
+    """
+    return types.MappingProxyType(
+        {
+            fluent_type: types.MappingProxyType(dict(parameters.case_exclusions))
+            for fluent_type, parameters in CONTRACT_PARAMETERS.items()
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Published record-coverage literals
+#
+# These two frozensets are read by the compatibility-reference generator to know which
+# registered types its page cannot mention, and which of its records cannot claim the tier
+# this suite backs. They live here, in the module with no test function, because the
+# generator needs a plain import surface rather than a pytest module.
+# ---------------------------------------------------------------------------
+
+FLUENT_TYPES_NAMED_BY_NO_RECORD: FrozenSet[str] = frozenset(
+    {
+        "spark",  # the Spark DataFrame data source; the only Spark record names the filesystem type
+        "pandas_dbfs",  # Databricks File System paths; the public reference names Databricks SQL, not DBFS  # noqa: E501
+        "spark_dbfs",  # same
+        "fabric_powerbi",  # Power BI semantic models; the Fabric record names the SQL-family type
+    }
+)
+
+RECORDS_COVERED_BUT_UNABLE_TO_CLAIM: FrozenSet[str] = frozenset(
+    {
+        "azure-blob-storage",
+        "alloydb",
+        "aurora",
+        "citus",
+        "neon",
+        "fabric",
+    }
+)

--- a/tests/datasource/fluent/test_crud_contract.py
+++ b/tests/datasource/fluent/test_crud_contract.py
@@ -646,10 +646,13 @@ class TestFluentDatasourceCrudContractPersistence:
     passing case is evidence that the configuration actually reached disk rather than
     evidence about in-process state the two context objects happen to share.
 
-    There is no delete case here. Delete's own persistence is already exercised, against a
-    file-backed context reopened from disk the same way this class's cases reopen theirs, by
-    tests elsewhere in this suite; a per-type copy of that coverage here would duplicate an
-    existing check rather than add signal.
+    There is no delete case here, and its absence is deliberate. Deleting a datasource does
+    not reach the persisted project configuration in every shape: removing one of several
+    datasources is written out, but removing the last one is not, and that gap is already
+    recorded elsewhere by a strict expected failure naming the save path responsible. This
+    class neither covers that behavior nor changes it, so adding a per-type delete case here
+    would either duplicate coverage that already passes or restate a failure that is already
+    recorded once.
     """
 
     @_registered_fluent_type_parameters

--- a/tests/datasource/fluent/test_crud_contract.py
+++ b/tests/datasource/fluent/test_crud_contract.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import pathlib
 import types
 import uuid
-from typing import TYPE_CHECKING, Callable, List
+from typing import TYPE_CHECKING, Callable, List, Mapping
 
 import pytest
 
@@ -30,6 +30,7 @@ from tests.datasource.fluent.crud_contract import (
     CONTRACT_PARAMETERS,
     CREATE_OR_UPDATE_REPLACES_WHEN_PRESENT,
     OVERLAY_DEPENDENT_CASE_KEYS,
+    UPDATE_REJECTS_ABSENT_NAME,
     UPDATE_REPLACES_CONFIGURATION,
     case_exclusions_by_type,
     contract_parameters_for,
@@ -239,6 +240,16 @@ _registered_fluent_type_parameters = pytest.mark.parametrize(
 )
 
 
+def _configuration_of(datasource: Datasource) -> Mapping[str, object]:
+    """The full field mapping of a stored datasource, with assets and identity excluded.
+
+    Assets are excluded because none of these cases add one, and comparing the identifier
+    separately keeps a case's identifier assertion distinct from its configuration
+    assertion rather than folding both into one dict equality.
+    """
+    return datasource.dict(exclude={"assets", "id"})
+
+
 @pytest.mark.unit
 class TestFluentDatasourceCrudContract:
     """The CRUD contract every registered fluent datasource type satisfies.
@@ -310,3 +321,96 @@ class TestFluentDatasourceCrudContract:
 
         assert isinstance(created, datasource_class)
         assert context.data_sources.get(name) is created
+
+    @_registered_fluent_type_parameters
+    def test_update_replaces_configuration(
+        self,
+        fluent_type: str,
+        neutralized_connection_testing: Callable[[str], type],
+        tmp_path: pathlib.Path,
+    ) -> None:
+        reason = exclusion_reason(fluent_type, UPDATE_REPLACES_CONFIGURATION)
+        if reason is not None:
+            pytest.skip(reason)
+
+        datasource_class = neutralized_connection_testing(fluent_type)
+        context = gx.get_context(mode="ephemeral")
+        name = f"contract-update-{fluent_type}"
+        seeded_id = uuid.uuid4()
+        parameters = contract_parameters_for(fluent_type)
+        creation_arguments = parameters.creation_arguments(tmp_path)
+        overlay_arguments = parameters.update_overlay(tmp_path)  # type: ignore[misc]
+
+        add_method = getattr(context.data_sources, f"add_{fluent_type}")
+        created = add_method(name=name, id=seeded_id, **creation_arguments)
+        created_configuration = _configuration_of(created)
+
+        update_method = getattr(context.data_sources, f"update_{fluent_type}")
+        updated = update_method(name=name, **overlay_arguments)
+
+        assert updated.id == seeded_id
+        assert context.data_sources.get(name).id == seeded_id
+
+        stored_configuration = _configuration_of(context.data_sources.get(name))
+        expected_configuration = _configuration_of(datasource_class(name=name, **overlay_arguments))
+        assert stored_configuration == expected_configuration
+        assert stored_configuration != created_configuration
+
+    @_registered_fluent_type_parameters
+    def test_update_rejects_absent_name(
+        self,
+        fluent_type: str,
+        neutralized_connection_testing: Callable[[str], type],
+        tmp_path: pathlib.Path,
+    ) -> None:
+        reason = exclusion_reason(fluent_type, UPDATE_REJECTS_ABSENT_NAME)
+        if reason is not None:
+            pytest.skip(reason)
+
+        neutralized_connection_testing(fluent_type)
+        context = gx.get_context(mode="ephemeral")
+        name = f"contract-update-absent-{fluent_type}"
+        arguments = contract_parameters_for(fluent_type).creation_arguments(tmp_path)
+
+        update_method = getattr(context.data_sources, f"update_{fluent_type}")
+
+        with pytest.raises(ValueError) as excinfo:
+            update_method(name=name, **arguments)
+
+        assert name in str(excinfo.value)
+        with pytest.raises(KeyError):
+            context.data_sources.get(name)
+
+    @_registered_fluent_type_parameters
+    def test_create_or_update_replaces_when_present(
+        self,
+        fluent_type: str,
+        neutralized_connection_testing: Callable[[str], type],
+        tmp_path: pathlib.Path,
+    ) -> None:
+        reason = exclusion_reason(fluent_type, CREATE_OR_UPDATE_REPLACES_WHEN_PRESENT)
+        if reason is not None:
+            pytest.skip(reason)
+
+        datasource_class = neutralized_connection_testing(fluent_type)
+        context = gx.get_context(mode="ephemeral")
+        name = f"contract-create-or-update-replace-{fluent_type}"
+        seeded_id = uuid.uuid4()
+        parameters = contract_parameters_for(fluent_type)
+        creation_arguments = parameters.creation_arguments(tmp_path)
+        overlay_arguments = parameters.update_overlay(tmp_path)  # type: ignore[misc]
+
+        add_method = getattr(context.data_sources, f"add_{fluent_type}")
+        created = add_method(name=name, id=seeded_id, **creation_arguments)
+        created_configuration = _configuration_of(created)
+
+        add_or_update_method = getattr(context.data_sources, f"add_or_update_{fluent_type}")
+        replaced = add_or_update_method(name=name, **overlay_arguments)
+
+        assert replaced.id == seeded_id
+        assert context.data_sources.get(name).id == seeded_id
+
+        stored_configuration = _configuration_of(context.data_sources.get(name))
+        expected_configuration = _configuration_of(datasource_class(name=name, **overlay_arguments))
+        assert stored_configuration == expected_configuration
+        assert stored_configuration != created_configuration

--- a/tests/datasource/fluent/test_crud_contract.py
+++ b/tests/datasource/fluent/test_crud_contract.py
@@ -481,7 +481,7 @@ class TestFluentDatasourceCrudContract:
         seeded_id = uuid.uuid4()
         arguments = contract_parameters_for(fluent_type).creation_arguments(tmp_path)
 
-        add_method = getattr(context.data_sources, f"add_{fluent_type}")
+        add_method: Callable[..., Datasource] = getattr(context.data_sources, f"add_{fluent_type}")
         created = add_method(name=name, id=seeded_id, **arguments)
 
         assert isinstance(created, datasource_class)
@@ -632,7 +632,9 @@ class TestFluentDatasourceCrudContract:
 def _fluent_datasources_config(config_file_path: pathlib.Path) -> Mapping[str, object]:
     """The ``fluent_datasources`` mapping as it is actually written to the project config file."""
     yaml_dict = YAMLHandler().load(config_file_path.read_text())
-    return yaml_dict.get("fluent_datasources", {})
+    fluent_datasources = yaml_dict.get("fluent_datasources", {})
+    assert isinstance(fluent_datasources, dict)
+    return fluent_datasources
 
 
 @pytest.mark.filesystem

--- a/tests/datasource/fluent/test_crud_contract.py
+++ b/tests/datasource/fluent/test_crud_contract.py
@@ -1,18 +1,30 @@
-"""Accessor-level tests over the CRUD contract's vocabulary and parameter table.
+"""Tests over the CRUD contract's vocabulary, parameter table, and the contract cases
+themselves.
 
-This module exercises only the accessors declared in ``crud_contract.py``: the case-key
-vocabulary, the lookup that turns an unknown type into an actionable failure, the exclusion
-resolvers, and the covered-type set. The contract cases themselves, and the completeness
-guards over the live registry, belong to other modules.
+The accessor tests below exercise only the accessors declared in ``crud_contract.py``: the
+case-key vocabulary, the lookup that turns an unknown type into an actionable failure, the
+exclusion resolvers, and the covered-type set.
+
+The ``TestFluentDatasourceCrudContract`` class runs the contract's create-family cases
+against every registered fluent datasource type, with connection testing neutralized for the
+duration of each case. Neutralization is deliberate: a passing case in that class asserts
+that the create, duplicate-rejection and create-or-update behavior described by the contract
+holds for that type, and asserts nothing about whether any real service backing that type is
+reachable. The completeness guards over the live registry belong to another module.
 """
 
 from __future__ import annotations
 
 import pathlib
 import types
+import uuid
+from typing import TYPE_CHECKING, Callable, List
 
 import pytest
 
+import great_expectations as gx
+import great_expectations.exceptions as gx_exceptions
+from great_expectations.datasource.fluent.sources import DataSourceManager
 from tests.datasource.fluent.crud_contract import (
     CONTRACT_CASE_KEYS,
     CONTRACT_PARAMETERS,
@@ -24,6 +36,9 @@ from tests.datasource.fluent.crud_contract import (
     covered_fluent_types,
     exclusion_reason,
 )
+
+if TYPE_CHECKING:
+    from great_expectations.datasource.fluent.interfaces import Datasource
 
 
 @pytest.mark.unit
@@ -167,3 +182,131 @@ def test_creation_arguments_are_produced_by_a_callable_over_a_scratch_directory(
         if parameters.update_overlay is not None:
             overlay = parameters.update_overlay(tmp_path)
             assert isinstance(overlay, (dict, types.MappingProxyType))
+
+
+# ---------------------------------------------------------------------------
+# Connection-testing neutralization
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def neutralized_connection_testing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Callable[[str], type]:
+    """Return a callable that neutralizes connection testing for one fluent type.
+
+    Calling the returned function with a registered fluent type name patches
+    ``test_connection`` on the concrete class the registry resolves for that type, then
+    returns that class. Patching a shared base class does not reach every type: several
+    concrete classes override ``test_connection`` themselves, so a base-class patch leaves
+    those types making a real connection attempt. ``monkeypatch`` restores the original
+    method for every patched class when the test ends, so no case leaves a lasting change to
+    any datasource class.
+
+    This neutralization is deliberate, not incidental. A case built on top of this fixture
+    asserts the CRUD contract for the patched type. It never asserts, and cannot assert, that
+    the type can actually reach the service it represents.
+    """
+
+    def _neutralize(fluent_type: str) -> type:
+        datasource_class = DataSourceManager.type_lookup[fluent_type]
+
+        def _fake_test_connection(self: Datasource, test_assets: bool = True) -> None:
+            return None
+
+        monkeypatch.setattr(datasource_class, "test_connection", _fake_test_connection)
+        return datasource_class
+
+    return _neutralize
+
+
+# ---------------------------------------------------------------------------
+# The create-family contract cases
+# ---------------------------------------------------------------------------
+
+
+def _registered_fluent_types() -> List[str]:
+    """Every registered fluent datasource type name, sorted, read from the live registry.
+
+    Built as a module-level function so a collection-time failure names this module, and so a
+    type registered after this suite is written is exercised without editing this list.
+    """
+    return sorted(name for name in DataSourceManager.type_lookup if isinstance(name, str))
+
+
+_registered_fluent_type_parameters = pytest.mark.parametrize(
+    "fluent_type", _registered_fluent_types(), ids=_registered_fluent_types()
+)
+
+
+@pytest.mark.unit
+class TestFluentDatasourceCrudContract:
+    """The CRUD contract every registered fluent datasource type satisfies.
+
+    Every case in this class runs with connection testing neutralized for the type under
+    test. That neutralization is deliberate: a passing case here is evidence about the
+    create, duplicate-rejection and create-or-update behavior the contract describes, and is
+    never evidence that the underlying service the type represents can be reached.
+    """
+
+    @_registered_fluent_type_parameters
+    def test_create_returns_the_stored_datasource(
+        self,
+        fluent_type: str,
+        neutralized_connection_testing: Callable[[str], type],
+        tmp_path: pathlib.Path,
+    ) -> None:
+        datasource_class = neutralized_connection_testing(fluent_type)
+        context = gx.get_context(mode="ephemeral")
+        name = f"contract-create-{fluent_type}"
+        seeded_id = uuid.uuid4()
+        arguments = contract_parameters_for(fluent_type).creation_arguments(tmp_path)
+
+        add_method = getattr(context.data_sources, f"add_{fluent_type}")
+        created = add_method(name=name, id=seeded_id, **arguments)
+
+        assert isinstance(created, datasource_class)
+        assert created.name == name
+        assert created.id == seeded_id
+        assert context.data_sources.get(name) is created
+
+    @_registered_fluent_type_parameters
+    def test_create_rejects_duplicate_name(
+        self,
+        fluent_type: str,
+        neutralized_connection_testing: Callable[[str], type],
+        tmp_path: pathlib.Path,
+    ) -> None:
+        neutralized_connection_testing(fluent_type)
+        context = gx.get_context(mode="ephemeral")
+        name = f"contract-duplicate-{fluent_type}"
+        arguments = contract_parameters_for(fluent_type).creation_arguments(tmp_path)
+
+        add_method = getattr(context.data_sources, f"add_{fluent_type}")
+        original = add_method(name=name, id=uuid.uuid4(), **arguments)
+
+        with pytest.raises(gx_exceptions.DataContextError) as excinfo:
+            add_method(name=name, id=uuid.uuid4(), **arguments)
+
+        message = str(excinfo.value)
+        assert name in message
+        assert "already exists" in message
+        assert context.data_sources.get(name) is original
+
+    @_registered_fluent_type_parameters
+    def test_create_or_update_creates_when_absent(
+        self,
+        fluent_type: str,
+        neutralized_connection_testing: Callable[[str], type],
+        tmp_path: pathlib.Path,
+    ) -> None:
+        datasource_class = neutralized_connection_testing(fluent_type)
+        context = gx.get_context(mode="ephemeral")
+        name = f"contract-create-or-update-{fluent_type}"
+        arguments = contract_parameters_for(fluent_type).creation_arguments(tmp_path)
+
+        add_or_update_method = getattr(context.data_sources, f"add_or_update_{fluent_type}")
+        created = add_or_update_method(name=name, id=uuid.uuid4(), **arguments)
+
+        assert isinstance(created, datasource_class)
+        assert context.data_sources.get(name) is created

--- a/tests/datasource/fluent/test_crud_contract.py
+++ b/tests/datasource/fluent/test_crud_contract.py
@@ -34,6 +34,7 @@ from tests.datasource.fluent.crud_contract import (
     OVERLAY_DEPENDENT_CASE_KEYS,
     UPDATE_REJECTS_ABSENT_NAME,
     UPDATE_REPLACES_CONFIGURATION,
+    FluentTypeContractParameters,
     case_exclusions_by_type,
     contract_parameters_for,
     covered_fluent_types,
@@ -189,6 +190,207 @@ def test_creation_arguments_are_produced_by_a_callable_over_a_scratch_directory(
         if parameters.update_overlay is not None:
             overlay = parameters.update_overlay(tmp_path)
             assert isinstance(overlay, (dict, types.MappingProxyType))
+
+
+# ---------------------------------------------------------------------------
+# Completeness, exclusion-sanity and anti-vacuity guards
+#
+# Each check below is a small function that raises ``AssertionError`` naming the offending
+# value, rather than a bare assertion, so the same function can be exercised twice: once
+# against the live table, where it must stay silent, and once against a fabricated table
+# built only in this module, where it must raise. That is what lets a guard's failure
+# behavior be proven without mutating the immutable structures this module imports.
+# ---------------------------------------------------------------------------
+
+
+def _check_no_stale_entries(covered_types, registered_types) -> None:
+    stale = frozenset(covered_types) - frozenset(registered_types)
+    if stale:
+        raise AssertionError(
+            f"CONTRACT_PARAMETERS declares an entry for {sorted(stale)!r}, which the live "
+            f"fluent datasource registry does not hold. Remove the stale entry from "
+            f"CONTRACT_PARAMETERS or register the type."
+        )
+
+
+def _check_parameter_list_not_empty(covered_types) -> None:
+    if not covered_types:
+        raise AssertionError(
+            "The derived CRUD contract parameter list is empty; no fluent datasource type "
+            "would be exercised by this suite. Check that CONTRACT_PARAMETERS still has "
+            "entries."
+        )
+
+
+def _check_covered_type_count(actual_count: int, pinned_literal: int, registry_size: int) -> None:
+    if actual_count != pinned_literal:
+        raise AssertionError(
+            f"CONTRACT_PARAMETERS covers {actual_count} fluent datasource types but the "
+            f"pinned literal is {pinned_literal}. Update the pinned literal to match the "
+            f"table's current size."
+        )
+    if actual_count != registry_size:
+        raise AssertionError(
+            f"CONTRACT_PARAMETERS covers {actual_count} fluent datasource types but the "
+            f"live registry holds {registry_size}. Add or remove a table entry so the two "
+            f"stay equal."
+        )
+
+
+def _check_exclusions_use_published_keys(table, published_keys) -> None:
+    for fluent_type, parameters in table.items():
+        unpublished = set(parameters.case_exclusions.keys()) - set(published_keys)
+        if unpublished:
+            raise AssertionError(
+                f"{fluent_type!r} declares an exclusion for {sorted(unpublished)!r}, which "
+                f"is not a key CONTRACT_CASE_KEYS publishes. Use a case key from "
+                f"CONTRACT_CASE_KEYS or remove the exclusion."
+            )
+
+
+def _check_no_type_excluded_from_every_case(table, all_case_keys) -> None:
+    for fluent_type, parameters in table.items():
+        if set(parameters.case_exclusions.keys()) == set(all_case_keys):
+            raise AssertionError(
+                f"{fluent_type!r} is excluded from every contract case, so it is not "
+                f"actually covered despite having a table entry. Remove entries from its "
+                f"case_exclusions or drop the entry from CONTRACT_PARAMETERS."
+            )
+
+
+def _check_overlay_free_types_exclude_exactly_overlay_dependent_cases(
+    table, overlay_dependent_keys
+) -> None:
+    for fluent_type, parameters in table.items():
+        if parameters.update_overlay is None:
+            declared = frozenset(parameters.case_exclusions.keys())
+            if declared != frozenset(overlay_dependent_keys):
+                raise AssertionError(
+                    f"{fluent_type!r} declares no update_overlay but excludes "
+                    f"{sorted(declared)!r} instead of exactly the overlay-dependent cases "
+                    f"{sorted(overlay_dependent_keys)!r}. Declare an update_overlay or fix "
+                    f"the exclusions to match exactly."
+                )
+
+
+@pytest.mark.unit
+def test_no_stale_table_entry_against_the_live_registry() -> None:
+    _check_no_stale_entries(covered_fluent_types(), _registered_fluent_types())
+
+
+@pytest.mark.unit
+def test_stale_entry_guard_fails_naming_the_stale_entry() -> None:
+    fabricated_types = frozenset(covered_fluent_types()) | {"not_a_real_fluent_type"}
+    with pytest.raises(AssertionError, match=r"not_a_real_fluent_type") as excinfo:
+        _check_no_stale_entries(fabricated_types, _registered_fluent_types())
+    assert "not_a_real_fluent_type" in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_derived_parameter_list_is_not_empty() -> None:
+    _check_parameter_list_not_empty(covered_fluent_types())
+
+
+@pytest.mark.unit
+def test_empty_parameter_list_guard_fails() -> None:
+    with pytest.raises(AssertionError, match=r"empty"):
+        _check_parameter_list_not_empty(frozenset())
+
+
+@pytest.mark.unit
+def test_covered_type_count_matches_the_pinned_literal_and_the_registry() -> None:
+    _check_covered_type_count(
+        actual_count=len(covered_fluent_types()),
+        pinned_literal=26,
+        registry_size=len(_registered_fluent_types()),
+    )
+
+
+@pytest.mark.unit
+def test_covered_type_count_guard_fails_against_a_stale_pinned_literal() -> None:
+    actual_count = len(covered_fluent_types())
+    stale_literal = actual_count - 1
+    with pytest.raises(AssertionError, match=str(stale_literal)) as excinfo:
+        _check_covered_type_count(
+            actual_count=actual_count,
+            pinned_literal=stale_literal,
+            registry_size=len(_registered_fluent_types()),
+        )
+    assert str(stale_literal) in str(excinfo.value)
+    assert str(actual_count) in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_covered_type_count_guard_fails_against_a_mismatched_registry_size() -> None:
+    actual_count = len(covered_fluent_types())
+    wrong_registry_size = actual_count + 1
+    with pytest.raises(AssertionError, match=str(wrong_registry_size)) as excinfo:
+        _check_covered_type_count(
+            actual_count=actual_count,
+            pinned_literal=actual_count,
+            registry_size=wrong_registry_size,
+        )
+    assert str(wrong_registry_size) in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_no_declared_exclusion_names_an_unpublished_case_key() -> None:
+    _check_exclusions_use_published_keys(CONTRACT_PARAMETERS, CONTRACT_CASE_KEYS)
+
+
+@pytest.mark.unit
+def test_unpublished_exclusion_key_guard_fails_naming_the_key() -> None:
+    fabricated_entry = FluentTypeContractParameters(
+        creation_arguments=lambda _scratch_directory: {},
+        case_exclusions={"not_a_published_case_key": "fabricated for this proof"},
+    )
+    fabricated_table = {"fabricated_type": fabricated_entry}
+    with pytest.raises(AssertionError, match=r"not_a_published_case_key") as excinfo:
+        _check_exclusions_use_published_keys(fabricated_table, CONTRACT_CASE_KEYS)
+    assert "not_a_published_case_key" in str(excinfo.value)
+    assert "fabricated_type" in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_no_type_is_excluded_from_every_case_via_the_guard() -> None:
+    _check_no_type_excluded_from_every_case(CONTRACT_PARAMETERS, CONTRACT_CASE_KEYS)
+
+
+@pytest.mark.unit
+def test_excluded_from_every_case_guard_fails_naming_the_type() -> None:
+    fabricated_entry = FluentTypeContractParameters(
+        creation_arguments=lambda _scratch_directory: {},
+        case_exclusions=dict.fromkeys(CONTRACT_CASE_KEYS, "fabricated for this proof"),
+    )
+    fabricated_table = {"fully_excluded_type": fabricated_entry}
+    with pytest.raises(AssertionError, match=r"fully_excluded_type") as excinfo:
+        _check_no_type_excluded_from_every_case(fabricated_table, CONTRACT_CASE_KEYS)
+    assert "fully_excluded_type" in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_overlay_free_types_exclude_exactly_the_overlay_dependent_cases() -> None:
+    _check_overlay_free_types_exclude_exactly_overlay_dependent_cases(
+        CONTRACT_PARAMETERS, OVERLAY_DEPENDENT_CASE_KEYS
+    )
+
+
+@pytest.mark.unit
+def test_overlay_removed_without_its_exclusion_fails_naming_the_type() -> None:
+    # Simulate an overlay being dropped from a type that used to declare one, without also
+    # adding the exclusions that absence obliges.
+    postgres_creation_arguments = contract_parameters_for("postgres").creation_arguments
+    fabricated_entry = FluentTypeContractParameters(
+        creation_arguments=postgres_creation_arguments,
+        update_overlay=None,
+        case_exclusions={},
+    )
+    fabricated_table = {"postgres": fabricated_entry}
+    with pytest.raises(AssertionError, match=r"postgres") as excinfo:
+        _check_overlay_free_types_exclude_exactly_overlay_dependent_cases(
+            fabricated_table, OVERLAY_DEPENDENT_CASE_KEYS
+        )
+    assert "postgres" in str(excinfo.value)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/datasource/fluent/test_crud_contract.py
+++ b/tests/datasource/fluent/test_crud_contract.py
@@ -1,0 +1,169 @@
+"""Accessor-level tests over the CRUD contract's vocabulary and parameter table.
+
+This module exercises only the accessors declared in ``crud_contract.py``: the case-key
+vocabulary, the lookup that turns an unknown type into an actionable failure, the exclusion
+resolvers, and the covered-type set. The contract cases themselves, and the completeness
+guards over the live registry, belong to other modules.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import types
+
+import pytest
+
+from tests.datasource.fluent.crud_contract import (
+    CONTRACT_CASE_KEYS,
+    CONTRACT_PARAMETERS,
+    CREATE_OR_UPDATE_REPLACES_WHEN_PRESENT,
+    OVERLAY_DEPENDENT_CASE_KEYS,
+    UPDATE_REPLACES_CONFIGURATION,
+    case_exclusions_by_type,
+    contract_parameters_for,
+    covered_fluent_types,
+    exclusion_reason,
+)
+
+
+@pytest.mark.unit
+def test_contract_case_keys_has_eight_entries() -> None:
+    assert len(CONTRACT_CASE_KEYS) == 8
+    assert all(isinstance(key, str) for key in CONTRACT_CASE_KEYS)
+
+
+@pytest.mark.unit
+def test_overlay_dependent_case_keys_is_a_subset_of_contract_case_keys() -> None:
+    assert OVERLAY_DEPENDENT_CASE_KEYS <= CONTRACT_CASE_KEYS
+    assert {
+        UPDATE_REPLACES_CONFIGURATION,
+        CREATE_OR_UPDATE_REPLACES_WHEN_PRESENT,
+    } == OVERLAY_DEPENDENT_CASE_KEYS
+
+
+@pytest.mark.unit
+def test_covered_fluent_types_matches_the_table_keys() -> None:
+    assert covered_fluent_types() == frozenset(CONTRACT_PARAMETERS.keys())
+
+
+@pytest.mark.unit
+def test_covered_fluent_types_has_twenty_six_entries() -> None:
+    assert len(covered_fluent_types()) == 26
+
+
+@pytest.mark.unit
+def test_contract_parameters_for_known_type_returns_the_table_entry() -> None:
+    parameters = contract_parameters_for("postgres")
+    assert parameters is CONTRACT_PARAMETERS["postgres"]
+
+
+@pytest.mark.unit
+def test_contract_parameters_for_unknown_type_names_the_type_and_the_module() -> None:
+    with pytest.raises(KeyError) as excinfo:
+        contract_parameters_for("not_a_real_fluent_type")
+
+    message = str(excinfo.value)
+    assert "not_a_real_fluent_type" in message
+    assert "crud_contract.py" in message
+    assert "CONTRACT_PARAMETERS" in message
+    assert "creation_arguments" in message
+    assert "update_overlay" in message
+    assert "case_exclusions" in message
+
+
+@pytest.mark.unit
+def test_exclusion_reason_is_none_for_a_case_the_type_runs() -> None:
+    assert exclusion_reason("postgres", UPDATE_REPLACES_CONFIGURATION) is None
+
+
+@pytest.mark.unit
+def test_exclusion_reason_returns_the_declared_reason() -> None:
+    reason = exclusion_reason("pandas", UPDATE_REPLACES_CONFIGURATION)
+    assert reason is not None
+    assert isinstance(reason, str)
+    assert reason != ""
+
+
+@pytest.mark.unit
+def test_pandas_excludes_exactly_the_two_overlay_dependent_cases() -> None:
+    reasons = CONTRACT_PARAMETERS["pandas"].case_exclusions
+    assert set(reasons.keys()) == OVERLAY_DEPENDENT_CASE_KEYS
+    assert all(reason for reason in reasons.values())
+
+
+@pytest.mark.unit
+def test_pandas_has_no_update_overlay() -> None:
+    assert CONTRACT_PARAMETERS["pandas"].update_overlay is None
+
+
+@pytest.mark.unit
+def test_no_type_is_excluded_from_every_case() -> None:
+    for fluent_type in covered_fluent_types():
+        excluded = set(CONTRACT_PARAMETERS[fluent_type].case_exclusions.keys())
+        assert excluded != CONTRACT_CASE_KEYS, (
+            f"{fluent_type!r} is excluded from every case; it must not read as covered"
+        )
+
+
+@pytest.mark.unit
+def test_case_exclusions_by_type_returns_the_whole_declared_mapping() -> None:
+    mapping = case_exclusions_by_type()
+    assert set(mapping.keys()) == covered_fluent_types()
+    assert mapping["pandas"] == {
+        UPDATE_REPLACES_CONFIGURATION: exclusion_reason("pandas", UPDATE_REPLACES_CONFIGURATION),
+        CREATE_OR_UPDATE_REPLACES_WHEN_PRESENT: exclusion_reason(
+            "pandas", CREATE_OR_UPDATE_REPLACES_WHEN_PRESENT
+        ),
+    }
+    assert mapping["postgres"] == {}
+
+
+@pytest.mark.unit
+def test_case_exclusions_by_type_is_immutable() -> None:
+    mapping = case_exclusions_by_type()
+    with pytest.raises(TypeError):
+        mapping["pandas"] = {}  # type: ignore[index]
+
+    inner = mapping["postgres"]
+    with pytest.raises(TypeError):
+        inner["create"] = "not allowed"  # type: ignore[index]
+
+
+@pytest.mark.unit
+def test_per_type_case_exclusions_is_immutable() -> None:
+    # The per-type accessor must be just as immutable as the bulk one: a caller reaching
+    # contract_parameters_for(...).case_exclusions directly gets a live reference to module
+    # state one call away from the bulk accessor, and mutating it would silently and
+    # permanently corrupt CONTRACT_PARAMETERS for every later reader.
+    exclusions = contract_parameters_for("postgres").case_exclusions
+    assert isinstance(exclusions, types.MappingProxyType)
+    with pytest.raises(TypeError):
+        exclusions["injected"] = "boom"  # type: ignore[index]
+
+    assert "injected" not in contract_parameters_for("postgres").case_exclusions
+
+
+@pytest.mark.unit
+def test_contract_parameters_table_rejects_insertion() -> None:
+    # CONTRACT_PARAMETERS itself must not be a plain dict a caller can grow or shrink; doing
+    # so would move covered_fluent_types() away from the live registry without any of this
+    # module's own guards noticing.
+    assert isinstance(CONTRACT_PARAMETERS, types.MappingProxyType)
+    with pytest.raises(TypeError):
+        CONTRACT_PARAMETERS["injected"] = contract_parameters_for("postgres")  # type: ignore[index]
+
+    assert "injected" not in covered_fluent_types()
+    assert len(covered_fluent_types()) == 26
+
+
+@pytest.mark.unit
+def test_creation_arguments_are_produced_by_a_callable_over_a_scratch_directory(
+    tmp_path: pathlib.Path,
+) -> None:
+    for fluent_type in covered_fluent_types():
+        parameters = contract_parameters_for(fluent_type)
+        arguments = parameters.creation_arguments(tmp_path)
+        assert isinstance(arguments, (dict, types.MappingProxyType))
+        if parameters.update_overlay is not None:
+            overlay = parameters.update_overlay(tmp_path)
+            assert isinstance(overlay, (dict, types.MappingProxyType))

--- a/tests/datasource/fluent/test_crud_contract.py
+++ b/tests/datasource/fluent/test_crud_contract.py
@@ -24,10 +24,12 @@ import pytest
 
 import great_expectations as gx
 import great_expectations.exceptions as gx_exceptions
+from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.datasource.fluent.sources import DataSourceManager
 from tests.datasource.fluent.crud_contract import (
     CONTRACT_CASE_KEYS,
     CONTRACT_PARAMETERS,
+    CREATE_OR_UPDATE_PERSISTS_ONE_ENTRY,
     CREATE_OR_UPDATE_REPLACES_WHEN_PRESENT,
     OVERLAY_DEPENDENT_CASE_KEYS,
     UPDATE_REJECTS_ABSENT_NAME,
@@ -54,6 +56,7 @@ def test_overlay_dependent_case_keys_is_a_subset_of_contract_case_keys() -> None
     assert {
         UPDATE_REPLACES_CONFIGURATION,
         CREATE_OR_UPDATE_REPLACES_WHEN_PRESENT,
+        CREATE_OR_UPDATE_PERSISTS_ONE_ENTRY,
     } == OVERLAY_DEPENDENT_CASE_KEYS
 
 
@@ -101,7 +104,7 @@ def test_exclusion_reason_returns_the_declared_reason() -> None:
 
 
 @pytest.mark.unit
-def test_pandas_excludes_exactly_the_two_overlay_dependent_cases() -> None:
+def test_pandas_excludes_exactly_the_overlay_dependent_cases() -> None:
     reasons = CONTRACT_PARAMETERS["pandas"].case_exclusions
     assert set(reasons.keys()) == OVERLAY_DEPENDENT_CASE_KEYS
     assert all(reason for reason in reasons.values())
@@ -129,6 +132,9 @@ def test_case_exclusions_by_type_returns_the_whole_declared_mapping() -> None:
         UPDATE_REPLACES_CONFIGURATION: exclusion_reason("pandas", UPDATE_REPLACES_CONFIGURATION),
         CREATE_OR_UPDATE_REPLACES_WHEN_PRESENT: exclusion_reason(
             "pandas", CREATE_OR_UPDATE_REPLACES_WHEN_PRESENT
+        ),
+        CREATE_OR_UPDATE_PERSISTS_ONE_ENTRY: exclusion_reason(
+            "pandas", CREATE_OR_UPDATE_PERSISTS_ONE_ENTRY
         ),
     }
     assert mapping["postgres"] == {}
@@ -414,3 +420,112 @@ class TestFluentDatasourceCrudContract:
         expected_configuration = _configuration_of(datasource_class(name=name, **overlay_arguments))
         assert stored_configuration == expected_configuration
         assert stored_configuration != created_configuration
+
+
+# ---------------------------------------------------------------------------
+# Persistence round-trip against a file-backed context
+# ---------------------------------------------------------------------------
+
+
+def _fluent_datasources_config(config_file_path: pathlib.Path) -> Mapping[str, object]:
+    """The ``fluent_datasources`` mapping as it is actually written to the project config file."""
+    yaml_dict = YAMLHandler().load(config_file_path.read_text())
+    return yaml_dict.get("fluent_datasources", {})
+
+
+@pytest.mark.filesystem
+class TestFluentDatasourceCrudContractPersistence:
+    """The subset of the CRUD contract that only a real, file-backed project can verify.
+
+    These cases reopen the project from a fresh context instance rooted at the same
+    directory, rather than reusing the context object that performed the write, so a
+    passing case is evidence that the configuration actually reached disk rather than
+    evidence about in-process state the two context objects happen to share.
+
+    There is no delete case here. Delete's own persistence is already exercised, against a
+    file-backed context reopened from disk the same way this class's cases reopen theirs, by
+    tests elsewhere in this suite; a per-type copy of that coverage here would duplicate an
+    existing check rather than add signal.
+    """
+
+    @_registered_fluent_type_parameters
+    def test_configuration_survives_a_fresh_read_from_disk(
+        self,
+        fluent_type: str,
+        neutralized_connection_testing: Callable[[str], type],
+        tmp_path: pathlib.Path,
+        file_dc_config_dir_init: pathlib.Path,
+    ) -> None:
+        datasource_class = neutralized_connection_testing(fluent_type)
+        writing_context = gx.get_context(context_root_dir=file_dc_config_dir_init, cloud_mode=False)
+        name = f"contract-persist-roundtrip-{fluent_type}"
+        seeded_id = uuid.uuid4()
+        arguments = contract_parameters_for(fluent_type).creation_arguments(tmp_path)
+
+        add_method = getattr(writing_context.data_sources, f"add_{fluent_type}")
+        created = add_method(name=name, id=seeded_id, **arguments)
+        expected_configuration = _configuration_of(created)
+
+        assert created.assets == []
+
+        config_file_path = pathlib.Path(writing_context.root_directory, writing_context.GX_YML)
+        assert name in _fluent_datasources_config(config_file_path)
+
+        # Discard `writing_context` entirely and build a genuinely new context object over
+        # the same directory, so the read below can only be satisfied from disk.
+        del writing_context
+        reread_context = gx.get_context(context_root_dir=file_dc_config_dir_init, cloud_mode=False)
+
+        reread_datasource = reread_context.data_sources.get(name)
+        assert isinstance(reread_datasource, datasource_class)
+        assert reread_datasource.id == seeded_id
+        assert _configuration_of(reread_datasource) == expected_configuration
+
+    @_registered_fluent_type_parameters
+    def test_create_then_create_or_update_leaves_exactly_one_persisted_entry(
+        self,
+        fluent_type: str,
+        neutralized_connection_testing: Callable[[str], type],
+        tmp_path: pathlib.Path,
+        file_dc_config_dir_init: pathlib.Path,
+    ) -> None:
+        # A count over a mapping keyed by datasource name can never exceed one by
+        # construction, so it cannot by itself detect the create-or-update path failing to
+        # persist. The case also has to show that the persisted entry is the *replacement*:
+        # that only holds if create-or-update's own save actually reached disk, rather than
+        # riding on the save the preceding create already performed. A type with no update
+        # overlay cannot produce a materially different replacement, so it is excluded here
+        # exactly as the in-memory replaces-when-present case excludes it.
+        reason = exclusion_reason(fluent_type, CREATE_OR_UPDATE_PERSISTS_ONE_ENTRY)
+        if reason is not None:
+            pytest.skip(reason)
+
+        datasource_class = neutralized_connection_testing(fluent_type)
+        writing_context = gx.get_context(context_root_dir=file_dc_config_dir_init, cloud_mode=False)
+        name = f"contract-persist-create-or-update-{fluent_type}"
+        parameters = contract_parameters_for(fluent_type)
+        creation_arguments = parameters.creation_arguments(tmp_path)
+        overlay_arguments = parameters.update_overlay(tmp_path)  # type: ignore[misc]
+
+        add_method = getattr(writing_context.data_sources, f"add_{fluent_type}")
+        add_method(name=name, id=uuid.uuid4(), **creation_arguments)
+
+        add_or_update_method = getattr(writing_context.data_sources, f"add_or_update_{fluent_type}")
+        add_or_update_method(name=name, id=uuid.uuid4(), **overlay_arguments)
+
+        expected_configuration = _configuration_of(datasource_class(name=name, **overlay_arguments))
+
+        config_file_path = pathlib.Path(writing_context.root_directory, writing_context.GX_YML)
+        persisted_datasources = _fluent_datasources_config(config_file_path)
+        matching_entries = [
+            entry_name for entry_name in persisted_datasources if entry_name == name
+        ]
+        assert len(matching_entries) == 1
+
+        # Discard `writing_context` and reread from disk, so the assertion below can only be
+        # satisfied by create-or-update's own save having reached the file, not by in-process
+        # state the two context objects happen to share.
+        del writing_context
+        reread_context = gx.get_context(context_root_dir=file_dc_config_dir_init, cloud_mode=False)
+        reread_datasource = reread_context.data_sources.get(name)
+        assert _configuration_of(reread_datasource) == expected_configuration

--- a/tests/datasource/fluent/test_datasource_factory_stubs.py
+++ b/tests/datasource/fluent/test_datasource_factory_stubs.py
@@ -1,0 +1,153 @@
+"""Drift detection between the generated datasource factory methods and their type stub.
+
+The data source manager generates one create, update, create-or-update, and delete method per
+registered fluent datasource type. Those methods only exist at runtime through dynamic
+attribute assignment, so a type checker only sees them if a matching declaration is hand
+maintained in the manager's stub file. This module derives the expected declarations from the
+live registry and compares them against what the stub actually declares, so a declaration that
+falls out of sync with the registry is caught without invoking a type checker at all.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+from typing import FrozenSet
+
+import pytest
+
+from great_expectations.datasource.fluent import sources
+from great_expectations.datasource.fluent.sources import DataSourceManager
+
+# Longest-first so a create-or-update declaration is not misread as a create declaration
+# followed by a nonsense type part (e.g. "add_or_update_postgres" must not be parsed as
+# prefix "add_" plus type "or_update_postgres").
+_FACTORY_PREFIXES: tuple[str, ...] = (
+    "add_or_update_",
+    "add_",
+    "update_",
+    "delete_",
+)
+
+
+def _stub_path() -> pathlib.Path:
+    """The manager's type stub, located from the module's own file rather than a fixed path."""
+    module_file = inspect.getfile(sources)
+    return pathlib.Path(module_file).with_suffix(".pyi")
+
+
+def _registered_type_names() -> FrozenSet[str]:
+    return frozenset(DataSourceManager.type_lookup.type_names())
+
+
+def _expected_factory_methods() -> FrozenSet[str]:
+    """Every generated factory method name, derived from the live fluent type registry."""
+    type_names = _registered_type_names()
+    return frozenset(
+        f"{prefix}{type_name}" for prefix in _FACTORY_PREFIXES for type_name in type_names
+    )
+
+
+def _split_factory_name(method_name: str) -> tuple[str, str] | None:
+    """Split a method name into its prefix and type part, matching longest-first.
+
+    Returns None if the name does not start with any of the recognized prefixes.
+    """
+    for prefix in _FACTORY_PREFIXES:
+        if method_name.startswith(prefix):
+            return prefix, method_name[len(prefix) :]
+    return None
+
+
+def _factory_type_part(method_name: str) -> str:
+    """The type part of a name already known to be factory-shaped."""
+    split = _split_factory_name(method_name)
+    assert split is not None, f"{method_name} is not factory-shaped"
+    return split[1]
+
+
+def _declared_method_names(stub_path: pathlib.Path) -> FrozenSet[str]:
+    """Method names declared on the data source manager class in a stub file.
+
+    Parses the stub as a syntax tree rather than importing it, because a stub file is not an
+    importable runtime module. Overload groups (repeated declarations of the same name, most
+    commonly decorated with ``@overload``) collapse to a single occurrence of that name.
+    """
+    tree = ast.parse(stub_path.read_text(), filename=str(stub_path))
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == DataSourceManager.__name__:
+            for item in node.body:
+                if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    names.add(item.name)
+    return frozenset(names)
+
+
+def _declared_factory_methods(stub_path: pathlib.Path) -> FrozenSet[str]:
+    """Declared method names on the manager class that are shaped like a factory method."""
+    return frozenset(
+        name for name in _declared_method_names(stub_path) if _split_factory_name(name)
+    )
+
+
+@pytest.mark.unit
+def test_expected_factory_methods_are_not_vacuous() -> None:
+    """The expected set must be nonempty and exactly four times the registered type count.
+
+    Without this guard, a registry that yields no type names would make the drift check pass
+    trivially, having compared nothing against nothing.
+    """
+    registered_type_names = _registered_type_names()
+    expected = _expected_factory_methods()
+
+    assert expected, "Derived no generated factory methods, which means the registry appears empty."
+    assert len(expected) == 4 * len(registered_type_names), (
+        f"Expected {4 * len(registered_type_names)} generated factory methods "
+        f"(4 prefixes x {len(registered_type_names)} registered types), "
+        f"but derived {len(expected)}."
+    )
+
+
+@pytest.mark.unit
+def test_longest_prefix_matches_first() -> None:
+    """A create-or-update name resolves to that prefix, not to create plus a nonsense type."""
+    split = _split_factory_name("add_or_update_postgres")
+    assert split == ("add_or_update_", "postgres"), (
+        f"Expected 'add_or_update_postgres' to split into prefix 'add_or_update_' and type "
+        f"'postgres', but got {split!r}."
+    )
+
+
+@pytest.mark.unit
+def test_stub_declares_every_generated_factory_method() -> None:
+    """Every generated factory method for a registered type must appear in the stub."""
+    stub_path = _stub_path()
+    expected = _expected_factory_methods()
+    declared = _declared_method_names(stub_path)
+
+    missing = sorted(expected - declared)
+    assert not missing, (
+        "The following generated factory methods are missing from "
+        f"{stub_path}: {missing}. Each is generated for a registered datasource type; "
+        "add a matching declaration to the stub for each missing method and its type: "
+        + ", ".join(f"{name} ({_factory_type_part(name)})" for name in missing)
+    )
+
+
+@pytest.mark.unit
+def test_stub_declares_no_factory_methods_for_unregistered_types() -> None:
+    """A factory-shaped stub declaration whose type part is not registered is stale."""
+    stub_path = _stub_path()
+    registered_type_names = _registered_type_names()
+    declared_factory_methods = _declared_factory_methods(stub_path)
+
+    stale = sorted(
+        name
+        for name in declared_factory_methods
+        if _factory_type_part(name) not in registered_type_names
+    )
+    assert not stale, (
+        f"The following declarations in {stub_path} are factory-shaped but their type part is "
+        f"not a registered datasource type: {stale}. Remove or correct each stale declaration."
+    )

--- a/tests/integration/data_sources_and_expectations/README.md
+++ b/tests/integration/data_sources_and_expectations/README.md
@@ -253,9 +253,11 @@ point enrolled it, so a declaration-only record cannot be sloppier than a config
 
 **The one misreading to avoid: a declared CI lane and a tier claim are different assertions.** A
 lane means a job installs this data source's dependencies and runs something. A tier means that
-tier's suite passes here. Only the second is a support claim. That distinction is what lets Amazon
-S3 and Google Cloud Storage declare the real lanes that install their client libraries while still
-claiming no tier — reading those two records as tested data sources would be wrong.
+tier's suite passes here. Only the second is a support claim. Amazon S3 and Google Cloud Storage
+show why the two are worth keeping apart: they declare real lanes that install their client
+libraries, and they claim the fluent API tier because that tier's suite covers the fluent types
+they are reached through — but claiming it says nothing about whether either store is reachable,
+and neither claims a tier that would assert expectations run against them.
 
 #### Dedicated and shared markers, and having no marker at all
 

--- a/tests/integration/data_sources_and_expectations/data_source_backlog.md
+++ b/tests/integration/data_sources_and_expectations/data_source_backlog.md
@@ -152,7 +152,9 @@ source would mean the only data sources this repository can name are the ones it
 
 ## Data sources declared but not tested
 
-Each of the eight below has a registered record and no test surface. The records live in
+Each of the eight below has a registered record and no suite validating expectations against
+it. Two of them, Amazon S3 and Google Cloud Storage, do claim the fluent API tier, so their
+fluent types are covered by that tier's suite; the rest carry no tier at all. The records live in
 `tests/integration/test_utils/data_source_config/declaration_only.py`; what a record declares is
 checked by the drift check, and what follows here is what onboarding one would concretely require.
 

--- a/tests/integration/test_utils/data_source_config/big_query.py
+++ b/tests/integration/test_utils/data_source_config/big_query.py
@@ -52,7 +52,7 @@ class BigQueryDatasourceTestConfig(SqlDatasourceTestConfig):
         # while this is False raises, so that need surfaces as a clear error rather
         # than silently doing the wrong thing.
         uses_schema=False,
-        tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS}),
+        tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS, SupportTier.FLUENT_API}),
         dev_requirements_file="reqs/requirements-dev-bigquery.txt",
         task_runner_marker="bigquery",
     )

--- a/tests/integration/test_utils/data_source_config/clickhouse.py
+++ b/tests/integration/test_utils/data_source_config/clickhouse.py
@@ -99,7 +99,7 @@ class ClickHouseDatasourceTestConfig(SqlDatasourceTestConfig):
         dev_requirements_file="reqs/requirements-dev-clickhouse.txt",
         task_runner_marker="clickhouse",
         container_service="clickhouse",
-        tiers=frozenset({SupportTier.CURATED_SQL}),
+        tiers=frozenset({SupportTier.CURATED_SQL, SupportTier.FLUENT_API}),
         tier_case_exclusions={
             # Same root cause already recorded on this backend's scoped module's
             # `test_match_regex`/`test_not_match_regex`: the dialect's regex-matching path calls

--- a/tests/integration/test_utils/data_source_config/data_source_spec.py
+++ b/tests/integration/test_utils/data_source_config/data_source_spec.py
@@ -64,6 +64,15 @@ class SupportTier(Enum):
     meaning for a data source that speaks no dialect.
     """
 
+    FLUENT_API = "fluent_api"
+    """Every fluent datasource type this data source is reached through satisfies the standard
+    create, update and create-or-update contract, including configuration persistence.
+
+    This is a claim about the data source management API, not about reachability: the suite that
+    earns this tier runs with connection testing neutralized. A data source can satisfy it and be
+    unreachable.
+    """
+
 
 class MarkerScope(Enum):
     """Whether a declared marker names this data source alone or a class of them."""

--- a/tests/integration/test_utils/data_source_config/databricks.py
+++ b/tests/integration/test_utils/data_source_config/databricks.py
@@ -45,7 +45,7 @@ class DatabricksDatasourceTestConfig(SqlDatasourceTestConfig):
         # databricks requires a length for VARCHAR
         column_type_overrides={str: sqltypes.VARCHAR(255)},
         insert_parameter_limit=250,
-        tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS}),
+        tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS, SupportTier.FLUENT_API}),
         dev_requirements_file="reqs/requirements-dev-databricks.txt",
         task_runner_marker="databricks",
     )

--- a/tests/integration/test_utils/data_source_config/declaration_only.py
+++ b/tests/integration/test_utils/data_source_config/declaration_only.py
@@ -3,15 +3,16 @@
 A declaration-only record states what a data source *is* - its harness label, the name its users
 know it by, where a test run would obtain an instance of it, and the fluent datasource types it is
 reachable through - together with whatever wiring genuinely exists for it in this repository. It
-asserts nothing about coverage. None of the records here claims a tier, because no suite in this
-repository runs against any of these data sources, and a tier claim asserts that one does.
+asserts nothing about coverage beyond what a claimed tier states. Most records here claim no tier,
+because no suite in this repository runs against them, and a tier claim asserts that one does.
 
 **A declared CI lane and a tier claim are different assertions, and conflating them is the one
 misreading this module has to prevent.** A lane means a job installs this data source's
 dependencies and runs something; a tier means that tier's suite passes here. Only the second is a
 support claim. That distinction is what lets Amazon S3 and Google Cloud Storage declare the real
-lanes that install their client libraries while still claiming no tier - a reader who conflated the
-two would read those two records as tested data sources, which they are not.
+lanes that install their client libraries and, separately, claim the tier whose suite genuinely
+covers their fluent types - a reader who conflated the two would credit the lane alone with a
+support claim it does not make.
 
 Registration goes through the config-less entry point, because none of these has a harness config
 class: requiring one would mean the only data sources this repository can describe are the ones it
@@ -31,6 +32,7 @@ from tests.integration.test_utils.data_source_config.data_source_spec import (
     DataSourceProvisioning,
     DataSourceSpec,
     MarkerScope,
+    SupportTier,
 )
 from tests.integration.test_utils.data_source_config.registry import register_data_source
 
@@ -56,6 +58,7 @@ AMAZON_S3 = register_data_source(
         marker="aws_deps",
         marker_scope=MarkerScope.SHARED,
         ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="aws_deps"),
+        tiers=frozenset({SupportTier.FLUENT_API}),
         task_runner_marker="aws_deps",
         # No dev_requirements_file, deliberately. The `aws_deps` task-runner entry names
         # `reqs/requirements-dev-lite.txt`, which is the shared lite requirements file rather than
@@ -75,6 +78,7 @@ GOOGLE_CLOUD_STORAGE = register_data_source(
         marker="gcs_deps",
         marker_scope=MarkerScope.SHARED,
         ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="gcs_deps"),
+        tiers=frozenset({SupportTier.FLUENT_API}),
         # Unlike `aws_deps`, this task-runner entry names a data-source-specific requirements file,
         # so the record can declare it truthfully.
         dev_requirements_file="reqs/requirements-dev-gcs.txt",

--- a/tests/integration/test_utils/data_source_config/mysql.py
+++ b/tests/integration/test_utils/data_source_config/mysql.py
@@ -32,7 +32,7 @@ class MySQLDatasourceTestConfig(SqlDatasourceTestConfig):
         fluent_types=frozenset({"sql"}),
         ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="mysql"),
         uses_schema=True,
-        tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS}),
+        tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS, SupportTier.FLUENT_API}),
         # MySQL requires a length for VARCHAR.
         column_type_overrides={str: sqltypes.VARCHAR(255)},
         dev_requirements_file="reqs/requirements-dev-mysql.txt",

--- a/tests/integration/test_utils/data_source_config/oracle.py
+++ b/tests/integration/test_utils/data_source_config/oracle.py
@@ -61,7 +61,7 @@ class OracleDatasourceTestConfig(SqlDatasourceTestConfig):
         dev_requirements_file="reqs/requirements-dev-oracle.txt",
         task_runner_marker="oracle",
         container_service="oracle",
-        tiers=frozenset({SupportTier.CURATED_SQL}),
+        tiers=frozenset({SupportTier.CURATED_SQL, SupportTier.FLUENT_API}),
     )
 
     @override

--- a/tests/integration/test_utils/data_source_config/pandas_data_frame.py
+++ b/tests/integration/test_utils/data_source_config/pandas_data_frame.py
@@ -42,7 +42,7 @@ class PandasDataFrameDatasourceTestConfig(DataSourceTestConfig):
         # `unit` lane today, through every one of its expectation modules. Declaring the tier
         # states that existing result; it switches nothing on. The marker and CI lane the claim
         # obliges are already declared above.
-        tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS}),
+        tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS, SupportTier.FLUENT_API}),
         # No dev_requirements_file and no task_runner_marker: the task runner's dependency map has
         # no key for `unit`, because running these tests installs nothing beyond the base
         # development requirements and starts no service.

--- a/tests/integration/test_utils/data_source_config/pandas_filesystem_csv.py
+++ b/tests/integration/test_utils/data_source_config/pandas_filesystem_csv.py
@@ -48,7 +48,7 @@ class PandasFilesystemCsvDatasourceTestConfig(DataSourceTestConfig):
         # `filesystem` lane today, through every one of its expectation modules. Declaring the
         # tier states that existing result; it switches nothing on. The marker and CI lane the
         # claim obliges are already declared above.
-        tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS}),
+        tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS, SupportTier.FLUENT_API}),
         # No dev_requirements_file and no task_runner_marker: the task runner's dependency map has
         # no key for `filesystem`, because running these tests installs nothing beyond the base
         # development requirements and starts no service.

--- a/tests/integration/test_utils/data_source_config/postgres.py
+++ b/tests/integration/test_utils/data_source_config/postgres.py
@@ -32,7 +32,7 @@ class PostgreSQLDatasourceTestConfig(SqlDatasourceTestConfig):
         fluent_types=frozenset({"postgres"}),
         ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="postgresql"),
         uses_schema=True,
-        tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS}),
+        tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS, SupportTier.FLUENT_API}),
         dev_requirements_file="reqs/requirements-dev-postgresql.txt",
         task_runner_marker="postgresql",
         container_service="postgresql",

--- a/tests/integration/test_utils/data_source_config/redshift.py
+++ b/tests/integration/test_utils/data_source_config/redshift.py
@@ -59,7 +59,7 @@ class RedshiftDatasourceTestConfig(SqlDatasourceTestConfig):
         # the job is named explicitly here rather than being the shared matrix job.
         ci_lane=CiLaneRef(workflow_job="redshift", marker_token="redshift"),
         uses_schema=True,
-        tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS}),
+        tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS, SupportTier.FLUENT_API}),
         dev_requirements_file="reqs/requirements-dev-redshift.txt",
         task_runner_marker="redshift",
     )

--- a/tests/integration/test_utils/data_source_config/singlestore.py
+++ b/tests/integration/test_utils/data_source_config/singlestore.py
@@ -32,7 +32,7 @@ class SingleStoreDatasourceTestConfig(SqlDatasourceTestConfig):
         fluent_types=frozenset({"sql"}),
         ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="singlestore"),
         uses_schema=False,
-        tiers=frozenset({SupportTier.CURATED_SQL}),
+        tiers=frozenset({SupportTier.CURATED_SQL, SupportTier.FLUENT_API}),
         # SingleStore requires a length for VARCHAR, the same requirement MySQL declares.
         column_type_overrides={str: sqltypes.VARCHAR(255)},
         dev_requirements_file="reqs/requirements-dev-singlestore.txt",

--- a/tests/integration/test_utils/data_source_config/snowflake.py
+++ b/tests/integration/test_utils/data_source_config/snowflake.py
@@ -44,7 +44,7 @@ class SnowflakeDatasourceTestConfig(SqlDatasourceTestConfig):
         # selected as one matrix cell among many markers.
         ci_lane=CiLaneRef(workflow_job="marker-tests-snowflake", marker_token="snowflake"),
         uses_schema=True,
-        tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS}),
+        tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS, SupportTier.FLUENT_API}),
         dev_requirements_file="reqs/requirements-dev-snowflake.txt",
         task_runner_marker="snowflake",
     )

--- a/tests/integration/test_utils/data_source_config/spark_filesystem_csv.py
+++ b/tests/integration/test_utils/data_source_config/spark_filesystem_csv.py
@@ -60,7 +60,7 @@ class SparkFilesystemCsvDatasourceTestConfig(DataSourceTestConfig):
         # `spark` lane today, through every one of its expectation modules. Declaring the tier
         # states that existing result; it switches nothing on. The marker and CI lane the claim
         # obliges are already declared above.
-        tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS}),
+        tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS, SupportTier.FLUENT_API}),
         dev_requirements_file="reqs/requirements-dev-spark.txt",
         task_runner_marker="spark",
     )

--- a/tests/integration/test_utils/data_source_config/sql_server.py
+++ b/tests/integration/test_utils/data_source_config/sql_server.py
@@ -48,7 +48,7 @@ class SQLServerDatasourceTestConfig(SqlDatasourceTestConfig):
         fluent_types=frozenset({"sql_server"}),
         ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="sql_server"),
         uses_schema=True,
-        tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS}),
+        tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS, SupportTier.FLUENT_API}),
         dev_requirements_file="reqs/requirements-dev-sql-server.txt",
         task_runner_marker="sql_server",
         container_service="mssql",

--- a/tests/integration/test_utils/data_source_config/sqlite.py
+++ b/tests/integration/test_utils/data_source_config/sqlite.py
@@ -32,7 +32,7 @@ class SqliteDatasourceTestConfig(SqlDatasourceTestConfig):
         fluent_types=frozenset({"sqlite"}),
         ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="sqlite"),
         uses_schema=False,
-        tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS}),
+        tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS, SupportTier.FLUENT_API}),
         # SQLite has neither a dev-requirements file nor a task-runner entry.
     )
 

--- a/tests/integration/test_utils/data_source_config/trino.py
+++ b/tests/integration/test_utils/data_source_config/trino.py
@@ -40,7 +40,7 @@ class TrinoDatasourceTestConfig(SqlDatasourceTestConfig):
         # scale zero, silently rounding fractional values to integers. A precision-carrying
         # FLOAT compiles to double precision and round-trips exactly.
         column_type_overrides={float: sqltypes.FLOAT(precision=53)},
-        tiers=frozenset({SupportTier.CURATED_SQL}),
+        tiers=frozenset({SupportTier.CURATED_SQL, SupportTier.FLUENT_API}),
         dev_requirements_file="reqs/requirements-dev-trino.txt",
         task_runner_marker="trino",
         container_service="trino",

--- a/tests/test_data_source_registry.py
+++ b/tests/test_data_source_registry.py
@@ -2120,6 +2120,7 @@ _EXPECTED_DECLARATION_ONLY_SPECS: Mapping[str, DataSourceSpec] = {
         marker="aws_deps",
         marker_scope=MarkerScope.SHARED,
         ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="aws_deps"),
+        tiers=frozenset({SupportTier.FLUENT_API}),
         task_runner_marker="aws_deps",
     ),
     "aurora": DataSourceSpec(
@@ -2154,6 +2155,7 @@ _EXPECTED_DECLARATION_ONLY_SPECS: Mapping[str, DataSourceSpec] = {
         marker="gcs_deps",
         marker_scope=MarkerScope.SHARED,
         ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="gcs_deps"),
+        tiers=frozenset({SupportTier.FLUENT_API}),
         dev_requirements_file="reqs/requirements-dev-gcs.txt",
         task_runner_marker="gcs_deps",
     ),
@@ -2216,16 +2218,30 @@ class TestDeclarationOnlyRecordsJoinTheRegistryWithoutConfigs:
             replace(registered, provisioning_note=None) == (_EXPECTED_DECLARATION_ONLY_SPECS[label])
         )
 
-    def test_no_declaration_only_record_claims_a_tier(self) -> None:
-        """No suite in this repository runs against any of the eight, so none may claim one.
+    def test_only_the_two_with_wiring_claim_a_tier(self) -> None:
+        """A tier claim tracks whether a suite genuinely covers the record, not whether it is
+        declaration-only.
 
-        This is the assertion that keeps a declared CI lane from being read as a support claim:
-        Amazon S3 and Google Cloud Storage declare real lanes, and a lane means a job installs a
-        data source's dependencies and runs something - not that a tier's suite passes here.
+        Six of the eight declare neither a marker nor a CI lane, so no suite in this repository
+        runs against them and they claim no tier. Amazon S3 and Google Cloud Storage are the
+        exception: they declare a real marker and CI lane, and their fluent types are exercised
+        by the suite backing the fluent-API tier, so they claim that tier - while still being
+        declaration-only in the sense this test class is named for, since neither has a harness
+        config class. This is the assertion that keeps a declared CI lane from being conflated
+        with a tier claim in the other direction: a lane means a job installs a data source's
+        dependencies and runs something, and only a tier claim asserts that a specific suite
+        passes against it.
         """
-        assert {
-            label: spec.tiers for label, spec in _DECLARATION_ONLY_SPECS.items()
-        } == dict.fromkeys(_EXPECTED_DECLARATION_ONLY_SPECS, frozenset())
+        assert {label: spec.tiers for label, spec in _DECLARATION_ONLY_SPECS.items()} == {
+            "alloydb": frozenset(),
+            "amazon-s3": frozenset({SupportTier.FLUENT_API}),
+            "aurora": frozenset(),
+            "azure-blob-storage": frozenset(),
+            "citus": frozenset(),
+            "fabric": frozenset(),
+            "google-cloud-storage": frozenset({SupportTier.FLUENT_API}),
+            "neon": frozenset(),
+        }
 
     def test_citus_records_its_costed_onboarding_surfaces_in_its_provisioning_note(self) -> None:
         """Local-container provisioning with no container service is Citus's honest shape, and
@@ -2528,7 +2544,7 @@ _RETROFITTED_CONTROLS: Mapping[str, _RetrofitControl] = {
             marker="unit",
             marker_scope=MarkerScope.SHARED,
             ci_lane=CiLaneRef(workflow_job="unit-tests", marker_token="unit"),
-            tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS}),
+            tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS, SupportTier.FLUENT_API}),
         ),
     ),
     "pandas-filesystem-csv": (
@@ -2543,7 +2559,7 @@ _RETROFITTED_CONTROLS: Mapping[str, _RetrofitControl] = {
             marker="filesystem",
             marker_scope=MarkerScope.SHARED,
             ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="filesystem"),
-            tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS}),
+            tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS, SupportTier.FLUENT_API}),
         ),
     ),
     "spark-filesystem-csv": (
@@ -2558,7 +2574,7 @@ _RETROFITTED_CONTROLS: Mapping[str, _RetrofitControl] = {
             marker="spark",
             marker_scope=MarkerScope.SHARED,
             ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="spark"),
-            tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS}),
+            tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS, SupportTier.FLUENT_API}),
             dev_requirements_file="reqs/requirements-dev-spark.txt",
             task_runner_marker="spark",
         ),

--- a/tests/test_fluent_api_tier.py
+++ b/tests/test_fluent_api_tier.py
@@ -1,0 +1,195 @@
+"""Cross-checks between the fluent-type contract table and the tier the registry records claim.
+
+A record claims `SupportTier.FLUENT_API` by asserting that every fluent datasource `type` literal
+it corresponds to satisfies the create/update/create-or-update contract. That claim is only as
+good as two things lining up: every type a claiming record names must actually have a contract
+table entry, and every type it names must actually exist in the fluent datasource registry. This
+module checks both directions against the live registry, and pins the two gaps the current
+registrations and the current contract table leave: fluent types no record names, and covered
+records that stop short of the claim because they declare neither a marker nor a CI lane.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from great_expectations.datasource.fluent.sources import DataSourceManager
+from tests.datasource.fluent.crud_contract import (
+    FLUENT_TYPES_NAMED_BY_NO_RECORD,
+    RECORDS_COVERED_BUT_UNABLE_TO_CLAIM,
+    covered_fluent_types,
+)
+from tests.integration.test_utils.data_source_config.data_source_spec import (
+    CiLaneRef,
+    DataSourceProvisioning,
+    DataSourceSpec,
+    SupportTier,
+)
+from tests.integration.test_utils.data_source_config.registry import (
+    isolated_registry,
+    iter_data_sources,
+    register_data_source,
+)
+
+pytestmark = pytest.mark.project
+
+
+def _fluent_api_records() -> tuple[DataSourceSpec, ...]:
+    """Registered records claiming the fluent-API tier, read fresh at call time."""
+    return tuple(
+        registered.spec
+        for registered in iter_data_sources()
+        if SupportTier.FLUENT_API in registered.spec.tiers
+    )
+
+
+def _registered_fluent_type_names() -> frozenset[str]:
+    """Every `type` literal the fluent datasource registry holds, read fresh at call time."""
+    return frozenset(DataSourceManager.type_lookup.type_names())
+
+
+def _assert_every_claiming_record_names_only_covered_types() -> None:
+    """Raise naming the record and the type, the first time a tier claim outruns the table."""
+    covered = covered_fluent_types()
+    for spec in _fluent_api_records():
+        for fluent_type in spec.fluent_types:
+            if fluent_type not in covered:
+                raise AssertionError(
+                    f"{spec.label!r} claims the fluent-API tier and names fluent type "
+                    f"{fluent_type!r}, but no CRUD contract parameters are declared for that "
+                    f"type"
+                )
+
+
+def _assert_every_claiming_record_names_a_registered_type() -> None:
+    """Raise naming the record and the type, the first time a tier claim names a type that
+    does not exist in the fluent datasource registry."""
+    registered_types = _registered_fluent_type_names()
+    for spec in _fluent_api_records():
+        for fluent_type in spec.fluent_types:
+            if fluent_type not in registered_types:
+                raise AssertionError(
+                    f"{spec.label!r} claims the fluent-API tier and names fluent type "
+                    f"{fluent_type!r}, but the fluent datasource registry holds no such type"
+                )
+
+
+def test_registry_is_not_empty() -> None:
+    """An empty registry would let every assertion below pass for lack of anything to check."""
+    assert len(iter_data_sources()) > 0
+
+
+def test_contract_table_is_not_empty() -> None:
+    """An empty contract table would let every assertion below pass for lack of anything to
+    check."""
+    assert len(covered_fluent_types()) > 0
+
+
+def test_every_fluent_api_record_names_only_covered_types() -> None:
+    """Every fluent type a tier-claiming record names must have a contract table entry."""
+    _assert_every_claiming_record_names_only_covered_types()
+
+
+def test_every_fluent_api_record_names_a_registered_type() -> None:
+    """Every fluent type a tier-claiming record names must exist in the fluent type registry."""
+    _assert_every_claiming_record_names_a_registered_type()
+
+
+def test_fluent_types_named_by_no_record_matches_the_pinned_set() -> None:
+    """The set of registered fluent types no record's `fluent_types` names.
+
+    Pinned in `tests/datasource/fluent/crud_contract.py`, where a compatibility-reference
+    generator reads it. Checked here against one snapshot of the live registry, so a drift in
+    either direction — a record starting to name one of these types, or a new gap opening up —
+    fails loudly here rather than only downstream in the generator.
+    """
+    named_by_some_record: set[str] = set()
+    for registered in iter_data_sources():
+        named_by_some_record.update(registered.spec.fluent_types)
+    actual_gap = _registered_fluent_type_names() - named_by_some_record
+
+    assert actual_gap == FLUENT_TYPES_NAMED_BY_NO_RECORD
+
+
+def test_records_unable_to_claim_the_tier_matches_the_pinned_set() -> None:
+    """The set of contract-covered records that cannot claim the tier.
+
+    A record can only claim `SupportTier.FLUENT_API` if it declares both a marker and a CI lane,
+    which any tier claim requires. A record whose fluent types are all contract-covered but which
+    declares neither is stuck short of the claim for a reason that has nothing to do with the
+    contract table. Pinned in `crud_contract.py` for the same downstream reader as the sibling
+    literal above.
+    """
+    covered = covered_fluent_types()
+    actual_gap = {
+        registered.spec.label
+        for registered in iter_data_sources()
+        if registered.spec.fluent_types
+        and registered.spec.fluent_types <= covered
+        and SupportTier.FLUENT_API not in registered.spec.tiers
+        and (registered.spec.marker is None or registered.spec.ci_lane is None)
+    }
+
+    assert actual_gap == RECORDS_COVERED_BUT_UNABLE_TO_CLAIM
+
+
+def test_a_record_claiming_the_tier_with_an_uncovered_type_is_rejected() -> None:
+    """A throwaway record naming a type absent from the contract table fails the check.
+
+    Registered inside the isolation seam so the failing record never reaches the real registry;
+    the assertion after the failure proves the seam did its job.
+    """
+    before = iter_data_sources()
+    uncovered_type = "not-a-real-fluent-type-anyone-would-declare"
+    assert uncovered_type not in covered_fluent_types()
+
+    with isolated_registry():
+        register_data_source(
+            DataSourceSpec(
+                label="throwaway-uncovered-type",
+                public_name="Throwaway Uncovered Type",
+                provisioning=DataSourceProvisioning.IN_PROCESS,
+                fluent_types=frozenset({uncovered_type}),
+                marker="throwaway_uncovered_type",
+                ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="throwaway"),
+                tiers=frozenset({SupportTier.FLUENT_API}),
+            )
+        )
+        with pytest.raises(
+            AssertionError,
+            match=r"throwaway-uncovered-type.*not-a-real-fluent-type-anyone-would-declare",
+        ):
+            _assert_every_claiming_record_names_only_covered_types()
+
+    assert iter_data_sources() == before
+
+
+def test_a_record_naming_an_unregistered_fluent_type_is_rejected() -> None:
+    """A throwaway record naming a fluent type the registry does not hold fails the check.
+
+    Registered inside the isolation seam so the failing record never reaches the real registry;
+    the assertion after the failure proves the seam did its job.
+    """
+    before = iter_data_sources()
+    unregistered_type = "not-a-registered-fluent-type-anyone-would-declare"
+    assert unregistered_type not in _registered_fluent_type_names()
+
+    with isolated_registry():
+        register_data_source(
+            DataSourceSpec(
+                label="throwaway-unregistered-type",
+                public_name="Throwaway Unregistered Type",
+                provisioning=DataSourceProvisioning.IN_PROCESS,
+                fluent_types=frozenset({unregistered_type}),
+                marker="throwaway_unregistered_type",
+                ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="throwaway"),
+                tiers=frozenset({SupportTier.FLUENT_API}),
+            )
+        )
+        with pytest.raises(
+            AssertionError,
+            match=r"throwaway-unregistered-type.*not-a-registered-fluent-type-anyone-would-declare",
+        ):
+            _assert_every_claiming_record_names_a_registered_type()
+
+    assert iter_data_sources() == before


### PR DESCRIPTION
## What

Adds a contract suite that exercises the create, update and create-or-update behavior of the
fluent datasource management API against **every registered fluent datasource type**, completes
the factory type stubs so those methods are actually typed, and adds a support tier recording
which data sources that contract covers.

## Why

The fluent factory methods are generated at runtime, one create/update/create-or-update/delete
per registered type. Two things followed from that and neither was visible:

- **Four registered types had no stub declarations at all**, and a fifth had only its create
  declaration — nineteen methods in total. They worked at runtime, but resolved through the
  stub's untyped attribute fallback, so callers got no signature, no parameter checking and no
  return type. Nothing would have told us: the fallback answers for anything undeclared.
- **No test exercised the management API across types.** A type could be registered and reachable
  while its update silently failed to persist, and the suite would stay green.

## What's in it

**The contract** (`tests/datasource/fluent/crud_contract.py`) — a parameter table declaring, per
type, the arguments that create it and an overlay that produces a materially different datasource
of the same type. It imports only the standard library, so it stays loadable in the fastest lane,
and its accessors are immutable because other checks read them.

**The cases** (`test_crud_contract.py`) — eight cases per type, parameterized over the live
registry rather than a written list, so registering a new type exercises it with no edit here.
Connection testing is neutralized on the concrete registered class, which is stated wherever a
reader meets it: **a passing case asserts the API contract, never that the service behind the type
is reachable.** The cases therefore run with no Spark distribution, no cloud SDK, no Power BI
runtime and no SQL driver installed.

**Guards** — the table cannot drift from the registry unnoticed: a stale entry, an empty
derivation, a drifting count, an unpublished exclusion key, or a type excluded from every case
each fail by name.

**The stubs** (`sources.pyi`, +148/-0) — the nineteen missing declarations, mirroring the type
each most closely resembles. Plus a drift check that derives what the stub should declare from
the live registry and parses the stub rather than importing it, so this gap cannot reopen.

**The tier** — one new support tier asserting the contract holds for every fluent type a data
source is reached through. Seventeen records claim it: exactly those declaring both a marker and
a CI lane.

## Scope

- Exactly one file under `great_expectations/` changes, additively: the type stub. No runtime
  module, no behavior, no deprecation status.
- No marker, required-marker entry, workflow job or matrix entry added, removed or re-scoped.
- No field added to the data source record schema, no accessor added to its registry.
- The existing delete-persistence expected failure is untouched.
- One existing test file changed: control literals that pin declarations move with the
  declarations they pin, and one test whose premise ("no declaration-only record claims a tier")
  the new tier deliberately makes false is rewritten to assert what is now true.

## A deliberate limitation, stated plainly

This tier is **not a reachability claim**, and its description says so. The suite that earns it
runs with connection testing neutralized, so a data source can satisfy the tier and be
unreachable. Conflating the two would make the tier read as a support claim it does not support.

## Verification

- Type check clean across 787 source files.
- Contract and stub-drift suites: 238 passed, 3 skipped. Registry, wiring and tier: 289 passed,
  69 skipped. `-m filesystem`: 116 passed.
- Marker coverage, lint and format gates all clean.
- **Every assertion added here was observed failing against a deliberately broken subject**, with
  the eight contract cases broken at the product rather than in the test, so each is shown to pin
  real behavior. One assertion is recorded as partially proven: the persisted-entry count reds for
  absence but cannot detect duplication, because the store is keyed by name.
- Sixteen failures in `tests/datasource/fluent/` are pre-existing and unrelated (azure/gcs/spark
  modules); the same node IDs fail identically at `develop`.