### PR TITLE
[MAINTENANCE] Say what the shared fixture column types mean

### DIFF
--- a/tests/integration/data_sources_and_expectations/test_fixture_column_round_trip.py
+++ b/tests/integration/data_sources_and_expectations/test_fixture_column_round_trip.py
@@ -7,9 +7,9 @@ about a value quietly becomes an assertion about a different value.
 
 The shapes below are the ones that have actually broken. A decimal type carrying no scale is read
 by several servers as scale zero, which rounds every fractional value to an integer on write. A
-float type carrying no width is read by at least one server as its 4-byte type, which stores a
-Python float -- a double -- at half the width it was declared at. A datetime type that a server
-does not have makes the table impossible to create at all.
+float type carrying no width is read by some servers as their 4-byte type, which stores a Python
+float -- a double -- at half the width it was declared at. A datetime type that a server does not
+have makes the table impossible to create at all.
 """
 
 from __future__ import annotations
@@ -27,11 +27,28 @@ from tests.integration.data_sources_and_expectations.data_source_lists import (
 )
 from tests.integration.test_utils.data_source_config import (
     ALL_DATA_SOURCES,
+    CURATED_SQL_DATA_SOURCES,
     SQL_DATA_SOURCES,
 )
 
 if TYPE_CHECKING:
     from great_expectations.datasource.fluent.interfaces import Batch
+
+# Every data source the harness declares, not just the canonical-expectations tier. The curated
+# tier's four backends are where the shared type map is overridden most, and reaching them found
+# SingleStore storing a declared value narrowed -- a defect no lane would otherwise have run into.
+#
+# Read from the tier lists directly rather than through `data_sources_for_tier_case`, which
+# `test_curated_backend_suite.py` requires of its own cases so that a member can sit one out. That
+# mechanism is for a case a backend legitimately cannot pass, and no such case exists here: a
+# backend that does not store what a fixture declared has a defect to fix, not a case to opt out
+# of. Keyed by label on the way in, so a data source declaring both tiers is parameterized once.
+EVERY_DATA_SOURCE = list(
+    {config.label: config for config in [*ALL_DATA_SOURCES, *CURATED_SQL_DATA_SOURCES]}.values()
+)
+EVERY_SQL_DATA_SOURCE = list(
+    {config.label: config for config in [*SQL_DATA_SOURCES, *CURATED_SQL_DATA_SOURCES]}.values()
+)
 
 FRACTIONAL_COL = "fractional_value"
 MOMENT_COL = "moment"
@@ -74,7 +91,7 @@ ROUND_TRIP_DATA = pd.DataFrame(
 )
 
 
-@parameterize_batch_for_data_sources(data_source_configs=ALL_DATA_SOURCES, data=ROUND_TRIP_DATA)
+@parameterize_batch_for_data_sources(data_source_configs=EVERY_DATA_SOURCE, data=ROUND_TRIP_DATA)
 def test_the_largest_fractional_value_is_stored_as_declared(batch_for_datasource: Batch) -> None:
     """A column narrowed to single precision returns a neighbour of the declared maximum."""
     result = batch_for_datasource.validate(
@@ -91,7 +108,7 @@ def test_the_largest_fractional_value_is_stored_as_declared(batch_for_datasource
     )
 
 
-@parameterize_batch_for_data_sources(data_source_configs=ALL_DATA_SOURCES, data=ROUND_TRIP_DATA)
+@parameterize_batch_for_data_sources(data_source_configs=EVERY_DATA_SOURCE, data=ROUND_TRIP_DATA)
 def test_the_smallest_fractional_value_is_stored_as_declared(batch_for_datasource: Batch) -> None:
     """A column stored at scale zero rounds the declared minimum to an integer."""
     result = batch_for_datasource.validate(
@@ -108,7 +125,7 @@ def test_the_smallest_fractional_value_is_stored_as_declared(batch_for_datasourc
     )
 
 
-@parameterize_batch_for_data_sources(data_source_configs=ALL_DATA_SOURCES, data=ROUND_TRIP_DATA)
+@parameterize_batch_for_data_sources(data_source_configs=EVERY_DATA_SOURCE, data=ROUND_TRIP_DATA)
 def test_a_datetime_column_can_be_created_and_read(batch_for_datasource: Batch) -> None:
     """Reaching this assertion at all is most of the point: a backend whose type vocabulary
     does not include the declared datetime type fails during table creation, before any
@@ -122,7 +139,9 @@ def test_a_datetime_column_can_be_created_and_read(batch_for_datasource: Batch) 
     assert result.success
 
 
-@parameterize_batch_for_data_sources(data_source_configs=SQL_DATA_SOURCES, data=ROUND_TRIP_DATA)
+@parameterize_batch_for_data_sources(
+    data_source_configs=EVERY_SQL_DATA_SOURCE, data=ROUND_TRIP_DATA
+)
 def test_a_datetime_value_is_stored_as_declared(batch_for_datasource: Batch) -> None:
     """The declared maximum is a specific moment, not just a non-null one.
 
@@ -130,7 +149,7 @@ def test_a_datetime_value_is_stored_as_declared(batch_for_datasource: Batch) -> 
     in it. A type that resolves to a date rather than a datetime accepts the write and drops the
     time of day, which is not null and so passes every assertion above.
 
-    The SQL data sources rather than all of them, because the column type map this pins is a SQL
+    The SQL data sources rather than every one, because the column type map this pins is a SQL
     declaration: a CSV-backed source reads the column back as text no matter what any type map
     says, and comparing text to a datetime would fail here for a reason that has nothing to do
     with what this file is about.

--- a/tests/integration/data_sources_and_expectations/test_fixture_column_round_trip.py
+++ b/tests/integration/data_sources_and_expectations/test_fixture_column_round_trip.py
@@ -1,0 +1,70 @@
+"""What a fixture frame declares is what the backend must store.
+
+Every assertion in this directory rests on an unstated assumption: that the values a test
+declares in a pandas frame are the values the backend holds once the harness has written them.
+Where that fails it fails silently -- the DDL is valid, no error is raised, and an assertion
+about a value quietly becomes an assertion about a different value.
+
+The two shapes below are the ones that have actually broken. A decimal type carrying no scale
+is read by several servers as scale zero, which rounds every fractional value to an integer on
+write. A datetime type that a server does not have makes the table impossible to create at all.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+import great_expectations.expectations as gxe
+from great_expectations.core.result_format import ResultFormat
+from tests.integration.conftest import parameterize_batch_for_data_sources
+from tests.integration.test_utils.data_source_config import ALL_DATA_SOURCES
+
+if TYPE_CHECKING:
+    from great_expectations.datasource.fluent.interfaces import Batch
+
+FRACTIONAL_COL = "fractional_value"
+MOMENT_COL = "moment"
+
+# A fractional part that survives no rounding: every value here differs from its nearest
+# integer, so a backend storing these at scale zero cannot coincidentally agree.
+ROUND_TRIP_DATA = pd.DataFrame(
+    {
+        FRACTIONAL_COL: [1.5, 2.25, -3.75],
+        # Deliberately naive. Whether a tz-aware value survives the round trip is a separate
+        # question with its own failure mode, and pinning it here would conflate the two.
+        MOMENT_COL: pd.to_datetime(
+            ["2024-01-01 12:00:00", "2024-01-02 12:00:00", "2024-01-03 12:00:00"]
+        ),
+    }
+)
+
+
+@parameterize_batch_for_data_sources(data_source_configs=ALL_DATA_SOURCES, data=ROUND_TRIP_DATA)
+def test_a_fractional_value_is_stored_as_declared(batch_for_datasource: Batch) -> None:
+    """The largest value is 2.25. A backend that rounds to scale zero observes 2."""
+    result = batch_for_datasource.validate(
+        gxe.ExpectColumnMaxToBeBetween(column=FRACTIONAL_COL, min_value=2.25, max_value=2.25),
+        result_format=ResultFormat.COMPLETE,
+    )
+
+    observed = result.result.get("observed_value")
+    assert result.success, (
+        f"the maximum of {FRACTIONAL_COL} came back as {observed!r} rather than 2.25, so the "
+        "column's declared values are not the values this backend stored"
+    )
+
+
+@parameterize_batch_for_data_sources(data_source_configs=ALL_DATA_SOURCES, data=ROUND_TRIP_DATA)
+def test_a_datetime_column_can_be_created_and_read(batch_for_datasource: Batch) -> None:
+    """Reaching this assertion at all is most of the point: a backend whose type vocabulary
+    does not include the declared datetime type fails during table creation, before any
+    expectation runs.
+    """
+    result = batch_for_datasource.validate(
+        gxe.ExpectColumnValuesToNotBeNull(column=MOMENT_COL),
+        result_format=ResultFormat.COMPLETE,
+    )
+
+    assert result.success

--- a/tests/integration/data_sources_and_expectations/test_fixture_column_round_trip.py
+++ b/tests/integration/data_sources_and_expectations/test_fixture_column_round_trip.py
@@ -12,6 +12,7 @@ write. A datetime type that a server does not have makes the table impossible to
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 import pandas as pd
@@ -19,6 +20,9 @@ import pandas as pd
 import great_expectations.expectations as gxe
 from great_expectations.core.result_format import ResultFormat
 from tests.integration.conftest import parameterize_batch_for_data_sources
+from tests.integration.data_sources_and_expectations.data_source_lists import (
+    SPARK_DATA_SOURCES,
+)
 from tests.integration.test_utils.data_source_config import ALL_DATA_SOURCES
 
 if TYPE_CHECKING:
