### PR TITLE
[BUGFIX] Make ExpectColumnValueZScoresToBeLessThan pass rather than fail or raise on zero or undefined variance

### DIFF
--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_z_score.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_z_score.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
+import numpy as np
+import pandas as pd
+
 from great_expectations.compatibility.pyspark import functions as F
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.compatibility.typing_extensions import override
@@ -22,8 +25,6 @@ from great_expectations.expectations.metrics.map_metric_provider import (
 from great_expectations.validator.metric_configuration import MetricConfiguration
 
 if TYPE_CHECKING:
-    import pandas as pd
-
     from great_expectations.expectations.expectation_configuration import (
         ExpectationConfiguration,
     )
@@ -45,6 +46,13 @@ class ColumnValuesZScore(ColumnMapMetricProvider):
         # return the z_score values
         mean = _metrics.get("column.mean")
         std_dev = _metrics.get("column.standard_deviation")
+
+        # std_dev is an already-resolved Python scalar, so the divide-by-zero (constant
+        # column) and undefined (None) cases can be decided here rather than per row.
+        # Dividing by zero would yield NaN/Infinity, so return an undefined z-score in
+        # those cases, matching the SqlAlchemy and Spark implementations.
+        if std_dev is None or std_dev == 0:
+            return pd.Series(np.nan, index=column.index)
         try:
             return (column - mean) / std_dev
         except TypeError:
@@ -61,7 +69,10 @@ class ColumnValuesZScore(ColumnMapMetricProvider):
                 under_threshold = z_score.abs() < abs(threshold)
             else:
                 under_threshold = z_score < threshold
-            return under_threshold
+            # An undefined z-score (constant column) compares False against any threshold,
+            # which would flag every row as an outlier. Treat it as meeting the expectation
+            # instead, matching the NULL comparison semantics of the SQL implementation.
+            return under_threshold | z_score.isna()
         except TypeError:
             raise (TypeError("Cannot check if a string lies under a numerical threshold"))  # noqa: TRY003 # FIXME CoP
 
@@ -69,6 +80,16 @@ class ColumnValuesZScore(ColumnMapMetricProvider):
     def _sqlalchemy_function(cls, column, _metrics, _dialect, **kwargs):
         mean = _metrics["column.mean"]
         standard_deviation = _metrics["column.standard_deviation"]
+
+        # standard_deviation is an already-resolved Python scalar, so the divide-by-zero
+        # (constant column) and undefined (None) cases can be decided here rather than
+        # delegated to the database. Dialects disagree on division by zero -- Postgres,
+        # SQL Server and friends raise, while SQLite and MySQL return NULL -- so decide
+        # it here to keep every data source consistent. The NULL is cast to a numeric
+        # type because dialects such as Postgres cannot resolve abs() over an untyped
+        # NULL.
+        if standard_deviation is None or standard_deviation == 0:
+            return sa.cast(sa.null(), sa.Float)
         return (column - mean) / standard_deviation
 
     @column_condition_partial(engine=SqlAlchemyExecutionEngine)

--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_z_score.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_z_score.py
@@ -47,10 +47,17 @@ class ColumnValuesZScore(ColumnMapMetricProvider):
         mean = _metrics.get("column.mean")
         std_dev = _metrics.get("column.standard_deviation")
 
-        # std_dev is an already-resolved Python scalar, so the divide-by-zero (constant
-        # column) and undefined (None) cases can be decided here rather than per row.
-        # Dividing by zero would yield NaN/Infinity, so return an undefined z-score in
-        # those cases, matching the SqlAlchemy and Spark implementations.
+        # Only the divide-by-zero (constant column) case is decided here. std_dev comes
+        # from column.std(), which is ddof=1 and returns NaN -- never None -- for a column
+        # with fewer than two non-null values, so the None limb is unreachable on this
+        # engine. It is kept because the shared guard reads the same on all three, and
+        # because on SQL the aggregate passes through convert_to_json_serializable, which
+        # maps NaN to None; there the limb catches both n<2 and a NaN aggregate.
+        #
+        # The guard is still load-bearing here: on an object-dtype column
+        # (column - mean) / 0.0 raises ZeroDivisionError rather than producing NaN.
+        # Undefined variance that does reach the division falls through to
+        # _pandas_condition, which accepts a NaN z-score rather than flagging every row.
         if std_dev is None or std_dev == 0:
             return pd.Series(np.nan, index=column.index)
         try:
@@ -69,9 +76,14 @@ class ColumnValuesZScore(ColumnMapMetricProvider):
                 under_threshold = z_score.abs() < abs(threshold)
             else:
                 under_threshold = z_score < threshold
-            # An undefined z-score (constant column) compares False against any threshold,
-            # which would flag every row as an outlier. Treat it as meeting the expectation
-            # instead, matching the NULL comparison semantics of the SQL implementation.
+            # An undefined z-score compares False against any threshold, which would flag
+            # every row as an outlier. Treat it as meeting the expectation instead,
+            # matching the NULL comparison semantics of the SQL implementation. This is
+            # where undefined variance is resolved on pandas whenever the guard above did
+            # not catch it -- a NaN std_dev from fewer than two non-null values, or from a
+            # column containing inf -- as well as a constant column of numeric dtype.
+            # Required regardless of how wide that guard is, since _pandas_function
+            # returns an all-NaN series and NaN < threshold is False.
             return under_threshold | z_score.isna()
         except TypeError:
             raise (TypeError("Cannot check if a string lies under a numerical threshold"))  # noqa: TRY003 # FIXME CoP

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_value_z_scores_to_be_less_than.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_value_z_scores_to_be_less_than.py
@@ -4,6 +4,9 @@ import pandas as pd
 import pytest
 
 import great_expectations.expectations as gxe
+from great_expectations.core.expectation_validation_result import (
+    ExpectationValidationResult,
+)
 from great_expectations.core.result_format import ResultFormat
 from great_expectations.datasource.fluent.interfaces import Batch
 from tests.integration.conftest import parameterize_batch_for_data_sources
@@ -12,6 +15,7 @@ from tests.integration.data_sources_and_expectations.data_source_lists import (
     NON_SQL_DATA_SOURCES,
 )
 from tests.integration.test_utils.data_source_config import (
+    ALL_DATA_SOURCES,
     SQL_DATA_SOURCES,
     PostgreSQLDatasourceTestConfig,
 )
@@ -20,6 +24,8 @@ BASIC_COL = "basic"
 DISTRIBUTION_WITH_OUTLIER = "with_outlier"
 MOSTLY_ZERO_DISTRIBUTION = "mostly_zero"
 DISTRIBUTION_WITH_NULLS = "lotta_nulls"
+CONSTANT_COL = "constant"
+CONSTANT_COL_WITH_NULLS = "constant_with_nulls"
 
 DATA = pd.DataFrame(
     {
@@ -27,9 +33,21 @@ DATA = pd.DataFrame(
         DISTRIBUTION_WITH_OUTLIER: [-1000000, -1, 0, 1, 1],
         MOSTLY_ZERO_DISTRIBUTION: [1, 0, 0, 0, 0],
         DISTRIBUTION_WITH_NULLS: [-1, 0, 1, None, None],
+        CONSTANT_COL: [5, 5, 5, 5, 5],
+        CONSTANT_COL_WITH_NULLS: [5, 5, 5, None, None],
     },
     dtype="object",
 )
+
+
+def _assert_no_metric_exceptions(result: ExpectationValidationResult) -> None:
+    """Fail loudly if any metric raised instead of producing a value."""
+    exception_info = result.exception_info or {}
+    if "raised_exception" in exception_info:
+        assert not exception_info["raised_exception"], exception_info
+    else:
+        for info in exception_info.values():
+            assert not (info or {}).get("raised_exception"), info
 
 
 @parameterize_batch_for_data_sources(data_source_configs=NON_SQL_DATA_SOURCES, data=DATA)
@@ -191,3 +209,37 @@ def test_include_unexpected_rows_sql(batch_for_datasource: Batch) -> None:
     # Check that "-1000000" appears in the unexpected rows data
     unexpected_rows_str = str(unexpected_rows_data)
     assert "-1000000" in unexpected_rows_str
+
+
+@pytest.mark.parametrize(
+    "column",
+    [
+        pytest.param(CONSTANT_COL, id="constant_column"),
+        pytest.param(CONSTANT_COL_WITH_NULLS, id="constant_column_with_nulls"),
+    ],
+)
+@parameterize_batch_for_data_sources(data_source_configs=ALL_DATA_SOURCES, data=DATA)
+def test_zero_standard_deviation_is_consistent_across_data_sources(
+    batch_for_datasource: Batch,
+    column: str,
+) -> None:
+    """A column with no variance must produce the same verdict on every backend.
+
+    The z-score of a constant column divides by a standard deviation of zero, and the
+    backends disagree about what that means: Postgres and SQL Server raise, SQLite and
+    MySQL return NULL, Spark returns Infinity (or raises under ANSI), and pandas produces
+    NaN. Left to the backend, the same data yielded a raised exception on some data
+    sources, a silent pass on others, and every row flagged as an outlier on pandas.
+
+    A constant column has no outliers, so the expectation succeeds with nothing
+    unexpected -- and, critically, does so identically everywhere.
+    """
+    expectation = gxe.ExpectColumnValueZScoresToBeLessThan(
+        column=column, threshold=1.96, double_sided=True
+    )
+    result = batch_for_datasource.validate(expectation, result_format=ResultFormat.COMPLETE)
+
+    _assert_no_metric_exceptions(result)
+    assert result.success
+    assert result.result["unexpected_count"] == 0
+    assert result.result["unexpected_list"] == []

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_value_z_scores_to_be_less_than.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_value_z_scores_to_be_less_than.py
@@ -267,9 +267,14 @@ def test_zero_standard_deviation_is_consistent_across_data_sources(
     assert result.result["unexpected_list"] == []
 
 
-# SQLite is excluded: its `stddev` user-defined function raises outright on fewer than two
-# non-null values, so it never reaches the z-score metric at all. That is a pre-existing
-# defect in `column.standard_deviation`, unrelated to this change and recorded separately.
+# SQLite sits out the parameterization below: its `stddev` user-defined function raises outright
+# on fewer than two non-null values, so it never reaches the z-score metric at all. That is a
+# pre-existing defect in `column.standard_deviation`, upstream of anything this change touches.
+#
+# The exclusion is paired with `test_undefined_standard_deviation_on_sqlite` rather than left to
+# stand on its own. A list that simply omits a backend keeps omitting it forever, including after
+# the reason has gone away and nobody has any prompt to notice; running the case as a strict xfail
+# keeps the gap visible in the test report and makes the exclusion expire by itself.
 UNDEFINED_VARIANCE_DATA_SOURCES: Sequence[DataSourceTestConfig] = [
     config for config in ALL_DATA_SOURCES if not isinstance(config, SqliteDatasourceTestConfig)
 ]
@@ -288,6 +293,34 @@ def test_undefined_standard_deviation_is_consistent_across_data_sources(
     resolves it in `_pandas_condition` rather than in the guard.
 
     A column that cannot have outliers must not report any, whichever of those paths runs.
+    """
+    expectation = gxe.ExpectColumnValueZScoresToBeLessThan(
+        column=SINGLE_NON_NULL_VALUE, threshold=1.96, double_sided=True
+    )
+    result = batch_for_datasource.validate(expectation, result_format=ResultFormat.COMPLETE)
+
+    _assert_no_metric_exceptions(result)
+    assert result.success
+    assert result.result["unexpected_count"] == 0
+    assert result.result["unexpected_list"] == []
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "SQLite's `stddev` user-defined function raises on fewer than two non-null values, so "
+        "`column.standard_deviation` fails before the z-score metric is reached. Pre-existing, "
+        "and upstream of the guards this module covers."
+    ),
+)
+@parameterize_batch_for_data_sources(data_source_configs=[SqliteDatasourceTestConfig()], data=DATA)
+def test_undefined_standard_deviation_on_sqlite(batch_for_datasource: Batch) -> None:
+    """The one case SQLite sits out above, kept executable rather than dropped.
+
+    The assertions are the ones the shared test makes, so this states what SQLite would have to
+    do to rejoin that parameterization. It is strict on purpose: the day the aggregate stops
+    raising, this passes, pytest fails the run for passing, and whoever fixed it is told that
+    the exclusion above is no longer earned. An omission from a list reports nothing at all.
     """
     expectation = gxe.ExpectColumnValueZScoresToBeLessThan(
         column=SINGLE_NON_NULL_VALUE, threshold=1.96, double_sided=True

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_value_z_scores_to_be_less_than.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_value_z_scores_to_be_less_than.py
@@ -30,6 +30,7 @@ DISTRIBUTION_WITH_NULLS = "lotta_nulls"
 CONSTANT_COL = "constant"
 CONSTANT_COL_WITH_NULLS = "constant_with_nulls"
 SINGLE_NON_NULL_VALUE = "single_non_null_value"
+INFINITY_COL = "with_infinity"
 
 DATA = pd.DataFrame(
     {
@@ -45,6 +46,18 @@ DATA = pd.DataFrame(
     },
     dtype="object",
 )
+
+# Deliberately separate frames rather than more columns on DATA.
+#
+# NUMERIC_DTYPE_DATA exists because DATA is built with dtype="object", and the dtype
+# decides which path a constant column takes on pandas: object raises ZeroDivisionError
+# from (column - mean) / 0.0, while a numeric dtype yields NaN. Only the first is covered
+# by the tests above.
+NUMERIC_DTYPE_DATA = pd.DataFrame({CONSTANT_COL: [5.0, 5.0, 5.0, 5.0, 5.0]})
+
+# INFINITY_DATA is separate because not every backend can store a floating-point infinity,
+# and a column here would break every other test on those.
+INFINITY_DATA = pd.DataFrame({INFINITY_COL: [1.0, 2.0, 3.0, float("inf")]})
 
 
 def _assert_no_metric_exceptions(result: ExpectationValidationResult) -> None:
@@ -285,3 +298,54 @@ def test_undefined_standard_deviation_is_consistent_across_data_sources(
     assert result.success
     assert result.result["unexpected_count"] == 0
     assert result.result["unexpected_list"] == []
+
+
+@parameterize_batch_for_data_sources(
+    data_source_configs=JUST_PANDAS_DATA_SOURCES, data=NUMERIC_DTYPE_DATA
+)
+def test_zero_standard_deviation_on_a_numeric_dtype_column(batch_for_datasource: Batch) -> None:
+    """A constant column reaches the same verdict whatever its pandas dtype.
+
+    The two dtypes take different paths: on an object-dtype column
+    (column - mean) / 0.0 raises ZeroDivisionError, and on a numeric one it yields NaN
+    that the isna() limb in _pandas_condition accepts. Every column in DATA is object
+    dtype, so without this the numeric path is untested.
+    """
+    expectation = gxe.ExpectColumnValueZScoresToBeLessThan(
+        column=CONSTANT_COL, threshold=1.96, double_sided=True
+    )
+    result = batch_for_datasource.validate(expectation, result_format=ResultFormat.COMPLETE)
+
+    _assert_no_metric_exceptions(result)
+    assert result.success
+    assert result.result["unexpected_count"] == 0
+
+
+# pandas only. The SQL engines cannot reach this metric at all with an infinite value:
+# `column.mean` raises decimal.InvalidOperation on PostgreSQL, from convert_decimal_to_float
+# handling a Decimal("Infinity"). That divergence is upstream of the z-score metric, in the
+# aggregate metrics, and is not something this change reaches.
+@pytest.mark.filterwarnings("ignore:invalid value encountered in subtract:RuntimeWarning")
+@parameterize_batch_for_data_sources(
+    data_source_configs=JUST_PANDAS_DATA_SOURCES, data=INFINITY_DATA
+)
+def test_infinite_value_has_no_defined_z_score(batch_for_datasource: Batch) -> None:
+    """An infinite value makes the variance undefined, so no row can be an outlier.
+
+    Series.std() returns NaN for a column containing inf -- not zero, and not None -- so
+    this input clears the guard in _pandas_function entirely and is resolved by the isna()
+    limb in _pandas_condition instead. Before this fix every row was reported as an
+    outlier, because NaN compares False against any threshold.
+
+    The warning filter is needed because numpy emits "invalid value encountered in
+    subtract" computing the variance, and this suite promotes warnings to errors, which
+    would otherwise fail inside column.standard_deviation before the z-score metric ran.
+    """
+    expectation = gxe.ExpectColumnValueZScoresToBeLessThan(
+        column=INFINITY_COL, threshold=1.96, double_sided=True
+    )
+    result = batch_for_datasource.validate(expectation, result_format=ResultFormat.COMPLETE)
+
+    _assert_no_metric_exceptions(result)
+    assert result.success
+    assert result.result["unexpected_count"] == 0

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_value_z_scores_to_be_less_than.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_value_z_scores_to_be_less_than.py
@@ -1,3 +1,4 @@
+from typing import Sequence
 from unittest.mock import ANY
 
 import pandas as pd
@@ -17,7 +18,9 @@ from tests.integration.data_sources_and_expectations.data_source_lists import (
 from tests.integration.test_utils.data_source_config import (
     ALL_DATA_SOURCES,
     SQL_DATA_SOURCES,
+    DataSourceTestConfig,
     PostgreSQLDatasourceTestConfig,
+    SqliteDatasourceTestConfig,
 )
 
 BASIC_COL = "basic"
@@ -26,6 +29,7 @@ MOSTLY_ZERO_DISTRIBUTION = "mostly_zero"
 DISTRIBUTION_WITH_NULLS = "lotta_nulls"
 CONSTANT_COL = "constant"
 CONSTANT_COL_WITH_NULLS = "constant_with_nulls"
+SINGLE_NON_NULL_VALUE = "single_non_null_value"
 
 DATA = pd.DataFrame(
     {
@@ -35,6 +39,9 @@ DATA = pd.DataFrame(
         DISTRIBUTION_WITH_NULLS: [-1, 0, 1, None, None],
         CONSTANT_COL: [5, 5, 5, 5, 5],
         CONSTANT_COL_WITH_NULLS: [5, 5, 5, None, None],
+        # One non-null value, so the sample standard deviation is undefined rather than
+        # zero. This is the input that reaches the guards' `is None` limb on SQL.
+        SINGLE_NON_NULL_VALUE: [5, None, None, None, None],
     },
     dtype="object",
 )
@@ -226,16 +233,51 @@ def test_zero_standard_deviation_is_consistent_across_data_sources(
     """A column with no variance must produce the same verdict on every backend.
 
     The z-score of a constant column divides by a standard deviation of zero, and the
-    backends disagree about what that means: Postgres and SQL Server raise, SQLite and
-    MySQL return NULL, Spark returns Infinity (or raises under ANSI), and pandas produces
-    NaN. Left to the backend, the same data yielded a raised exception on some data
-    sources, a silent pass on others, and every row flagged as an outlier on pandas.
+    backends disagree about what that means: Postgres and SQL Server raise; SQLite, MySQL
+    and Spark return NULL, with Spark raising instead under
+    ``spark.sql.ansi.enabled=true``; and pandas either produces NaN or raises
+    ZeroDivisionError depending on the column's dtype. Left to the backend, the same data
+    yielded a raised exception on some data sources, a silent pass on others, and every
+    row flagged as an outlier on pandas.
 
     A constant column has no outliers, so the expectation succeeds with nothing
     unexpected -- and, critically, does so identically everywhere.
     """
     expectation = gxe.ExpectColumnValueZScoresToBeLessThan(
         column=column, threshold=1.96, double_sided=True
+    )
+    result = batch_for_datasource.validate(expectation, result_format=ResultFormat.COMPLETE)
+
+    _assert_no_metric_exceptions(result)
+    assert result.success
+    assert result.result["unexpected_count"] == 0
+    assert result.result["unexpected_list"] == []
+
+
+# SQLite is excluded: its `stddev` user-defined function raises outright on fewer than two
+# non-null values, so it never reaches the z-score metric at all. That is a pre-existing
+# defect in `column.standard_deviation`, unrelated to this change and recorded separately.
+UNDEFINED_VARIANCE_DATA_SOURCES: Sequence[DataSourceTestConfig] = [
+    config for config in ALL_DATA_SOURCES if not isinstance(config, SqliteDatasourceTestConfig)
+]
+
+
+@parameterize_batch_for_data_sources(data_source_configs=UNDEFINED_VARIANCE_DATA_SOURCES, data=DATA)
+def test_undefined_standard_deviation_is_consistent_across_data_sources(
+    batch_for_datasource: Batch,
+) -> None:
+    """Undefined variance must reach the same verdict as zero variance.
+
+    The sample standard deviation of a single value is undefined, not zero, so this input
+    misses the `== 0` arm of the guards that the constant-column test covers and exercises
+    the dialect-dependent half instead. Postgres, Spark and BigQuery return NULL from
+    `stddev_samp` here, which arrives as None; pandas gets NaN from `Series.std()` and
+    resolves it in `_pandas_condition` rather than in the guard.
+
+    A column that cannot have outliers must not report any, whichever of those paths runs.
+    """
+    expectation = gxe.ExpectColumnValueZScoresToBeLessThan(
+        column=SINGLE_NON_NULL_VALUE, threshold=1.96, double_sided=True
     )
     result = batch_for_datasource.validate(expectation, result_format=ResultFormat.COMPLETE)
 


### PR DESCRIPTION
Closes #12144

## Summary

`ExpectColumnValueZScoresToBeLessThan` computes `(column - mean) / std_dev`. When a
column is constant its standard deviation is zero, and each backend was left to decide
what that division means. They disagree, so the same data produced three different
verdicts depending only on where it was stored.

Reproduced locally against SQLite and a live PostgreSQL instance, on a constant column
`[5, 5, 5, 5, 5]` with `threshold=1.96, double_sided=True`:

| Backend | Before | After |
| --- | --- | --- |
| Pandas | `success=False`, 5/5 rows flagged as outliers | `success=True`, `unexpected_count=0` |
| SQLite / MySQL | `success=True`, `unexpected_count=0` (silent) | unchanged |
| PostgreSQL / SQL Server | `psycopg2.errors.DivisionByZero` in `exception_info` | `success=True`, `unexpected_count=0` |
| Spark | already guarded | unchanged |

The pandas case is arguably the worst of the three: NaN compares `False` against any
threshold, so every row of a constant column is reported as an outlier. That looks like
a legitimate result rather than a failure, so nothing signals that anything went wrong.

## Behavior change on pandas

Flagging this for the changelog, per review. The `| z_score.isna()` limb in
`_pandas_condition` accepts every undefined z-score, so this affects three input classes
on pandas, not only the constant column this PR is named for. Measured against `develop`
with `threshold=1.96, double_sided=True`:

| Input | pandas before | pandas after |
| --- | --- | --- |
| constant column, object dtype | raised `ZeroDivisionError`, empty result | `success=True`, 0 unexpected |
| constant column, numeric dtype | `success=False`, 5/5 unexpected | `success=True`, 0 unexpected |
| single-row column | `success=False`, 1/1 unexpected | `success=True`, 0 unexpected |
| column containing `inf` | `success=False`, 4/4 unexpected | `success=True`, 0 unexpected |

The last two arise because `Series.std()` is `ddof=1` and returns `NaN` -- not `0`, not
`None` -- for fewer than two non-null values and for a column containing `inf`. Those
clear the guard in `_pandas_function` and are resolved in `_pandas_condition` instead.

The constant-column row splits by dtype because `(column - mean) / 0.0` raises on an
object-dtype column and yields `NaN` on a numeric one. The integration harness builds
`DATA` with `dtype="object"`, so it takes the raising path.

**Anyone relying on this Expectation to catch a stuck or constant column will stop
getting a failure.** It never detected that deliberately -- the failure came from `NaN`
comparing `False` -- but the change is real and worth stating.
`ExpectColumnStdevToBeBetween` with a non-zero `min_value` is the check that actually
tests for zero variance.

## Fix

`std_dev` arrives as an already-resolved Python scalar on every execution engine, so the
zero and `None` cases can be decided before the division is handed to the backend.

Spark already did exactly this — added in #11969 for Spark 4, whose ANSI mode raises on
division by zero. This applies the same guard to the SqlAlchemy and pandas
implementations, so all four engines now agree.

A constant column has no outliers, which makes "succeeds with nothing unexpected" the
right verdict as well as a uniform one.

Two details worth a reviewer's attention:

- The SQL `NULL` is cast to a numeric type (`sa.cast(sa.null(), sa.Float)`). A bare
  `NULL` trades one PostgreSQL error for another, because PostgreSQL cannot resolve
  `abs()` over an untyped `NULL`.
- On pandas, an undefined z-score is treated as meeting the expectation, to match SQL's
  `NULL` comparison semantics. The guard alone is not sufficient there: `NaN` compares
  `False` and would still flag the entire column.

## Testing

Adds `test_zero_standard_deviation_is_consistent_across_data_sources`, parameterized
over `ALL_DATA_SOURCES`, covering a constant column and a constant column containing
nulls. It asserts no metric raised, `success`, and `unexpected_count == 0`.

Verified the new test **fails** on pandas and PostgreSQL without the source change, and
passes on all locally available backends (pandas-data-frame, pandas-filesystem-csv,
sqlite, postgresql) with it.

Also ran the full `tests/integration/data_sources_and_expectations/` suite before and
after the change and diffed the results: an identical failure set, so no regressions.
`ruff check`, `ruff format --check` and `mypy` are clean on both files.

I was not able to run the Spark, MySQL, SQL Server, BigQuery, Snowflake, Databricks or
Redshift backends locally, so those paths rely on CI.

## Notes for reviewers

**A design question you may want to weigh in on.** The behaviour after this change is
still a "pass" on a zero-variance column, now deliberate and identical everywhere rather
than backend-dependent. It follows the precedent already set for Spark. It does not,
however, give the user an explicit signal that the standard deviation was zero. If
maintainers would prefer a louder signal (a raised exception, or a warning in `meta`),
that is a larger behavioural decision and I am happy to follow up separately — the
consistency fix stands either way.

**A separate pre-existing bug found while testing, deliberately left out of scope.** On
SQLite, a single-row column fails with
`sqlite3.OperationalError: user-defined function raised exception`, because its
`stddev` UDF cannot handle a one-value sample. This fails inside
`column.standard_deviation`, before the z-score metric runs, so it is unrelated to this
change. Happy to open a separate issue for it.


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)