@@ -32,10 +36,19 @@ MOMENT_COL = "moment"
 ROUND_TRIP_DATA = pd.DataFrame(
     {
         FRACTIONAL_COL: [1.5, 2.25, -3.75],
-        # Deliberately naive. Whether a tz-aware value survives the round trip is a separate
-        # question with its own failure mode, and pinning it here would conflate the two.
-        MOMENT_COL: pd.to_datetime(
-            ["2024-01-01 12:00:00", "2024-01-02 12:00:00", "2024-01-03 12:00:00"]
+        # Plain Python datetimes in an object column, deliberately, rather than a pandas
+        # datetime64 column. Two backends cannot take a pandas timestamp as a bound parameter
+        # at all, and one infers an empty struct for it rather than a time, so a frame built the
+        # convenient way would fail on them for reasons that have nothing to do with the column
+        # type under test here. Naive rather than tz-aware for the same reason: whether a
+        # timezone survives the trip is a separate question with its own failure mode.
+        MOMENT_COL: pd.Series(
+            [
+                datetime(2024, 1, 1, 12, 0, 0),  # noqa: DTZ001
+                datetime(2024, 1, 2, 12, 0, 0),  # noqa: DTZ001
+                datetime(2024, 1, 3, 12, 0, 0),  # noqa: DTZ001
+            ],
+            dtype=object,
         ),
     }
 )
@@ -61,6 +74,31 @@ def test_a_datetime_column_can_be_created_and_read(batch_for_datasource: Batch) 
     """Reaching this assertion at all is most of the point: a backend whose type vocabulary
     does not include the declared datetime type fails during table creation, before any
     expectation runs.
+    """
+    result = batch_for_datasource.validate(
+        gxe.ExpectColumnValuesToNotBeNull(column=MOMENT_COL),
+        result_format=ResultFormat.COMPLETE,
+    )
+
+    assert result.success
+
+
+# A pandas-native datetime column, which is what a frame built the convenient way holds. The
+# column above deliberately avoids this shape so that its own assertions are about the column
+# type the backend was given; this one exists to pin that the convenient shape works too.
+PANDAS_TIMESTAMP_DATA = pd.DataFrame(
+    {MOMENT_COL: pd.to_datetime(["2024-01-01 12:00:00", "2024-01-02 12:00:00"])}
+)
+
+
+@parameterize_batch_for_data_sources(
+    data_source_configs=SPARK_DATA_SOURCES, data=PANDAS_TIMESTAMP_DATA
+)
+def test_a_pandas_timestamp_column_is_written_as_a_time(batch_for_datasource: Batch) -> None:
+    """Spark infers a column's type from the values when a test declares none, and matches on
+    exact type. A pandas timestamp is a subclass rather than the type it looks for, so it reads
+    as an empty struct -- which no file format can write, and which fails during setup rather
+    than as an assertion. Reaching this assertion at all is the substance of the test.
     """
     result = batch_for_datasource.validate(
         gxe.ExpectColumnValuesToNotBeNull(column=MOMENT_COL),

--- a/tests/integration/data_sources_and_expectations/test_fixture_column_round_trip.py
+++ b/tests/integration/data_sources_and_expectations/test_fixture_column_round_trip.py
@@ -5,9 +5,11 @@ declares in a pandas frame are the values the backend holds once the harness has
 Where that fails it fails silently -- the DDL is valid, no error is raised, and an assertion
 about a value quietly becomes an assertion about a different value.
 
-The two shapes below are the ones that have actually broken. A decimal type carrying no scale
-is read by several servers as scale zero, which rounds every fractional value to an integer on
-write. A datetime type that a server does not have makes the table impossible to create at all.
+The shapes below are the ones that have actually broken. A decimal type carrying no scale is read
+by several servers as scale zero, which rounds every fractional value to an integer on write. A
+float type carrying no width is read by at least one server as its 4-byte type, which stores a
+Python float -- a double -- at half the width it was declared at. A datetime type that a server
+does not have makes the table impossible to create at all.
 """
 
 from __future__ import annotations
@@ -23,7 +25,10 @@ from tests.integration.conftest import parameterize_batch_for_data_sources
 from tests.integration.data_sources_and_expectations.data_source_lists import (
     SPARK_DATA_SOURCES,
 )
-from tests.integration.test_utils.data_source_config import ALL_DATA_SOURCES
+from tests.integration.test_utils.data_source_config import (
+    ALL_DATA_SOURCES,
+    SQL_DATA_SOURCES,
+)
 
 if TYPE_CHECKING:
     from great_expectations.datasource.fluent.interfaces import Batch
@@ -31,11 +36,25 @@ if TYPE_CHECKING:
 FRACTIONAL_COL = "fractional_value"
 MOMENT_COL = "moment"
 
-# A fractional part that survives no rounding: every value here differs from its nearest
-# integer, so a backend storing these at scale zero cannot coincidentally agree.
+# The largest and smallest values below each defeat a different silent substitution, and the
+# assertions pin exactly those two.
+#
+# `16777217.0` is the smallest positive integer a 4-byte float cannot represent: at 2**24 the
+# spacing between representable values is 2, so it sits midway between 16777216 and 16777218 and
+# resolves to a neighbour. A double holds it exactly. Nothing smaller in this column would do --
+# 1.5, 2.25 and -3.75 are all exactly representable at single precision, so a narrowed column
+# would round-trip them and agree.
+#
+# `-3.75` differs from its nearest integer, so a column a server read as scale zero returns -4.
+LARGEST_VALUE = 16777217.0
+SMALLEST_VALUE = -3.75
+
+# The last moment declared, which the datetime assertion pins the stored maximum against.
+LATEST_MOMENT = datetime(2024, 1, 4, 12, 34, 56)  # noqa: DTZ001
+
 ROUND_TRIP_DATA = pd.DataFrame(
     {
-        FRACTIONAL_COL: [1.5, 2.25, -3.75],
+        FRACTIONAL_COL: [1.5, 2.25, SMALLEST_VALUE, LARGEST_VALUE],
         # Plain Python datetimes in an object column, deliberately, rather than a pandas
         # datetime64 column. Two backends cannot take a pandas timestamp as a bound parameter
         # at all, and one infers an empty struct for it rather than a time, so a frame built the
@@ -47,6 +66,7 @@ ROUND_TRIP_DATA = pd.DataFrame(
                 datetime(2024, 1, 1, 12, 0, 0),  # noqa: DTZ001
                 datetime(2024, 1, 2, 12, 0, 0),  # noqa: DTZ001
                 datetime(2024, 1, 3, 12, 0, 0),  # noqa: DTZ001
+                LATEST_MOMENT,
             ],
             dtype=object,
         ),
@@ -55,17 +75,36 @@ ROUND_TRIP_DATA = pd.DataFrame(
 
 
 @parameterize_batch_for_data_sources(data_source_configs=ALL_DATA_SOURCES, data=ROUND_TRIP_DATA)
-def test_a_fractional_value_is_stored_as_declared(batch_for_datasource: Batch) -> None:
-    """The largest value is 2.25. A backend that rounds to scale zero observes 2."""
+def test_the_largest_fractional_value_is_stored_as_declared(batch_for_datasource: Batch) -> None:
+    """A column narrowed to single precision returns a neighbour of the declared maximum."""
     result = batch_for_datasource.validate(
-        gxe.ExpectColumnMaxToBeBetween(column=FRACTIONAL_COL, min_value=2.25, max_value=2.25),
+        gxe.ExpectColumnMaxToBeBetween(
+            column=FRACTIONAL_COL, min_value=LARGEST_VALUE, max_value=LARGEST_VALUE
+        ),
         result_format=ResultFormat.COMPLETE,
     )
 
     observed = result.result.get("observed_value")
     assert result.success, (
-        f"the maximum of {FRACTIONAL_COL} came back as {observed!r} rather than 2.25, so the "
-        "column's declared values are not the values this backend stored"
+        f"the maximum of {FRACTIONAL_COL} came back as {observed!r} rather than {LARGEST_VALUE}, "
+        "so this backend is storing the column at a narrower width than a Python float"
+    )
+
+
+@parameterize_batch_for_data_sources(data_source_configs=ALL_DATA_SOURCES, data=ROUND_TRIP_DATA)
+def test_the_smallest_fractional_value_is_stored_as_declared(batch_for_datasource: Batch) -> None:
+    """A column stored at scale zero rounds the declared minimum to an integer."""
+    result = batch_for_datasource.validate(
+        gxe.ExpectColumnMinToBeBetween(
+            column=FRACTIONAL_COL, min_value=SMALLEST_VALUE, max_value=SMALLEST_VALUE
+        ),
+        result_format=ResultFormat.COMPLETE,
+    )
+
+    observed = result.result.get("observed_value")
+    assert result.success, (
+        f"the minimum of {FRACTIONAL_COL} came back as {observed!r} rather than "
+        f"{SMALLEST_VALUE}, so this backend rounded the column's fractional part away"
     )
 
 
@@ -81,6 +120,40 @@ def test_a_datetime_column_can_be_created_and_read(batch_for_datasource: Batch) 
     )
 
     assert result.success
+
+
+@parameterize_batch_for_data_sources(data_source_configs=SQL_DATA_SOURCES, data=ROUND_TRIP_DATA)
+def test_a_datetime_value_is_stored_as_declared(batch_for_datasource: Batch) -> None:
+    """The declared maximum is a specific moment, not just a non-null one.
+
+    Creating the table proves the type exists; it does not prove the column holds what was put
+    in it. A type that resolves to a date rather than a datetime accepts the write and drops the
+    time of day, which is not null and so passes every assertion above.
+
+    The SQL data sources rather than all of them, because the column type map this pins is a SQL
+    declaration: a CSV-backed source reads the column back as text no matter what any type map
+    says, and comparing text to a datetime would fail here for a reason that has nothing to do
+    with what this file is about.
+
+    Pinned to the second, which is as fine as every backend here can hold in common: two of them
+    resolve `datetime` to a type with no sub-second component (T-SQL's `DATETIME` keeps about
+    3ms; MySQL's keeps none unless a fractional-seconds precision is declared on it), so a
+    declared microsecond would be rounded away on those two by design. Making the harness carry
+    sub-second values everywhere is a change to what those two backends declare, not to this
+    test, and belongs with that change.
+    """
+    result = batch_for_datasource.validate(
+        gxe.ExpectColumnMaxToBeBetween(
+            column=MOMENT_COL, min_value=LATEST_MOMENT, max_value=LATEST_MOMENT
+        ),
+        result_format=ResultFormat.COMPLETE,
+    )
+
+    observed = result.result.get("observed_value")
+    assert result.success, (
+        f"the maximum of {MOMENT_COL} came back as {observed!r} rather than {LATEST_MOMENT}, so "
+        "this backend is not holding the moment the fixture declared"
+    )
 
 
 # A pandas-native datetime column, which is what a frame built the convenient way holds. The

--- a/tests/integration/test_utils/data_source_config/clickhouse.py
+++ b/tests/integration/test_utils/data_source_config/clickhouse.py
@@ -50,13 +50,20 @@ _CLICKHOUSE_TABLE_SCHEMA_ITEMS: TableSchemaItemFactory = _clickhouse_table_engin
 # reject nulls at insert. The harness's insert path converts pandas/numpy null sentinels to real
 # `None` before insert, so this matters for round-tripping nulls correctly.
 #
-# `int -> Int64` and `float -> Float64` replace the shared map's `INTEGER` (ClickHouse's 32-bit
-# alias) and `DECIMAL` (no precision/scale, not usable). `date -> Date32` and
-# `datetime -> DateTime64()` replace the shared map's narrower `DATE` (starts at 1970) and
-# `DATETIME` (second resolution); `pd.Timestamp` is overridden alongside `datetime` because it is
-# a separate key in the shared inferred-type map. No length is declared for `str`: a length on
-# this dialect's generic `String` type renders `FixedString(n)`, a padded fixed-width type, not
-# what's wanted here -- unlike the length-carrying `str` override other backends declare.
+# `int -> Int64` replaces the shared map's `INTEGER`, ClickHouse's 32-bit alias. `float ->
+# Float64` replaces its `Float(precision=53)`: this dialect discards the precision, and the bare
+# `FLOAT` left over is this server's *single*-precision `Float32` -- verified against a live
+# server, which stores 16777217.0 as 16777216.0 under it and exactly under `Float64`. That is the
+# same narrowing Databricks needs its own override for, reached the same way (see
+# `DOUBLE_PRECISION_FLOAT_OVERRIDE` in `sql.py`); here the `Nullable(...)` wrapper means the entry
+# has to be declared regardless, so it names the 64-bit type rather than deferring to a shared
+# default that would not survive the trip. `date -> Date32` and `datetime -> DateTime64()` replace
+# the shared map's narrower `DATE` (starts at 1970) and `DateTime()`, which renders a
+# second-resolution `DateTime` on this dialect; `pd.Timestamp` is overridden alongside `datetime`
+# because it is a separate key in the shared inferred-type map. No length is declared for `str`:
+# a length on this dialect's generic `String` type renders `FixedString(n)`, a padded fixed-width
+# type, not what's wanted here -- unlike the length-carrying `str` override other backends
+# declare.
 #
 # The map is built eagerly at module scope, behind an import guard, because -- unlike the
 # table-schema-item factory above, which is deferred since its engine object binds to a table --

--- a/tests/integration/test_utils/data_source_config/databricks.py
+++ b/tests/integration/test_utils/data_source_config/databricks.py
@@ -17,7 +17,10 @@ from tests.integration.test_utils.data_source_config.data_source_spec import (
     SupportTier,
 )
 from tests.integration.test_utils.data_source_config.registry import register_sql_config
-from tests.integration.test_utils.data_source_config.sql import SQLBatchTestSetup
+from tests.integration.test_utils.data_source_config.sql import (
+    DOUBLE_PRECISION_FLOAT_OVERRIDE,
+    SQLBatchTestSetup,
+)
 from tests.integration.test_utils.data_source_config.sql_config import SqlDatasourceTestConfig
 
 if TYPE_CHECKING:
@@ -30,19 +33,12 @@ if TYPE_CHECKING:
     from tests.integration.test_utils.data_source_config.base import BatchTestSetup
 
 
-# This server reads a bare `FLOAT` as its 4-byte type and `DOUBLE` as its 8-byte one, and the
-# shared default's precision-carrying float renders as the former here: this dialect discards the
-# precision. A Python float is a double, so any value needing more than 24 bits of mantissa is
-# then stored at the narrower width -- valid DDL, no error, and a fixture value that is not the
-# value the test declared. Naming the 8-byte type leaves the server nothing to choose.
-#
-# Behind a guard because `Double` arrived in SQLAlchemy 2.0, and this module is imported under the
-# 1.4 floor the minimum-version lane installs. Nothing is lost by that: this backend's dialect
-# package requires SQLAlchemy 2.0 itself, so a 1.4 environment cannot run this backend at all.
+# The shared default's precision is discarded by this dialect, and the bare `FLOAT` it leaves is
+# this server's 4-byte type, so the declared override names the 8-byte one instead.
 _COLUMN_TYPE_OVERRIDES: Mapping[type, Union[Type[TypeEngine], TypeEngine]] = {
     # databricks requires a length for VARCHAR
     str: sqltypes.VARCHAR(255),
-    **({float: sqltypes.Double()} if hasattr(sqltypes, "Double") else {}),
+    **DOUBLE_PRECISION_FLOAT_OVERRIDE,
 }
 
 

--- a/tests/integration/test_utils/data_source_config/databricks.py
+++ b/tests/integration/test_utils/data_source_config/databricks.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import TYPE_CHECKING, Mapping, Optional
+from typing import TYPE_CHECKING, Mapping, Optional, Type, Union
 
 from great_expectations.compatibility.pydantic import BaseSettings
-from great_expectations.compatibility.sqlalchemy import sqltypes
+from great_expectations.compatibility.sqlalchemy import TypeEngine, sqltypes
 from great_expectations.compatibility.typing_extensions import override
 from tests.integration.test_utils.data_source_config.backend_spec import (
     SqlBackendSpec,
@@ -30,6 +30,22 @@ if TYPE_CHECKING:
     from tests.integration.test_utils.data_source_config.base import BatchTestSetup
 
 
+# This server reads a bare `FLOAT` as its 4-byte type and `DOUBLE` as its 8-byte one, and the
+# shared default's precision-carrying float renders as the former here: this dialect discards the
+# precision. A Python float is a double, so any value needing more than 24 bits of mantissa is
+# then stored at the narrower width -- valid DDL, no error, and a fixture value that is not the
+# value the test declared. Naming the 8-byte type leaves the server nothing to choose.
+#
+# Behind a guard because `Double` arrived in SQLAlchemy 2.0, and this module is imported under the
+# 1.4 floor the minimum-version lane installs. Nothing is lost by that: this backend's dialect
+# package requires SQLAlchemy 2.0 itself, so a 1.4 environment cannot run this backend at all.
+_COLUMN_TYPE_OVERRIDES: Mapping[type, Union[Type[TypeEngine], TypeEngine]] = {
+    # databricks requires a length for VARCHAR
+    str: sqltypes.VARCHAR(255),
+    **({float: sqltypes.Double()} if hasattr(sqltypes, "Double") else {}),
+}
+
+
 @register_sql_config
 class DatabricksDatasourceTestConfig(SqlDatasourceTestConfig):
     DATA_SOURCE_SPEC = SqlBackendSpec(
@@ -42,8 +58,7 @@ class DatabricksDatasourceTestConfig(SqlDatasourceTestConfig):
         ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="databricks"),
         uses_schema=True,
         transaction_mode=TransactionMode.AUTOCOMMIT,
-        # databricks requires a length for VARCHAR
-        column_type_overrides={str: sqltypes.VARCHAR(255)},
+        column_type_overrides=_COLUMN_TYPE_OVERRIDES,
         insert_parameter_limit=250,
         tiers=frozenset({SupportTier.CANONICAL_EXPECTATIONS, SupportTier.FLUENT_API}),
         dev_requirements_file="reqs/requirements-dev-databricks.txt",

--- a/tests/integration/test_utils/data_source_config/oracle.py
+++ b/tests/integration/test_utils/data_source_config/oracle.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Mapping, Optional
 
 import pandas as pd
@@ -45,17 +44,11 @@ class OracleDatasourceTestConfig(SqlDatasourceTestConfig):
             # `ORA-00906: missing left parenthesis`. SingleStore and MySQL declare the same
             # override for the same reason.
             str: sqltypes.VARCHAR(255),
-            # Bare DATETIME is not an Oracle type; DDL fails with
-            # `ORA-00902: invalid datatype`.
-            datetime: sqltypes.TIMESTAMP,
-            pd.Timestamp: sqltypes.TIMESTAMP,
-            # The shared default maps `float` to an unqualified DECIMAL, which this dialect
-            # resolves to a zero-scale NUMBER: the DDL succeeds but every fractional value
-            # rounds to the nearest integer on insert (10.5 comes back 11, -10.5 comes back
-            # -11). A DECIMAL carrying explicit precision and scale round-trips fractional
-            # values intact. A precision-only FLOAT (the override Trino declares) does not
-            # work here either: this dialect raises an argument error over binary vs. decimal
-            # precision, so a scale-carrying DECIMAL is what's declared instead.
+            # The shared default's precision-carrying FLOAT does not work here: this dialect
+            # raises an argument error over binary vs. decimal precision. A DECIMAL carrying
+            # explicit precision and scale round-trips fractional values intact, so that is
+            # what is declared instead. Not a bare DECIMAL, which this dialect resolves to a
+            # zero-scale NUMBER: the DDL succeeds, but 10.5 comes back 11.
             float: sqltypes.DECIMAL(38, 10),
         },
         dev_requirements_file="reqs/requirements-dev-oracle.txt",

--- a/tests/integration/test_utils/data_source_config/oracle.py
+++ b/tests/integration/test_utils/data_source_config/oracle.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Mapping, Optional
 
 import pandas as pd
@@ -44,6 +45,13 @@ class OracleDatasourceTestConfig(SqlDatasourceTestConfig):
             # `ORA-00906: missing left parenthesis`. SingleStore and MySQL declare the same
             # override for the same reason.
             str: sqltypes.VARCHAR(255),
+            # The shared default's `DateTime` compiles to this dialect's DATE, which carries a
+            # time of day but no fraction of a second. A declared microsecond is then dropped on
+            # write, with valid DDL and no error: `2024-01-03 12:00:00.123456` comes back
+            # `2024-01-03 12:00:00`. TIMESTAMP is this dialect's sub-second type and round-trips
+            # the declared value intact, so the fixture frame is what the table holds.
+            datetime: sqltypes.TIMESTAMP,
+            pd.Timestamp: sqltypes.TIMESTAMP,
             # The shared default's precision-carrying FLOAT does not work here: this dialect
             # raises an argument error over binary vs. decimal precision. A DECIMAL carrying
             # explicit precision and scale round-trips fractional values intact, so that is

--- a/tests/integration/test_utils/data_source_config/singlestore.py
+++ b/tests/integration/test_utils/data_source_config/singlestore.py
@@ -17,7 +17,10 @@ from tests.integration.test_utils.data_source_config.data_source_spec import (
     SupportTier,
 )
 from tests.integration.test_utils.data_source_config.registry import register_sql_config
-from tests.integration.test_utils.data_source_config.sql import SQLBatchTestSetup
+from tests.integration.test_utils.data_source_config.sql import (
+    DOUBLE_PRECISION_FLOAT_OVERRIDE,
+    SQLBatchTestSetup,
+)
 from tests.integration.test_utils.data_source_config.sql_config import SqlDatasourceTestConfig
 
 
@@ -33,8 +36,15 @@ class SingleStoreDatasourceTestConfig(SqlDatasourceTestConfig):
         ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="singlestore"),
         uses_schema=False,
         tiers=frozenset({SupportTier.CURATED_SQL, SupportTier.FLUENT_API}),
-        # SingleStore requires a length for VARCHAR, the same requirement MySQL declares.
-        column_type_overrides={str: sqltypes.VARCHAR(255)},
+        column_type_overrides={
+            # SingleStore requires a length for VARCHAR, the same requirement MySQL declares.
+            str: sqltypes.VARCHAR(255),
+            # The shared default's `FLOAT(53)` reaches this server with its precision intact, and
+            # unlike MySQL this server does not promote it: `SHOW CREATE TABLE` reports a plain
+            # 4-byte `float`, and 16777217.0 comes back 16777200.0 -- valid DDL, no error. Naming
+            # the 8-byte type round-trips the declared value.
+            **DOUBLE_PRECISION_FLOAT_OVERRIDE,
+        },
         dev_requirements_file="reqs/requirements-dev-singlestore.txt",
         task_runner_marker="singlestore",
         container_service="singlestore",

--- a/tests/integration/test_utils/data_source_config/spark_filesystem_csv.py
+++ b/tests/integration/test_utils/data_source_config/spark_filesystem_csv.py
@@ -143,12 +143,16 @@ class SparkFilesystemCsvBatchTestSetup(
         def _clean(val: object, info: _TypeInfo | None) -> object:
             if pd.isna(val):  # type: ignore[call-overload]  # scalar from itertuples
                 return None
+            # PySpark matches on exact type, and `pd.Timestamp` is a subclass rather than the
+            # type it looks for. Unconditional, because this is needed most where no schema was
+            # declared: with one, the value is checked against a known field type; without one,
+            # PySpark infers from the value alone and reads a timestamp it does not recognise as
+            # an empty struct, which is not a column any file format can be asked to write.
+            if isinstance(val, pd.Timestamp):
+                return val.to_pydatetime()
             if info is not None:
                 target, acceptable = info
                 if type(val) not in acceptable:
-                    # pd.Timestamp subclasses datetime but PySpark checks exact types
-                    if isinstance(val, pd.Timestamp):
-                        return val.to_pydatetime()
                     return target(val)
             return val
 

--- a/tests/integration/test_utils/data_source_config/sql.py
+++ b/tests/integration/test_utils/data_source_config/sql.py
@@ -83,15 +83,25 @@ class SQLBatchTestSetup(BatchTestSetup[_SqlConfigT, TableAsset], ABC, Generic[_S
         The backend's declared `column_type_overrides` are merged over this shared default map,
         so a backend that needs a different type for a given Python type (e.g. a length-carrying
         string type) states that fact once, in its spec, rather than by overriding this property.
+
+        The defaults name types every dialect in use here has, and carry a precision wherever
+        leaving it off would let the server pick one. An unparameterised type compiles on every
+        dialect, so a mismatch is not a DDL error the harness would notice -- it is whatever that
+        server decided the type meant, applied silently to the fixture data.
         """
         default: InferrableTypesLookup = {
             str: sqltypes.VARCHAR,
             int: sqltypes.INTEGER,
-            float: sqltypes.DECIMAL,
+            # Not a bare DECIMAL: several dialects read that as scale zero and round every
+            # fractional value in a fixture frame to an integer on write, so an assertion about
+            # a value ends up asserting about a different value.
+            float: sqltypes.FLOAT(precision=53),
             bool: sqltypes.BOOLEAN,
             date: sqltypes.DATE,
-            datetime: sqltypes.DATETIME,
-            pd.Timestamp: sqltypes.DATETIME,
+            # Not DATETIME: PostgreSQL and Oracle have no such type and reject the DDL outright,
+            # so a fixture frame carrying a datetime column cannot be created at all there.
+            datetime: sqltypes.TIMESTAMP,
+            pd.Timestamp: sqltypes.TIMESTAMP,
         }
         return {**default, **self.backend_spec.column_type_overrides}
 

--- a/tests/integration/test_utils/data_source_config/sql.py
+++ b/tests/integration/test_utils/data_source_config/sql.py
@@ -52,6 +52,59 @@ InferrableTypesLookup = dict[type[Any], Union[type[TypeEngine], TypeEngine]]
 InferredColumnTypes = dict[str, Union[type[TypeEngine], TypeEngine]]
 
 
+_SHARED_DEFAULTS: InferrableTypesLookup = {
+    str: sqltypes.VARCHAR,
+    int: sqltypes.INTEGER,
+    # Not a bare DECIMAL: an unqualified decimal is read by several dialects as scale zero,
+    # which rounds every fractional value in a fixture frame to an integer on write, so an
+    # assertion about a value ends up asserting about a different one. Nor `Double`, which one
+    # dialect renders as a type its server does not have.
+    #
+    # A precision-carrying float is the 64-bit type on every dialect here but two. Oracle raises
+    # rather than compiling it, over binary vs. decimal precision; Databricks discards the
+    # precision, and the bare `FLOAT` left over is that server's 4-byte type, which stores a
+    # Python float lossily. Both declare their own override for exactly that reason, and removing
+    # either surfaces this default's limit -- so those two overrides and this line belong
+    # together. The dialects that discard the precision without an override (SQLite, Snowflake)
+    # already mean 64 bits by a bare `FLOAT`.
+    float: sqltypes.Float(precision=53),
+    bool: sqltypes.BOOLEAN,
+    date: sqltypes.DATE,
+    # `DateTime`, not DATETIME or TIMESTAMP. Those two are emitted verbatim, and each is wrong
+    # somewhere: PostgreSQL has no DATETIME and rejects the DDL, while in T-SQL TIMESTAMP is a
+    # row-version column that refuses an explicit value entirely.
+    datetime: sqltypes.DateTime(),
+    pd.Timestamp: sqltypes.DateTime(),
+}
+"""The Python-type-to-SQL-type map every SQL backend starts from.
+
+These name types every dialect in use here has, and carry a precision wherever leaving it off
+would let the server pick one. An unparameterised type compiles on every dialect, so a mismatch is
+not a DDL error the harness would notice -- it is whatever that server decided the type meant,
+applied silently to the fixture data.
+
+Shared instances rather than per-call ones, which is safe because a SQLAlchemy type instance
+carries no binding to the table it is used on -- the same sharing a backend's declared
+`column_type_overrides` mapping already relies on. Schema *items* are the constructs that bind on
+attachment, and those are declared as a factory for that reason (see `SqlBackendSpec`).
+"""
+
+
+def inferrable_types_for(backend_spec: SqlBackendSpec) -> InferrableTypesLookup:
+    """The Python-type-to-SQL-type map one backend builds its fixture columns from.
+
+    The backend's declared `column_type_overrides` are merged over `_SHARED_DEFAULTS`, so a
+    backend that needs a different type for a given Python type (e.g. a length-carrying string
+    type) states that fact once, in its spec, rather than by overriding a property.
+
+    A function of the declaration rather than of a live setup, because what a backend's fixture
+    columns become is decided entirely by what that backend declares. Resolving it needs no
+    server, no credentials and no engine, which is what lets a test record the answer for every
+    registered backend at once rather than only for the backends a given lane can connect to.
+    """
+    return {**_SHARED_DEFAULTS, **backend_spec.column_type_overrides}
+
+
 class SQLBatchTestSetup(BatchTestSetup[_SqlConfigT, TableAsset], ABC, Generic[_SqlConfigT]):
     SCHEMA_PREFIX = "gx_ci_test_"
 
@@ -78,39 +131,8 @@ class SQLBatchTestSetup(BatchTestSetup[_SqlConfigT, TableAsset], ABC, Generic[_S
 
     @property
     def inferrable_types_lookup(self) -> InferrableTypesLookup:
-        """Dict of Python type keys mapped to SQL dialect-specific SqlAlchemy types.
-
-        The backend's declared `column_type_overrides` are merged over this shared default map,
-        so a backend that needs a different type for a given Python type (e.g. a length-carrying
-        string type) states that fact once, in its spec, rather than by overriding this property.
-
-        The defaults name types every dialect in use here has, and carry a precision wherever
-        leaving it off would let the server pick one. An unparameterised type compiles on every
-        dialect, so a mismatch is not a DDL error the harness would notice -- it is whatever that
-        server decided the type meant, applied silently to the fixture data.
-        """
-        default: InferrableTypesLookup = {
-            str: sqltypes.VARCHAR,
-            int: sqltypes.INTEGER,
-            # Not a bare DECIMAL: an unqualified decimal is read by several dialects as scale
-            # zero, which rounds every fractional value in a fixture frame to an integer on
-            # write, so an assertion about a value ends up asserting about a different one.
-            # Nor `Double`, which one dialect renders as a type its server does not have.
-            # A precision-carrying float resolves to double precision on the dialects that
-            # take a precision and to that dialect's own double elsewhere. It raises rather
-            # than compiling on Oracle, which is harmless only because Oracle declares its own
-            # override below -- removing that override would surface this, so the two belong
-            # together.
-            float: sqltypes.Float(precision=53),
-            bool: sqltypes.BOOLEAN,
-            date: sqltypes.DATE,
-            # `DateTime`, not DATETIME or TIMESTAMP. Those two are emitted verbatim, and each is
-            # wrong somewhere: PostgreSQL has no DATETIME and rejects the DDL, while in T-SQL
-            # TIMESTAMP is a row-version column that refuses an explicit value entirely.
-            datetime: sqltypes.DateTime(),
-            pd.Timestamp: sqltypes.DateTime(),
-        }
-        return {**default, **self.backend_spec.column_type_overrides}
+        """Dict of Python type keys mapped to SQL dialect-specific SqlAlchemy types."""
+        return inferrable_types_for(self.backend_spec)
 
     def __init__(
         self,

--- a/tests/integration/test_utils/data_source_config/sql.py
+++ b/tests/integration/test_utils/data_source_config/sql.py
@@ -92,11 +92,16 @@ class SQLBatchTestSetup(BatchTestSetup[_SqlConfigT, TableAsset], ABC, Generic[_S
         default: InferrableTypesLookup = {
             str: sqltypes.VARCHAR,
             int: sqltypes.INTEGER,
-            # `Double`, not a bare DECIMAL: an unqualified decimal is read by several dialects
-            # as scale zero, which rounds every fractional value in a fixture frame to an
-            # integer on write, so an assertion about a value ends up asserting about a
-            # different one.
-            float: sqltypes.Double(),
+            # Not a bare DECIMAL: an unqualified decimal is read by several dialects as scale
+            # zero, which rounds every fractional value in a fixture frame to an integer on
+            # write, so an assertion about a value ends up asserting about a different one.
+            # Nor `Double`, which one dialect renders as a type its server does not have.
+            # A precision-carrying float resolves to double precision on the dialects that
+            # take a precision and to that dialect's own double elsewhere. It raises rather
+            # than compiling on Oracle, which is harmless only because Oracle declares its own
+            # override below -- removing that override would surface this, so the two belong
+            # together.
+            float: sqltypes.Float(precision=53),
             bool: sqltypes.BOOLEAN,
             date: sqltypes.DATE,
             # `DateTime`, not DATETIME or TIMESTAMP. Those two are emitted verbatim, and each is

--- a/tests/integration/test_utils/data_source_config/sql.py
+++ b/tests/integration/test_utils/data_source_config/sql.py
@@ -60,14 +60,15 @@ _SHARED_DEFAULTS: InferrableTypesLookup = {
     # assertion about a value ends up asserting about a different one. Nor `Double`, which one
     # dialect renders as a type its server does not have.
     #
-    # A precision-carrying float is the 64-bit type on every dialect here but three, and each of
-    # those three declares its own override for a different reason: Oracle raises rather than
-    # compiling it, over binary vs. decimal precision; Databricks discards the precision and reads
-    # the bare `FLOAT` left over as its 4-byte type; SingleStore keeps the precision and ignores
-    # it, creating a 4-byte column anyway. Removing any of those three surfaces this line's limit,
-    # so they and it belong together -- see `DOUBLE_PRECISION_FLOAT_OVERRIDE` below. The dialects
-    # that discard the precision without an override (SQLite, Snowflake) already mean 64 bits by a
-    # bare `FLOAT`.
+    # A precision-carrying float is the 64-bit type on every dialect here but four, and each of
+    # those four declares its own override: Oracle raises rather than compiling it, over binary
+    # vs. decimal precision; Databricks discards the precision and reads the bare `FLOAT` left
+    # over as its 4-byte type; ClickHouse does the same, that spelling being its `Float32`;
+    # SingleStore keeps the precision and ignores it, creating a 4-byte column anyway. Removing
+    # any of those four surfaces this line's limit, so they and it belong together -- see
+    # `DOUBLE_PRECISION_FLOAT_OVERRIDE` below, which two of them share. The dialects that discard
+    # the precision without an override (SQLite, Snowflake) already mean 64 bits by a bare
+    # `FLOAT`.
     float: sqltypes.Float(precision=53),
     bool: sqltypes.BOOLEAN,
     date: sqltypes.DATE,
@@ -94,7 +95,7 @@ attachment, and those are declared as a factory for that reason (see `SqlBackend
 DOUBLE_PRECISION_FLOAT_OVERRIDE: InferrableTypesLookup = (
     {float: sqltypes.Double()} if hasattr(sqltypes, "Double") else {}
 )
-"""A `float` override for the two backends the shared default does not give 8 bytes.
+"""A `float` override for the two backends that need the 8-byte type named and can take it plain.
 
 They get there by different routes, which is why neither is fixable in the default. The Databricks
 dialect discards the precision and emits a bare `FLOAT`, and that spelling is its server's
@@ -104,7 +105,9 @@ stored at half the width the fixture declared, with valid DDL and no error: veri
 SingleStore, which stores 16777217.0 as 16777200.0 under the default and exactly under this.
 `Double` names the width in the type name, leaving the server nothing to pick.
 
-SQLite and Snowflake also emit a bare `FLOAT` and need nothing here: both mean 64 bits by it.
+SQLite and Snowflake also emit a bare `FLOAT` and need nothing: both mean 64 bits by it.
+ClickHouse does not, and is the third backend narrowed by the default -- but its types all
+carry a `Nullable(...)` wrapper, so it states its own `Float64` rather than sharing this.
 
 Empty on SQLAlchemy 1.4, where `Double` does not exist. This module is imported there -- the
 minimum-version lane constrains to that floor and collects every test module -- so naming the type

--- a/tests/integration/test_utils/data_source_config/sql.py
+++ b/tests/integration/test_utils/data_source_config/sql.py
@@ -60,13 +60,14 @@ _SHARED_DEFAULTS: InferrableTypesLookup = {
     # assertion about a value ends up asserting about a different one. Nor `Double`, which one
     # dialect renders as a type its server does not have.
     #
-    # A precision-carrying float is the 64-bit type on every dialect here but two. Oracle raises
-    # rather than compiling it, over binary vs. decimal precision; Databricks discards the
-    # precision, and the bare `FLOAT` left over is that server's 4-byte type, which stores a
-    # Python float lossily. Both declare their own override for exactly that reason, and removing
-    # either surfaces this default's limit -- so those two overrides and this line belong
-    # together. The dialects that discard the precision without an override (SQLite, Snowflake)
-    # already mean 64 bits by a bare `FLOAT`.
+    # A precision-carrying float is the 64-bit type on every dialect here but three, and each of
+    # those three declares its own override for a different reason: Oracle raises rather than
+    # compiling it, over binary vs. decimal precision; Databricks discards the precision and reads
+    # the bare `FLOAT` left over as its 4-byte type; SingleStore keeps the precision and ignores
+    # it, creating a 4-byte column anyway. Removing any of those three surfaces this line's limit,
+    # so they and it belong together -- see `DOUBLE_PRECISION_FLOAT_OVERRIDE` below. The dialects
+    # that discard the precision without an override (SQLite, Snowflake) already mean 64 bits by a
+    # bare `FLOAT`.
     float: sqltypes.Float(precision=53),
     bool: sqltypes.BOOLEAN,
     date: sqltypes.DATE,
@@ -87,6 +88,29 @@ Shared instances rather than per-call ones, which is safe because a SQLAlchemy t
 carries no binding to the table it is used on -- the same sharing a backend's declared
 `column_type_overrides` mapping already relies on. Schema *items* are the constructs that bind on
 attachment, and those are declared as a factory for that reason (see `SqlBackendSpec`).
+"""
+
+
+DOUBLE_PRECISION_FLOAT_OVERRIDE: InferrableTypesLookup = (
+    {float: sqltypes.Double()} if hasattr(sqltypes, "Double") else {}
+)
+"""A `float` override for the two backends the shared default does not give 8 bytes.
+
+They get there by different routes, which is why neither is fixable in the default. The Databricks
+dialect discards the precision and emits a bare `FLOAT`, and that spelling is its server's
+single-precision type. SingleStore is handed `FLOAT(53)` intact and, unlike MySQL, does not promote
+it -- `SHOW CREATE TABLE` reports a plain `float`. Either way a Python float, which is a double, is
+stored at half the width the fixture declared, with valid DDL and no error: verified against a live
+SingleStore, which stores 16777217.0 as 16777200.0 under the default and exactly under this.
+`Double` names the width in the type name, leaving the server nothing to pick.
+
+SQLite and Snowflake also emit a bare `FLOAT` and need nothing here: both mean 64 bits by it.
+
+Empty on SQLAlchemy 1.4, where `Double` does not exist. This module is imported there -- the
+minimum-version lane constrains to that floor and collects every test module -- so naming the type
+unconditionally would break collection in a lane that runs none of these backends. An environment
+that did run one under 1.4 would get the narrowing back, which is why the round-trip suite asserts
+the stored value rather than trusting the declaration.
 """
 
 

--- a/tests/integration/test_utils/data_source_config/sql.py
+++ b/tests/integration/test_utils/data_source_config/sql.py
@@ -92,16 +92,18 @@ class SQLBatchTestSetup(BatchTestSetup[_SqlConfigT, TableAsset], ABC, Generic[_S
         default: InferrableTypesLookup = {
             str: sqltypes.VARCHAR,
             int: sqltypes.INTEGER,
-            # Not a bare DECIMAL: several dialects read that as scale zero and round every
-            # fractional value in a fixture frame to an integer on write, so an assertion about
-            # a value ends up asserting about a different value.
-            float: sqltypes.FLOAT(precision=53),
+            # `Double`, not a bare DECIMAL: an unqualified decimal is read by several dialects
+            # as scale zero, which rounds every fractional value in a fixture frame to an
+            # integer on write, so an assertion about a value ends up asserting about a
+            # different one.
+            float: sqltypes.Double(),
             bool: sqltypes.BOOLEAN,
             date: sqltypes.DATE,
-            # Not DATETIME: PostgreSQL and Oracle have no such type and reject the DDL outright,
-            # so a fixture frame carrying a datetime column cannot be created at all there.
-            datetime: sqltypes.TIMESTAMP,
-            pd.Timestamp: sqltypes.TIMESTAMP,
+            # `DateTime`, not DATETIME or TIMESTAMP. Those two are emitted verbatim, and each is
+            # wrong somewhere: PostgreSQL has no DATETIME and rejects the DDL, while in T-SQL
+            # TIMESTAMP is a row-version column that refuses an explicit value entirely.
+            datetime: sqltypes.DateTime(),
+            pd.Timestamp: sqltypes.DateTime(),
         }
         return {**default, **self.backend_spec.column_type_overrides}
 

--- a/tests/integration/test_utils/data_source_config/trino.py
+++ b/tests/integration/test_utils/data_source_config/trino.py
@@ -3,7 +3,6 @@ from typing import Mapping, Optional
 import pandas as pd
 import pytest
 
-from great_expectations.compatibility.sqlalchemy import sqltypes
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.data_context import AbstractDataContext
 from great_expectations.datasource.fluent.sql_datasource import TableAsset
@@ -36,10 +35,6 @@ class TrinoDatasourceTestConfig(SqlDatasourceTestConfig):
         ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="trino"),
         uses_schema=True,
         transaction_mode=TransactionMode.AUTOCOMMIT,
-        # The shared default maps `float` to an unqualified DECIMAL, which Trino resolves to
-        # scale zero, silently rounding fractional values to integers. A precision-carrying
-        # FLOAT compiles to double precision and round-trips exactly.
-        column_type_overrides={float: sqltypes.FLOAT(precision=53)},
         tiers=frozenset({SupportTier.CURATED_SQL}),
         dev_requirements_file="reqs/requirements-dev-trino.txt",
         task_runner_marker="trino",

--- a/tests/integration/test_utils/test_shared_column_type_renderings.py
+++ b/tests/integration/test_utils/test_shared_column_type_renderings.py
@@ -1,0 +1,152 @@
+"""What each registered SQL backend's fixture columns actually become, written down.
+
+A shared default is a per-dialect decision even though it is written once, and a backend's own
+override is the other half of that decision. What a table ends up holding is the two together, so
+that is what this records: one row per registered SQL backend, resolved from its declaration and
+compiled against its dialect.
+
+Recording the shared defaults alone would leave the half a reader most needs to see. An override
+can change, or be dropped, and move nothing here -- which is how a backend whose datetime column
+had been pinned to a sub-second type could come to be created as a second-resolution one with no
+line disagreeing.
+
+This does not know which renderings are right; no local check can, since a type name means whatever
+the server says it means, and only a run against one settles that. What it does is make the
+renderings visible: editing a shared default or a backend override changes this table in the same
+diff, so the per-backend consequences are read at review time rather than discovered a
+continuous-integration run later.
+
+A module of its own, rather than a class inside `test_sql_batch_test_setup.py`, because of how each
+case has to be marked. A backend's row is only worth checking where that backend's dialect is
+installed, which means the case must carry that backend's own pytest marker -- and every test must
+carry exactly one required marker (`tests/conftest.py`, `--verify-marker-coverage-and-exit`). A
+module-level marker would be a second one on every case here.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, List, Mapping, Type, Union
+
+import pandas as pd
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.dialects import registry as sa_dialect_registry
+
+from tests.integration.test_utils.data_source_config import iter_data_source_specs
+from tests.integration.test_utils.data_source_config import sql as sql_module
+from tests.integration.test_utils.data_source_config.backend_spec import SqlBackendSpec
+
+if TYPE_CHECKING:
+    from _pytest.mark.structures import ParameterSet
+
+    from great_expectations.compatibility.sqlalchemy import TypeEngine
+
+
+def _rendered(sql_type: Union[Type[TypeEngine], TypeEngine], dialect: sa.engine.Dialect) -> str:
+    """The DDL fragment one dialect emits for one declared type."""
+    instance = sql_type() if isinstance(sql_type, type) else sql_type
+    return str(instance.compile(dialect=dialect))
+
+
+def _sql_backend_specs() -> List[SqlBackendSpec]:
+    """Every registered SQL backend's declaration, in label order.
+
+    Read from the registry rather than named here, so a backend added later is one this module
+    accounts for without an edit to this module -- and is not silently skipped by it.
+    """
+    return [spec for spec in iter_data_source_specs() if isinstance(spec, SqlBackendSpec)]
+
+
+def _backend_params() -> List[ParameterSet]:
+    """One parameter per registered SQL backend, carrying that backend's own pytest marker.
+
+    The marker is what puts a backend's case in the lane that installs its dialect. Seven of these
+    backends have a third-party dialect that only their own lane installs, so without it their
+    recorded rows would be checked in no lane at all.
+
+    Exactly one marker per case, never a second: a test carrying two required markers fails the
+    repository's marker-coverage check as surely as one carrying none. A backend declaring no
+    marker of its own has no lane to be routed to, so its case is marked as what it then is -- a
+    check on a property of this project, run wherever that lane runs.
+    """
+    return [
+        pytest.param(spec, marks=getattr(pytest.mark, spec.marker or "project"), id=spec.label)
+        for spec in _sql_backend_specs()
+    ]
+
+
+_RESOLVED: Mapping[str, Mapping[str, str]] = {
+    "big-query": {"dialect": "bigquery", "float": "FLOAT64", "datetime": "DATETIME"},
+    "clickhouse": {
+        "dialect": "clickhouse",
+        "float": "Nullable(Float64)",
+        "datetime": "Nullable(DateTime64(3))",
+    },
+    "databricks": {"dialect": "databricks", "float": "DOUBLE", "datetime": "TIMESTAMP_NTZ"},
+    "mssql": {"dialect": "mssql", "float": "FLOAT(53)", "datetime": "DATETIME"},
+    "mysql": {"dialect": "mysql", "float": "FLOAT(53)", "datetime": "DATETIME"},
+    "oracle": {"dialect": "oracle", "float": "DECIMAL(38, 10)", "datetime": "TIMESTAMP"},
+    "postgresql": {
+        "dialect": "postgresql",
+        "float": "FLOAT(53)",
+        "datetime": "TIMESTAMP WITHOUT TIME ZONE",
+    },
+    "redshift": {
+        "dialect": "redshift",
+        "float": "FLOAT(53)",
+        "datetime": "TIMESTAMP WITHOUT TIME ZONE",
+    },
+    "singlestore": {"dialect": "singlestoredb", "float": "DOUBLE", "datetime": "DATETIME"},
+    # Lowercase as this dialect emits it; the server reads type names case-insensitively.
+    "snowflake": {"dialect": "snowflake", "float": "FLOAT", "datetime": "datetime"},
+    "sqlite": {"dialect": "sqlite", "float": "FLOAT", "datetime": "DATETIME"},
+    "trino": {"dialect": "trino", "float": "DOUBLE", "datetime": "TIMESTAMP"},
+}
+"""Keyed by the backend's own declared label; `dialect` names the SQLAlchemy dialect it connects
+through, which is spelled differently from the label for two of them.
+
+`float` and `datetime` only, because those two are where a dialect's reading of a type name has
+actually diverged from what the harness meant. `pd.Timestamp` carries no column of its own: it is
+asserted to render as `datetime` does, since a backend overriding one and not the other is a defect
+rather than a fact worth recording.
+"""
+
+
+class TestEveryBackendResolvesTheColumnTypesRecordedHere:
+    @pytest.mark.project
+    def test_every_registered_sql_backend_has_a_row(self) -> None:
+        """A backend with no row is one whose columns nobody wrote down."""
+        assert {spec.label for spec in _sql_backend_specs()} == set(_RESOLVED), (
+            "a SQL backend is registered that this table does not account for (or the reverse); "
+            "add its row, resolved from its declaration, in the change that adds the backend"
+        )
+
+    @pytest.mark.parametrize("spec", _backend_params())
+    def test_the_recorded_types_are_what_this_backend_resolves(self, spec: SqlBackendSpec) -> None:
+        recorded = _RESOLVED.get(spec.label)
+        assert recorded is not None, (
+            f"{spec.label} has no row here; test_every_registered_sql_backend_has_a_row says why"
+        )
+
+        try:
+            dialect = sa_dialect_registry.load(recorded["dialect"])()
+        except sa.exc.NoSuchModuleError:
+            # Only this: a dialect absent from the lane is the expected case, and skipping says so
+            # out loud. Any other failure means an installed dialect is broken, which must not read
+            # here as though the backend simply were not present.
+            pytest.skip(f"the {recorded['dialect']} dialect is not installed in this lane")
+
+        resolved = sql_module.inferrable_types_for(spec)
+        for name, python_type in (("float", float), ("datetime", datetime)):
+            assert _rendered(resolved[python_type], dialect) == recorded[name], (
+                f"{spec.label} resolves `{name}` to a different type than recorded here; confirm "
+                "the new rendering is a type that server has, and that it holds a declared value "
+                "without narrowing it, then update this table in the same change"
+            )
+
+        assert _rendered(resolved[pd.Timestamp], dialect) == recorded["datetime"], (
+            f"{spec.label} resolves a pandas timestamp to a different type than a plain datetime; "
+            "the two describe the same fixture column and a backend overriding one without the "
+            "other stores the same value two ways"
+        )

--- a/tests/integration/test_utils/test_sql_batch_test_setup.py
+++ b/tests/integration/test_utils/test_sql_batch_test_setup.py
@@ -311,8 +311,13 @@ class TestSharedDefaultTypesSayWhatTheyMean:
             f"the shared default for `float` is {instance!r}, which is not a numeric type at all"
         )
         states_its_own_width = (
-            # `Double` names 8 bytes in the type name itself, so it needs no precision.
-            isinstance(instance, sa.Double)
+            # `Double` names 8 bytes in the type name itself, so it needs no precision. Behind
+            # the same `hasattr` guard the production override carries, and for the same reason:
+            # the type does not exist on the SQLAlchemy 1.4 floor, and a bare attribute access
+            # here raises before any assertion runs. Nothing is lost under 1.4 -- a default this
+            # branch would accept cannot be spelled there -- and the two branches below still
+            # reject every shape that names no width.
+            (hasattr(sa, "Double") and isinstance(instance, sa.Double))
             or (isinstance(instance, sa.Float) and instance.precision is not None)
             or (not isinstance(instance, sa.Float) and instance.scale is not None)
         )

--- a/tests/integration/test_utils/test_sql_batch_test_setup.py
+++ b/tests/integration/test_utils/test_sql_batch_test_setup.py
@@ -39,7 +39,10 @@ from tests.integration.test_utils.data_source_config.generic_sql import (
     GenericSQLBatchTestSetup,
     GenericSQLDatasourceTestConfig,
 )
-from tests.integration.test_utils.data_source_config.sql import SQLBatchTestSetup
+from tests.integration.test_utils.data_source_config.sql import (
+    InferrableTypesLookup,
+    SQLBatchTestSetup,
+)
 from tests.integration.test_utils.data_source_config.sql_config import SqlDatasourceTestConfig
 
 if TYPE_CHECKING:
@@ -265,6 +268,42 @@ class TestSchemaNameConflictsWithNoSchemaDeclarationRaises:
         assert (
             str(excinfo.value)
             == "Schema name provided but use_schema is False for this datasource type."
+        )
+
+
+class TestSharedDefaultTypesSayWhatTheyMean:
+    """A default type that leaves its precision unstated lets each server pick one.
+
+    That failure does not announce itself: the DDL is valid everywhere, so nothing errors --
+    the server simply stores something other than what the fixture declared, and an assertion
+    about a value ends up asserting about a different value.
+    """
+
+    @staticmethod
+    def _shared_defaults(tmp_path: pathlib.Path) -> InferrableTypesLookup:
+        """The shared map as a real batch setup resolves it, with no override declared."""
+        setup = _ThrowawayBatchTestSetup(
+            data=pd.DataFrame({"col_int": [1]}),
+            config=_ThrowawayDatasourceTestConfig(),
+            base_dir=tmp_path,
+            extra_data=_EXTRA_DATA,
+            context=gx.get_context(mode="ephemeral"),
+        )
+        return setup.inferrable_types_lookup
+
+    def test_the_float_default_states_its_precision(self, tmp_path: pathlib.Path) -> None:
+        """An unqualified decimal type is read by several servers as scale zero, which rounds
+        every fractional value in a fixture frame to an integer on write -- silently, since the
+        DDL is valid. The default has to say what it means instead of inheriting that.
+        """
+        default_float = self._shared_defaults(tmp_path)[float]
+        instance = default_float() if isinstance(default_float, type) else default_float
+
+        precision = getattr(instance, "precision", None)
+        scale = getattr(instance, "scale", None)
+        assert precision is not None or scale is not None, (
+            f"the shared default for `float` is {instance!r}, which carries neither precision "
+            "nor scale, so each server chooses -- and several choose scale zero"
         )
 
 

--- a/tests/integration/test_utils/test_sql_batch_test_setup.py
+++ b/tests/integration/test_utils/test_sql_batch_test_setup.py
@@ -15,7 +15,7 @@ import pathlib
 import subprocess
 import sys
 from datetime import datetime
-from typing import TYPE_CHECKING, ClassVar, List, Mapping, Optional, Sequence, cast
+from typing import TYPE_CHECKING, ClassVar, List, Mapping, Optional, Sequence, Type, Union, cast
 
 import pandas as pd
 import pytest
@@ -27,6 +27,7 @@ import great_expectations as gx
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.execution_engine.sqlalchemy_dialect import GXSqlDialect
 from tests.integration.conftest import parameterize_batch_for_data_sources
+from tests.integration.test_utils.data_source_config import iter_data_source_specs
 from tests.integration.test_utils.data_source_config import sql as sql_module
 from tests.integration.test_utils.data_source_config.backend_spec import (
     SqlBackendSpec,
@@ -40,13 +41,11 @@ from tests.integration.test_utils.data_source_config.generic_sql import (
     GenericSQLBatchTestSetup,
     GenericSQLDatasourceTestConfig,
 )
-from tests.integration.test_utils.data_source_config.sql import (
-    InferrableTypesLookup,
-    SQLBatchTestSetup,
-)
+from tests.integration.test_utils.data_source_config.sql import SQLBatchTestSetup
 from tests.integration.test_utils.data_source_config.sql_config import SqlDatasourceTestConfig
 
 if TYPE_CHECKING:
+    from great_expectations.compatibility.sqlalchemy import TypeEngine
     from great_expectations.data_context import AbstractDataContext
     from great_expectations.datasource.fluent.sql_datasource import TableAsset
     from tests.integration.conftest import TestConfig
@@ -272,79 +271,37 @@ class TestSchemaNameConflictsWithNoSchemaDeclarationRaises:
         )
 
 
+def _rendered(sql_type: Union[Type[TypeEngine], TypeEngine], dialect: sa.engine.Dialect) -> str:
+    """The DDL fragment one dialect emits for one declared type."""
+    instance = sql_type() if isinstance(sql_type, type) else sql_type
+    return str(instance.compile(dialect=dialect))
+
+
+def _sql_backend_specs() -> List[SqlBackendSpec]:
+    """Every registered SQL backend's declaration, in label order.
+
+    Read from the registry rather than named here, so a backend added later is one this module
+    accounts for without an edit to this module -- and is not silently skipped by it.
+    """
+    return [spec for spec in iter_data_source_specs() if isinstance(spec, SqlBackendSpec)]
+
+
 class TestSharedDefaultTypesSayWhatTheyMean:
-    """A default type that leaves its precision unstated lets each server pick one.
+    """A default type that leaves its width unstated lets each server pick one.
 
     That failure does not announce itself: the DDL is valid everywhere, so nothing errors --
     the server simply stores something other than what the fixture declared, and an assertion
     about a value ends up asserting about a different value.
     """
 
-    @staticmethod
-    def _shared_defaults(tmp_path: pathlib.Path) -> InferrableTypesLookup:
-        """The shared map as a real batch setup resolves it, with no override declared."""
-        setup = _ThrowawayBatchTestSetup(
-            data=pd.DataFrame({"col_int": [1]}),
-            config=_ThrowawayDatasourceTestConfig(),
-            base_dir=tmp_path,
-            extra_data=_EXTRA_DATA,
-            context=gx.get_context(mode="ephemeral"),
-        )
-        return setup.inferrable_types_lookup
-
-    def test_the_float_default_is_not_an_unscaled_decimal(self, tmp_path: pathlib.Path) -> None:
-        """A decimal type with no scale is the shape that silently truncates.
-
-        Several dialects read an unqualified decimal as scale zero, so every fractional value
-        in a fixture frame is rounded to an integer on write -- with valid DDL and no error. A
-        type that names its own precision (a double, or a decimal carrying an explicit scale)
-        leaves the server nothing to decide.
-        """
-        default_float = self._shared_defaults(tmp_path)[float]
-        instance = default_float() if isinstance(default_float, type) else default_float
-
-        if isinstance(instance, sa.Numeric) and not isinstance(instance, (sa.Float, sa.Double)):
-            assert instance.scale is not None, (
-                f"the shared default for `float` is {instance!r}: a decimal type with no scale, "
-                "which several servers read as scale zero and round every fractional value away"
-            )
-
-
-class TestSharedDefaultTypesRenderAsRecorded:
-    """What each dialect makes of the shared defaults, written down.
-
-    A default type is a per-dialect decision even though it is written once. The DDL it produces
-    is what each server actually sees, and a type can compile cleanly on every dialect and still
-    name something a particular server does not have -- which surfaces as a query error on that
-    backend alone, far from the line that caused it.
-
-    This does not know which renderings are valid; no local check can, since validity is the
-    server's opinion and only a run against one settles it. What it does is make the renderings
-    visible: editing a default changes this table in the same diff, so the per-backend
-    consequences are read at review time rather than discovered a continuous-integration run
-    later. A dialect absent from the environment is skipped, since each lane installs only its
-    own.
-    """
-
-    _RENDERED: ClassVar[Mapping[str, Mapping[str, str]]] = {
-        "postgresql": {"float": "FLOAT(53)", "datetime": "TIMESTAMP WITHOUT TIME ZONE"},
-        "mysql": {"float": "FLOAT(53)", "datetime": "DATETIME"},
-        "sqlite": {"float": "FLOAT", "datetime": "DATETIME"},
-        "mssql": {"float": "FLOAT(53)", "datetime": "DATETIME"},
-        "bigquery": {"float": "FLOAT64", "datetime": "DATETIME"},
-        "snowflake": {"float": "FLOAT", "datetime": "datetime"},
-        "redshift": {"float": "FLOAT(53)", "datetime": "TIMESTAMP WITHOUT TIME ZONE"},
-        "trino": {"float": "DOUBLE", "datetime": "TIMESTAMP"},
-        "databricks": {"float": "FLOAT", "datetime": "TIMESTAMP_NTZ"},
-        "singlestoredb": {"float": "FLOAT(53)", "datetime": "DATETIME"},
-    }
-    """Oracle is absent deliberately: it overrides both of these, so the shared default never
-    reaches its dialect -- and the float default raises rather than compiling there, which is
-    exactly what that override exists to avoid."""
-
-    def test_each_installed_dialect_renders_the_defaults_as_recorded(
+    def test_a_running_setup_resolves_what_the_declaration_resolves(
         self, tmp_path: pathlib.Path
     ) -> None:
+        """This module reads the type map from the declaration rather than from a live setup,
+        which says something about the tables the harness builds only while a setup reads the
+        same map. A setup that resolved its columns some other way would leave every check below
+        true of a map nothing uses.
+        """
         setup = _ThrowawayBatchTestSetup(
             data=pd.DataFrame({"col_int": [1]}),
             config=_ThrowawayDatasourceTestConfig(),
@@ -352,23 +309,127 @@ class TestSharedDefaultTypesRenderAsRecorded:
             extra_data=_EXTRA_DATA,
             context=gx.get_context(mode="ephemeral"),
         )
-        defaults = setup.inferrable_types_lookup
-        by_name = {"float": defaults[float], "datetime": defaults[datetime]}
 
+        assert setup.inferrable_types_lookup == sql_module.inferrable_types_for(_BASE_SPEC)
+
+    def test_the_float_default_states_its_own_width(self) -> None:
+        """A float type that names no width is the shape that silently loses data.
+
+        Two spellings do it. An unqualified decimal is read by several dialects as scale zero, so
+        every fractional value in a fixture frame is rounded to an integer on write. A float with
+        no precision is read by at least one dialect as its 4-byte type, so a Python float -- a
+        double -- is stored at half the width it was declared at. Both produce valid DDL and no
+        error. A type that names its own width (a double, a float carrying a precision, or a
+        decimal carrying an explicit scale) leaves the server nothing to decide.
+        """
+        default_float = sql_module.inferrable_types_for(_BASE_SPEC)[float]
+        instance = default_float() if isinstance(default_float, type) else default_float
+
+        assert isinstance(instance, sa.Numeric), (
+            f"the shared default for `float` is {instance!r}, which is not a numeric type at all"
+        )
+        states_its_own_width = (
+            # `Double` names 8 bytes in the type name itself, so it needs no precision.
+            isinstance(instance, sa.Double)
+            or (isinstance(instance, sa.Float) and instance.precision is not None)
+            or (not isinstance(instance, sa.Float) and instance.scale is not None)
+        )
+
+        assert states_its_own_width, (
+            f"the shared default for `float` is {instance!r}, which names no width: the server "
+            "picks one, and a fixture value that does not fit the one it picks is rounded or "
+            "narrowed on write, with valid DDL and no error"
+        )
+
+
+class TestEveryBackendResolvesTheColumnTypesRecordedHere:
+    """What each registered backend's fixture columns actually become, written down.
+
+    A shared default is a per-dialect decision even though it is written once, and a backend's own
+    override is the other half of that decision. What a table ends up holding is the two together,
+    so that is what this records: one row per registered SQL backend, resolved from its
+    declaration and compiled against its dialect.
+
+    Recording the shared defaults alone would leave the half a reader most needs to see. An
+    override can change, or be dropped, and move nothing in this file -- which is how a backend
+    whose datetime column had been pinned to a sub-second type could come to be created as a
+    second-resolution one with no line here disagreeing.
+
+    This does not know which renderings are right; no local check can, since a type name means
+    whatever the server says it means, and only a run against one settles that. What it does is
+    make the renderings visible: editing a shared default or a backend override changes this table
+    in the same diff, so the per-backend consequences are read at review time rather than
+    discovered a continuous-integration run later. A dialect absent from the environment is
+    skipped, since each lane installs only its own.
+
+    `float` and `datetime` only, because those two are where a dialect's reading of a type name
+    has actually diverged from what the harness meant. `pd.Timestamp` carries no row of its own:
+    it is asserted to render as `datetime` does, since a backend overriding one and not the other
+    is a defect rather than a fact worth recording.
+    """
+
+    _RESOLVED: ClassVar[Mapping[str, Mapping[str, str]]] = {
+        "big-query": {"dialect": "bigquery", "float": "FLOAT64", "datetime": "DATETIME"},
+        "clickhouse": {
+            "dialect": "clickhouse",
+            "float": "Nullable(Float64)",
+            "datetime": "Nullable(DateTime64(3))",
+        },
+        "databricks": {"dialect": "databricks", "float": "DOUBLE", "datetime": "TIMESTAMP_NTZ"},
+        "mssql": {"dialect": "mssql", "float": "FLOAT(53)", "datetime": "DATETIME"},
+        "mysql": {"dialect": "mysql", "float": "FLOAT(53)", "datetime": "DATETIME"},
+        "oracle": {"dialect": "oracle", "float": "DECIMAL(38, 10)", "datetime": "TIMESTAMP"},
+        "postgresql": {
+            "dialect": "postgresql",
+            "float": "FLOAT(53)",
+            "datetime": "TIMESTAMP WITHOUT TIME ZONE",
+        },
+        "redshift": {
+            "dialect": "redshift",
+            "float": "FLOAT(53)",
+            "datetime": "TIMESTAMP WITHOUT TIME ZONE",
+        },
+        "singlestore": {"dialect": "singlestoredb", "float": "FLOAT(53)", "datetime": "DATETIME"},
+        # Lowercase as this dialect emits it; the server reads type names case-insensitively.
+        "snowflake": {"dialect": "snowflake", "float": "FLOAT", "datetime": "datetime"},
+        "sqlite": {"dialect": "sqlite", "float": "FLOAT", "datetime": "DATETIME"},
+        "trino": {"dialect": "trino", "float": "DOUBLE", "datetime": "TIMESTAMP"},
+    }
+    """Keyed by the backend's own declared label; `dialect` names the SQLAlchemy dialect it
+    connects through, which is spelled differently from the label for two of them."""
+
+    def test_every_registered_sql_backend_has_a_row(self) -> None:
+        """A backend with no row is one whose columns nobody wrote down."""
+        assert {spec.label for spec in _sql_backend_specs()} == set(self._RESOLVED), (
+            "a SQL backend is registered that this table does not account for (or the reverse); "
+            "add its row, resolved from its declaration, in the change that adds the backend"
+        )
+
+    def test_each_installed_dialect_renders_the_recorded_types(self) -> None:
         checked = []
-        for dialect_name, expected in self._RENDERED.items():
+        for spec in _sql_backend_specs():
+            recorded = self._RESOLVED.get(spec.label)
+            if recorded is None:  # the test above is the one that reports a missing row
+                continue
             try:
-                dialect = sa_dialect_registry.load(dialect_name)()
+                dialect = sa_dialect_registry.load(recorded["dialect"])()
             except Exception:  # this lane does not install that dialect
                 continue
-            checked.append(dialect_name)
-            for label, sql_type in by_name.items():
-                instance = sql_type() if isinstance(sql_type, type) else sql_type
-                assert instance.compile(dialect=dialect) == expected[label], (
-                    f"{dialect_name} renders the shared default for `{label}` differently than "
-                    "recorded here; confirm the new rendering is a type that server has, then "
-                    "update this table in the same change"
+            checked.append(spec.label)
+            resolved = sql_module.inferrable_types_for(spec)
+
+            for name, python_type in (("float", float), ("datetime", datetime)):
+                assert _rendered(resolved[python_type], dialect) == recorded[name], (
+                    f"{spec.label} resolves `{name}` to a different type than recorded here; "
+                    "confirm the new rendering is a type that server has, and that it holds a "
+                    "declared value without narrowing it, then update this table in the same "
+                    "change"
                 )
+            assert _rendered(resolved[pd.Timestamp], dialect) == recorded["datetime"], (
+                f"{spec.label} resolves a pandas timestamp to a different type than a plain "
+                "datetime; the two describe the same fixture column and a backend overriding "
+                "one without the other stores the same value two ways"
+            )
 
         # Non-vacuity: with no dialect loaded every assertion above is skipped, which would make
         # this pass hardest exactly when it is checking nothing.

--- a/tests/integration/test_utils/test_sql_batch_test_setup.py
+++ b/tests/integration/test_utils/test_sql_batch_test_setup.py
@@ -14,8 +14,7 @@ import os
 import pathlib
 import subprocess
 import sys
-from datetime import datetime
-from typing import TYPE_CHECKING, ClassVar, List, Mapping, Optional, Sequence, Type, Union, cast
+from typing import TYPE_CHECKING, ClassVar, List, Mapping, Optional, Sequence, cast
 
 import pandas as pd
 import pytest
@@ -27,7 +26,6 @@ import great_expectations as gx
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.execution_engine.sqlalchemy_dialect import GXSqlDialect
 from tests.integration.conftest import parameterize_batch_for_data_sources
-from tests.integration.test_utils.data_source_config import iter_data_source_specs
 from tests.integration.test_utils.data_source_config import sql as sql_module
 from tests.integration.test_utils.data_source_config.backend_spec import (
     SqlBackendSpec,
@@ -45,9 +43,6 @@ from tests.integration.test_utils.data_source_config.sql import SQLBatchTestSetu
 from tests.integration.test_utils.data_source_config.sql_config import SqlDatasourceTestConfig
 
 if TYPE_CHECKING:
-    from _pytest.mark.structures import ParameterSet
-
-    from great_expectations.compatibility.sqlalchemy import TypeEngine
     from great_expectations.data_context import AbstractDataContext
     from great_expectations.datasource.fluent.sql_datasource import TableAsset
     from tests.integration.conftest import TestConfig
@@ -273,42 +268,6 @@ class TestSchemaNameConflictsWithNoSchemaDeclarationRaises:
         )
 
 
-def _rendered(sql_type: Union[Type[TypeEngine], TypeEngine], dialect: sa.engine.Dialect) -> str:
-    """The DDL fragment one dialect emits for one declared type."""
-    instance = sql_type() if isinstance(sql_type, type) else sql_type
-    return str(instance.compile(dialect=dialect))
-
-
-def _sql_backend_specs() -> List[SqlBackendSpec]:
-    """Every registered SQL backend's declaration, in label order.
-
-    Read from the registry rather than named here, so a backend added later is one this module
-    accounts for without an edit to this module -- and is not silently skipped by it.
-    """
-    return [spec for spec in iter_data_source_specs() if isinstance(spec, SqlBackendSpec)]
-
-
-def _backend_params() -> List[ParameterSet]:
-    """One parameter per registered SQL backend, carrying that backend's own pytest marker.
-
-    The marker is what puts a backend's case in the lane that installs its dialect. This module
-    carries a module-level `sqlite` marker, which covers the dialects SQLAlchemy ships with, but
-    seven of these backends have a third-party dialect that only its own lane installs -- and no
-    lane selects a module by a marker it does not carry. Without the per-backend marker those
-    seven would be skipped in every lane, leaving their recorded rows checked nowhere.
-    """
-    return [
-        pytest.param(
-            spec,
-            # No marker declared means no lane of its own selects this backend, so its case runs
-            # only where this module's own marker does.
-            marks=[getattr(pytest.mark, spec.marker)] if spec.marker else [],
-            id=spec.label,
-        )
-        for spec in _sql_backend_specs()
-    ]
-
-
 class TestSharedDefaultTypesSayWhatTheyMean:
     """A default type that leaves its width unstated lets each server pick one.
 
@@ -320,10 +279,10 @@ class TestSharedDefaultTypesSayWhatTheyMean:
     def test_a_running_setup_resolves_what_the_declaration_resolves(
         self, tmp_path: pathlib.Path
     ) -> None:
-        """This module reads the type map from the declaration rather than from a live setup,
-        which says something about the tables the harness builds only while a setup reads the
-        same map. A setup that resolved its columns some other way would leave every check below
-        true of a map nothing uses.
+        """The check below, and the recorded rendering table in its own module, both read the
+        type map from a backend's declaration rather than from a live setup. That says something
+        about the tables the harness builds only while a running setup reads the same map; a setup
+        resolving its columns some other way would leave both asserting about a map nothing uses.
         """
         setup = _ThrowawayBatchTestSetup(
             data=pd.DataFrame({"col_int": [1]}),
@@ -340,10 +299,10 @@ class TestSharedDefaultTypesSayWhatTheyMean:
 
         Two spellings do it. An unqualified decimal is read by several dialects as scale zero, so
         every fractional value in a fixture frame is rounded to an integer on write. A float with
-        no precision is read by at least one dialect as its 4-byte type, so a Python float -- a
-        double -- is stored at half the width it was declared at. Both produce valid DDL and no
-        error. A type that names its own width (a double, a float carrying a precision, or a
-        decimal carrying an explicit scale) leaves the server nothing to decide.
+        no width is read by some servers as their 4-byte type, so a Python float -- a double -- is
+        stored at half the width it was declared at. Both produce valid DDL and no error. A type
+        naming its own width -- a double, a float carrying a precision, or a decimal carrying an
+        explicit scale -- leaves the server nothing to decide.
         """
         default_float = sql_module.inferrable_types_for(_BASE_SPEC)[float]
         instance = default_float() if isinstance(default_float, type) else default_float
@@ -362,99 +321,6 @@ class TestSharedDefaultTypesSayWhatTheyMean:
             f"the shared default for `float` is {instance!r}, which names no width: the server "
             "picks one, and a fixture value that does not fit the one it picks is rounded or "
             "narrowed on write, with valid DDL and no error"
-        )
-
-
-class TestEveryBackendResolvesTheColumnTypesRecordedHere:
-    """What each registered backend's fixture columns actually become, written down.
-
-    A shared default is a per-dialect decision even though it is written once, and a backend's own
-    override is the other half of that decision. What a table ends up holding is the two together,
-    so that is what this records: one row per registered SQL backend, resolved from its
-    declaration and compiled against its dialect.
-
-    Recording the shared defaults alone would leave the half a reader most needs to see. An
-    override can change, or be dropped, and move nothing in this file -- which is how a backend
-    whose datetime column had been pinned to a sub-second type could come to be created as a
-    second-resolution one with no line here disagreeing.
-
-    This does not know which renderings are right; no local check can, since a type name means
-    whatever the server says it means, and only a run against one settles that. What it does is
-    make the renderings visible: editing a shared default or a backend override changes this table
-    in the same diff, so the per-backend consequences are read at review time rather than
-    discovered a continuous-integration run later. A dialect absent from the environment is
-    skipped, since each lane installs only its own.
-
-    `float` and `datetime` only, because those two are where a dialect's reading of a type name
-    has actually diverged from what the harness meant. `pd.Timestamp` carries no row of its own:
-    it is asserted to render as `datetime` does, since a backend overriding one and not the other
-    is a defect rather than a fact worth recording.
-    """
-
-    _RESOLVED: ClassVar[Mapping[str, Mapping[str, str]]] = {
-        "big-query": {"dialect": "bigquery", "float": "FLOAT64", "datetime": "DATETIME"},
-        "clickhouse": {
-            "dialect": "clickhouse",
-            "float": "Nullable(Float64)",
-            "datetime": "Nullable(DateTime64(3))",
-        },
-        "databricks": {"dialect": "databricks", "float": "DOUBLE", "datetime": "TIMESTAMP_NTZ"},
-        "mssql": {"dialect": "mssql", "float": "FLOAT(53)", "datetime": "DATETIME"},
-        "mysql": {"dialect": "mysql", "float": "FLOAT(53)", "datetime": "DATETIME"},
-        "oracle": {"dialect": "oracle", "float": "DECIMAL(38, 10)", "datetime": "TIMESTAMP"},
-        "postgresql": {
-            "dialect": "postgresql",
-            "float": "FLOAT(53)",
-            "datetime": "TIMESTAMP WITHOUT TIME ZONE",
-        },
-        "redshift": {
-            "dialect": "redshift",
-            "float": "FLOAT(53)",
-            "datetime": "TIMESTAMP WITHOUT TIME ZONE",
-        },
-        "singlestore": {"dialect": "singlestoredb", "float": "DOUBLE", "datetime": "DATETIME"},
-        # Lowercase as this dialect emits it; the server reads type names case-insensitively.
-        "snowflake": {"dialect": "snowflake", "float": "FLOAT", "datetime": "datetime"},
-        "sqlite": {"dialect": "sqlite", "float": "FLOAT", "datetime": "DATETIME"},
-        "trino": {"dialect": "trino", "float": "DOUBLE", "datetime": "TIMESTAMP"},
-    }
-    """Keyed by the backend's own declared label; `dialect` names the SQLAlchemy dialect it
-    connects through, which is spelled differently from the label for two of them."""
-
-    def test_every_registered_sql_backend_has_a_row(self) -> None:
-        """A backend with no row is one whose columns nobody wrote down."""
-        assert {spec.label for spec in _sql_backend_specs()} == set(self._RESOLVED), (
-            "a SQL backend is registered that this table does not account for (or the reverse); "
-            "add its row, resolved from its declaration, in the change that adds the backend"
-        )
-
-    @pytest.mark.parametrize("spec", _backend_params())
-    def test_the_recorded_types_are_what_this_backend_resolves(self, spec: SqlBackendSpec) -> None:
-        recorded = self._RESOLVED.get(spec.label)
-        assert recorded is not None, (
-            f"{spec.label} has no row here; test_every_registered_sql_backend_has_a_row says why"
-        )
-
-        try:
-            dialect = sa_dialect_registry.load(recorded["dialect"])()
-        except sa.exc.NoSuchModuleError:
-            # Only this: a dialect absent from the lane is the expected case, and skipping says
-            # so out loud. Any other failure means an installed dialect is broken, which must not
-            # read here as though the backend simply were not present.
-            pytest.skip(f"the {recorded['dialect']} dialect is not installed in this lane")
-
-        resolved = sql_module.inferrable_types_for(spec)
-        for name, python_type in (("float", float), ("datetime", datetime)):
-            assert _rendered(resolved[python_type], dialect) == recorded[name], (
-                f"{spec.label} resolves `{name}` to a different type than recorded here; "
-                "confirm the new rendering is a type that server has, and that it holds a "
-                "declared value without narrowing it, then update this table in the same change"
-            )
-
-        assert _rendered(resolved[pd.Timestamp], dialect) == recorded["datetime"], (
-            f"{spec.label} resolves a pandas timestamp to a different type than a plain "
-            "datetime; the two describe the same fixture column and a backend overriding one "
-            "without the other stores the same value two ways"
         )
 
 

--- a/tests/integration/test_utils/test_sql_batch_test_setup.py
+++ b/tests/integration/test_utils/test_sql_batch_test_setup.py
@@ -45,6 +45,8 @@ from tests.integration.test_utils.data_source_config.sql import SQLBatchTestSetu
 from tests.integration.test_utils.data_source_config.sql_config import SqlDatasourceTestConfig
 
 if TYPE_CHECKING:
+    from _pytest.mark.structures import ParameterSet
+
     from great_expectations.compatibility.sqlalchemy import TypeEngine
     from great_expectations.data_context import AbstractDataContext
     from great_expectations.datasource.fluent.sql_datasource import TableAsset
@@ -286,6 +288,27 @@ def _sql_backend_specs() -> List[SqlBackendSpec]:
     return [spec for spec in iter_data_source_specs() if isinstance(spec, SqlBackendSpec)]
 
 
+def _backend_params() -> List[ParameterSet]:
+    """One parameter per registered SQL backend, carrying that backend's own pytest marker.
+
+    The marker is what puts a backend's case in the lane that installs its dialect. This module
+    carries a module-level `sqlite` marker, which covers the dialects SQLAlchemy ships with, but
+    seven of these backends have a third-party dialect that only its own lane installs -- and no
+    lane selects a module by a marker it does not carry. Without the per-backend marker those
+    seven would be skipped in every lane, leaving their recorded rows checked nowhere.
+    """
+    return [
+        pytest.param(
+            spec,
+            # No marker declared means no lane of its own selects this backend, so its case runs
+            # only where this module's own marker does.
+            marks=[getattr(pytest.mark, spec.marker)] if spec.marker else [],
+            id=spec.label,
+        )
+        for spec in _sql_backend_specs()
+    ]
+
+
 class TestSharedDefaultTypesSayWhatTheyMean:
     """A default type that leaves its width unstated lets each server pick one.
 
@@ -389,7 +412,7 @@ class TestEveryBackendResolvesTheColumnTypesRecordedHere:
             "float": "FLOAT(53)",
             "datetime": "TIMESTAMP WITHOUT TIME ZONE",
         },
-        "singlestore": {"dialect": "singlestoredb", "float": "FLOAT(53)", "datetime": "DATETIME"},
+        "singlestore": {"dialect": "singlestoredb", "float": "DOUBLE", "datetime": "DATETIME"},
         # Lowercase as this dialect emits it; the server reads type names case-insensitively.
         "snowflake": {"dialect": "snowflake", "float": "FLOAT", "datetime": "datetime"},
         "sqlite": {"dialect": "sqlite", "float": "FLOAT", "datetime": "DATETIME"},
@@ -405,35 +428,34 @@ class TestEveryBackendResolvesTheColumnTypesRecordedHere:
             "add its row, resolved from its declaration, in the change that adds the backend"
         )
 
-    def test_each_installed_dialect_renders_the_recorded_types(self) -> None:
-        checked = []
-        for spec in _sql_backend_specs():
-            recorded = self._RESOLVED.get(spec.label)
-            if recorded is None:  # the test above is the one that reports a missing row
-                continue
-            try:
-                dialect = sa_dialect_registry.load(recorded["dialect"])()
-            except Exception:  # this lane does not install that dialect
-                continue
-            checked.append(spec.label)
-            resolved = sql_module.inferrable_types_for(spec)
+    @pytest.mark.parametrize("spec", _backend_params())
+    def test_the_recorded_types_are_what_this_backend_resolves(self, spec: SqlBackendSpec) -> None:
+        recorded = self._RESOLVED.get(spec.label)
+        assert recorded is not None, (
+            f"{spec.label} has no row here; test_every_registered_sql_backend_has_a_row says why"
+        )
 
-            for name, python_type in (("float", float), ("datetime", datetime)):
-                assert _rendered(resolved[python_type], dialect) == recorded[name], (
-                    f"{spec.label} resolves `{name}` to a different type than recorded here; "
-                    "confirm the new rendering is a type that server has, and that it holds a "
-                    "declared value without narrowing it, then update this table in the same "
-                    "change"
-                )
-            assert _rendered(resolved[pd.Timestamp], dialect) == recorded["datetime"], (
-                f"{spec.label} resolves a pandas timestamp to a different type than a plain "
-                "datetime; the two describe the same fixture column and a backend overriding "
-                "one without the other stores the same value two ways"
+        try:
+            dialect = sa_dialect_registry.load(recorded["dialect"])()
+        except sa.exc.NoSuchModuleError:
+            # Only this: a dialect absent from the lane is the expected case, and skipping says
+            # so out loud. Any other failure means an installed dialect is broken, which must not
+            # read here as though the backend simply were not present.
+            pytest.skip(f"the {recorded['dialect']} dialect is not installed in this lane")
+
+        resolved = sql_module.inferrable_types_for(spec)
+        for name, python_type in (("float", float), ("datetime", datetime)):
+            assert _rendered(resolved[python_type], dialect) == recorded[name], (
+                f"{spec.label} resolves `{name}` to a different type than recorded here; "
+                "confirm the new rendering is a type that server has, and that it holds a "
+                "declared value without narrowing it, then update this table in the same change"
             )
 
-        # Non-vacuity: with no dialect loaded every assertion above is skipped, which would make
-        # this pass hardest exactly when it is checking nothing.
-        assert "sqlite" in checked, "no dialect was checked, so this proved nothing"
+        assert _rendered(resolved[pd.Timestamp], dialect) == recorded["datetime"], (
+            f"{spec.label} resolves a pandas timestamp to a different type than a plain "
+            "datetime; the two describe the same fixture column and a backend overriding one "
+            "without the other stores the same value two ways"
+        )
 
 
 class TestColumnTypeOverridesMergeOverSharedDefault:

--- a/tests/integration/test_utils/test_sql_batch_test_setup.py
+++ b/tests/integration/test_utils/test_sql_batch_test_setup.py
@@ -291,20 +291,22 @@ class TestSharedDefaultTypesSayWhatTheyMean:
         )
         return setup.inferrable_types_lookup
 
-    def test_the_float_default_states_its_precision(self, tmp_path: pathlib.Path) -> None:
-        """An unqualified decimal type is read by several servers as scale zero, which rounds
-        every fractional value in a fixture frame to an integer on write -- silently, since the
-        DDL is valid. The default has to say what it means instead of inheriting that.
+    def test_the_float_default_is_not_an_unscaled_decimal(self, tmp_path: pathlib.Path) -> None:
+        """A decimal type with no scale is the shape that silently truncates.
+
+        Several dialects read an unqualified decimal as scale zero, so every fractional value
+        in a fixture frame is rounded to an integer on write -- with valid DDL and no error. A
+        type that names its own precision (a double, or a decimal carrying an explicit scale)
+        leaves the server nothing to decide.
         """
         default_float = self._shared_defaults(tmp_path)[float]
         instance = default_float() if isinstance(default_float, type) else default_float
 
-        precision = getattr(instance, "precision", None)
-        scale = getattr(instance, "scale", None)
-        assert precision is not None or scale is not None, (
-            f"the shared default for `float` is {instance!r}, which carries neither precision "
-            "nor scale, so each server chooses -- and several choose scale zero"
-        )
+        if isinstance(instance, sa.Numeric) and not isinstance(instance, (sa.Float, sa.Double)):
+            assert instance.scale is not None, (
+                f"the shared default for `float` is {instance!r}: a decimal type with no scale, "
+                "which several servers read as scale zero and round every fractional value away"
+            )
 
 
 class TestColumnTypeOverridesMergeOverSharedDefault:

--- a/tests/integration/test_utils/test_sql_batch_test_setup.py
+++ b/tests/integration/test_utils/test_sql_batch_test_setup.py
@@ -14,6 +14,7 @@ import os
 import pathlib
 import subprocess
 import sys
+from datetime import datetime
 from typing import TYPE_CHECKING, ClassVar, List, Mapping, Optional, Sequence, cast
 
 import pandas as pd
@@ -307,6 +308,71 @@ class TestSharedDefaultTypesSayWhatTheyMean:
                 f"the shared default for `float` is {instance!r}: a decimal type with no scale, "
                 "which several servers read as scale zero and round every fractional value away"
             )
+
+
+class TestSharedDefaultTypesRenderAsRecorded:
+    """What each dialect makes of the shared defaults, written down.
+
+    A default type is a per-dialect decision even though it is written once. The DDL it produces
+    is what each server actually sees, and a type can compile cleanly on every dialect and still
+    name something a particular server does not have -- which surfaces as a query error on that
+    backend alone, far from the line that caused it.
+
+    This does not know which renderings are valid; no local check can, since validity is the
+    server's opinion and only a run against one settles it. What it does is make the renderings
+    visible: editing a default changes this table in the same diff, so the per-backend
+    consequences are read at review time rather than discovered a continuous-integration run
+    later. A dialect absent from the environment is skipped, since each lane installs only its
+    own.
+    """
+
+    _RENDERED: ClassVar[Mapping[str, Mapping[str, str]]] = {
+        "postgresql": {"float": "FLOAT(53)", "datetime": "TIMESTAMP WITHOUT TIME ZONE"},
+        "mysql": {"float": "FLOAT(53)", "datetime": "DATETIME"},
+        "sqlite": {"float": "FLOAT", "datetime": "DATETIME"},
+        "mssql": {"float": "FLOAT(53)", "datetime": "DATETIME"},
+        "bigquery": {"float": "FLOAT64", "datetime": "DATETIME"},
+        "snowflake": {"float": "FLOAT", "datetime": "datetime"},
+        "redshift": {"float": "FLOAT(53)", "datetime": "TIMESTAMP WITHOUT TIME ZONE"},
+        "trino": {"float": "DOUBLE", "datetime": "TIMESTAMP"},
+        "databricks": {"float": "FLOAT", "datetime": "TIMESTAMP_NTZ"},
+        "singlestoredb": {"float": "FLOAT(53)", "datetime": "DATETIME"},
+    }
+    """Oracle is absent deliberately: it overrides both of these, so the shared default never
+    reaches its dialect -- and the float default raises rather than compiling there, which is
+    exactly what that override exists to avoid."""
+
+    def test_each_installed_dialect_renders_the_defaults_as_recorded(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        setup = _ThrowawayBatchTestSetup(
+            data=pd.DataFrame({"col_int": [1]}),
+            config=_ThrowawayDatasourceTestConfig(),
+            base_dir=tmp_path,
+            extra_data=_EXTRA_DATA,
+            context=gx.get_context(mode="ephemeral"),
+        )
+        defaults = setup.inferrable_types_lookup
+        by_name = {"float": defaults[float], "datetime": defaults[datetime]}
+
+        checked = []
+        for dialect_name, expected in self._RENDERED.items():
+            try:
+                dialect = sa_dialect_registry.load(dialect_name)()
+            except Exception:  # this lane does not install that dialect
+                continue
+            checked.append(dialect_name)
+            for label, sql_type in by_name.items():
+                instance = sql_type() if isinstance(sql_type, type) else sql_type
+                assert instance.compile(dialect=dialect) == expected[label], (
+                    f"{dialect_name} renders the shared default for `{label}` differently than "
+                    "recorded here; confirm the new rendering is a type that server has, then "
+                    "update this table in the same change"
+                )
+
+        # Non-vacuity: with no dialect loaded every assertion above is skipped, which would make
+        # this pass hardest exactly when it is checking nothing.
+        assert "sqlite" in checked, "no dialect was checked, so this proved nothing"
 
 
 class TestColumnTypeOverridesMergeOverSharedDefault:


### PR DESCRIPTION
## Summary

The integration harness turns a fixture frame's column dtypes into DDL through one shared map of Python type to SQL type (`SqlDataSourceTestConfig.inferrable_types_lookup`). Two entries name a type without saying what it means, and leave the server to decide.

**`float` → unqualified `DECIMAL`.** Several dialects read a bare `DECIMAL` as scale zero and round every fractional value to an integer on write. The DDL is valid and nothing errors — the values under test are simply destroyed on the way into the table. Observed on MySQL against a column whose declared maximum is `22.5`:

```
"kwargs": {"column": "float_value", "min_value": 22.4, "max_value": 22.6}
"result": {"observed_value": 23.0}
```

This is worse than a failure: a test whose thresholds straddle the rounded value passes while asserting about data that is not the data it declared.

**`datetime`/`pd.Timestamp` → `DATETIME`.** PostgreSQL and Oracle have no such type, so table creation fails outright (`psycopg2.errors.UndefinedObject: type "datetime" does not exist`). Any fixture frame carrying a datetime column cannot be created on PostgreSQL at all.

Neither defect is new. Trino, Oracle and ClickHouse each hit one and declared a local override; the shared default stayed wrong for every backend that had not yet tripped over it. Trino's existing comment describes the float defect verbatim.

## What changed

**Portable types, not SQL-standard names.** SQLAlchemy's uppercase types are SQL-standard spellings emitted verbatim, so each is a bet that every server means the same thing by it. No uppercase spelling is right everywhere:

| | postgresql | mysql | mssql | oracle |
|---|---|---|---|---|
| `DATETIME` | no such type | DATETIME | DATETIME | no such type |
| `TIMESTAMP` | TIMESTAMP WITHOUT TIME ZONE | TIMESTAMP | **row version** | — |
| **`DateTime()`** | TIMESTAMP WITHOUT TIME ZONE | DATETIME | DATETIME | DATE |
| `FLOAT(53)` | FLOAT(53) | FLOAT(53) | FLOAT(53) | ArgumentError |
| **`Double()`** | DOUBLE PRECISION | DOUBLE | DOUBLE PRECISION | DOUBLE PRECISION |

The shared defaults are `Float(precision=53)` and `DateTime()`, which each dialect adapts to its own equivalent. `TIMESTAMP` was the first attempt and CI rejected it: in T-SQL that spelling is a deprecated synonym for `ROWVERSION`, an auto-generated binary column that refuses an explicit value, which broke 16 previously-passing tests whose `created_at` column became a row version.

**Overrides, after checking each against a live server.** One is removed and three are added or kept:

- **Trino's `float`** is removed — it existed only to undo the bad default.
- **Oracle keeps both `float` and `datetime`.** The `datetime` pair was removed at first and that was wrong: the shared `DateTime` compiles to Oracle's `DATE`, which carries a time of day and no fraction of a second. A declared `12:00:00.123456` came back `12:00:00` — valid DDL, no error, the exact failure shape this branch exists to remove. `float` stays because a precision-only `FLOAT` raises there over binary vs. decimal precision.
- **Databricks and SingleStore declare `Double()`.** Both were being handed a 4-byte column, by different routes: the Databricks dialect discards the precision and its bare `FLOAT` is single precision, while SingleStore keeps the precision and ignores it — `SHOW CREATE TABLE` reports a plain `float`, and 16777217.0 comes back 16777200.0. One guarded constant states that override once, along with why it is empty under SQLAlchemy 1.4.
- **ClickHouse's `Float64` is unchanged** and its comment now says why it earns its keep: that dialect narrows the same way Databricks does, but every ClickHouse type carries a `Nullable(...)` wrapper, so it states the 64-bit type itself.

**A Spark fix, included deliberately.** The Spark setup converted pandas timestamps to Python ones only inside `if info is not None`, i.e. only when a test declared explicit `column_types`. That is backwards: with a declared schema the value is checked against a known field type, but without one Spark infers from the value alone and matches on exact type, reading a pandas timestamp as `StructType([])` — an empty nested struct no file format can write:

```
pd.Timestamp -> StructField('moment', StructType([]), True)
datetime     -> StructField('moment', TimestampType(), True)
```

That is the `AnalysisException: Datasource does not support writing empty or nested empty schemas` this surfaced on Spark, and it is why any fixture with a datetime column and no declared column types failed there. The conversion now runs unconditionally.

## Tests

**`test_fixture_column_round_trip.py`** declares fractional and datetime values and asserts the backend stored what was declared. The float column carries `16777217.0`, which a 4-byte column cannot represent, and `-3.75`, which scale-zero rounding destroys; both ends are pinned, and each assertion was verified to discriminate only its own defect. The datetime case pins the stored maximum against the declared moment. All four cases run over the canonical-expectations *and* curated-SQL tiers, keyed by label so a data source declaring both is parameterized once — reaching the curated tier is what found SingleStore.

Sub-second datetime fidelity is deliberately not pinned, and the docstring says why: T-SQL's `DATETIME` keeps about 3ms and MySQL's keeps nothing unless a fractional-seconds precision is declared, so carrying microseconds everywhere means changing what those two backends declare — a separate change to how they store every fixture datetime.

**`test_shared_column_type_renderings.py`** records one row per registered SQL backend, resolved from that backend's own declaration — shared default and override together — so an override that changes or disappears moves this table in the same diff. A companion test walks the registry and fails if a registered backend has no row. Resolving a backend's map needed a live setup before, which is why only the defaults could be recorded; it is now `inferrable_types_for(backend_spec)`, a function of the declaration needing no server, with a test pinning that a running setup still reads it.

| | float | datetime |
|---|---|---|
| big-query | FLOAT64 | DATETIME |
| clickhouse | Nullable(Float64) | Nullable(DateTime64(3)) |
| databricks | DOUBLE | TIMESTAMP_NTZ |
| mssql | FLOAT(53) | DATETIME |
| mysql | FLOAT(53) | DATETIME |
| oracle | DECIMAL(38, 10) | TIMESTAMP |
| postgresql | FLOAT(53) | TIMESTAMP WITHOUT TIME ZONE |
| redshift | FLOAT(53) | TIMESTAMP WITHOUT TIME ZONE |
| singlestore | DOUBLE | DATETIME |
| snowflake | FLOAT | datetime |
| sqlite | FLOAT | DATETIME |
| trino | DOUBLE | TIMESTAMP |

Each case carries its own backend's declared marker, so `-m trino` runs the Trino row and `-m snowflake` the Snowflake row. It is a module of its own because every test must carry exactly one required marker, so a module-level marker would be a second one on every case. An absent dialect is caught as `NoSuchModuleError` alone and skipped visibly; anything else fails the case.

A unit test also pins that the shared float default states its own width. It previously asserted nothing — its guard excluded every float-shaped default, so a default naming no width passed silently. It now fails against both shapes it exists to reject.

## Verification

Local, against live containers:

| suite | result |
|---|---|
| sqlite | 640 passed, 2 skipped, 141 xfailed, 13 xpassed |
| mysql | 243 passed, 2 skipped |
| postgresql | 521 passed, 6 skipped, 32 xfailed |
| oracle | 17 passed, 2 skipped |
| trino | 45 passed, 10 skipped, 19 xfailed |
| clickhouse | 24 passed, 2 skipped, 2 xfailed |
| singlestore | 17 passed, 2 skipped |
| spark | 225 passed, 20 skipped |
| filesystem | 233 passed |

SingleStore needed its container run in isolation (it and MySQL both bind 3306) and an amd64 platform override; both were reverted afterwards and nothing about them is in the diff. `make typecheck` clean at 788 files; `ruff check` and `ruff format --check` clean. The postgresql count carries one pre-existing failure unrelated to this diff and reproduced without it.

Credential-gated backends (BigQuery, Snowflake, Redshift, Databricks, SQL Server) are not runnable locally — CI is the evidence for those, and every one of them was green on the commit before the marker split.
