### PR TITLE
[BUGFIX] Cache the SQL execution engine across calls instead of rebuilding it every time

### DIFF
--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -1529,17 +1529,22 @@ class SQLDatasource(Datasource):
             current_execution_engine_kwargs != self._cached_execution_engine_kwargs
             or not self._execution_engine
         ):
-            # Cache a copy: the pop below mutates the dict it is taken from, and the
+            # Copy before the pop below, which mutates the dict it is taken from. The
             # cached copy must keep the "kwargs" key so that it compares equal to the
             # next freshly computed dict. Caching the same object left the cache
             # permanently missing that key, so the comparison never matched and every
             # call built a new execution engine and SQLAlchemy engine.
-            self._cached_execution_engine_kwargs = dict(current_execution_engine_kwargs)
+            cached_execution_engine_kwargs = dict(current_execution_engine_kwargs)
             engine_kwargs = current_execution_engine_kwargs.pop("kwargs", {})
             self._execution_engine = self._execution_engine_type()(
                 **current_execution_engine_kwargs,
                 **engine_kwargs,
             )
+            # Cache only once the engine exists. Caching first would leave a failed
+            # rebuild holding kwargs no engine was ever built from, so the next call
+            # would compare equal and return the engine from the previous configuration
+            # instead of retrying.
+            self._cached_execution_engine_kwargs = cached_execution_engine_kwargs
         return self._execution_engine
 
     @override

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -1529,7 +1529,12 @@ class SQLDatasource(Datasource):
             current_execution_engine_kwargs != self._cached_execution_engine_kwargs
             or not self._execution_engine
         ):
-            self._cached_execution_engine_kwargs = current_execution_engine_kwargs
+            # Cache a copy: the pop below mutates the dict it is taken from, and the
+            # cached copy must keep the "kwargs" key so that it compares equal to the
+            # next freshly computed dict. Caching the same object left the cache
+            # permanently missing that key, so the comparison never matched and every
+            # call built a new execution engine and SQLAlchemy engine.
+            self._cached_execution_engine_kwargs = dict(current_execution_engine_kwargs)
             engine_kwargs = current_execution_engine_kwargs.pop("kwargs", {})
             self._execution_engine = self._execution_engine_type()(
                 **current_execution_engine_kwargs,

--- a/great_expectations/datasource/fluent/sql_server_datasource.py
+++ b/great_expectations/datasource/fluent/sql_server_datasource.py
@@ -248,7 +248,12 @@ class SQLServerDatasource(SQLDatasource):
             current_execution_engine_kwargs != self._cached_execution_engine_kwargs
             or not self._execution_engine
         ):
-            self._cached_execution_engine_kwargs = current_execution_engine_kwargs
+            # Copy before the pops below, which mutate the dict they are taken from. The
+            # cached copy must keep the "kwargs" and "connection_string" keys so that it
+            # compares equal to the next freshly computed dict. Caching the same object
+            # left the cache permanently missing both, so the comparison never matched
+            # and every call built a new execution engine and SQLAlchemy engine.
+            cached_execution_engine_kwargs = dict(current_execution_engine_kwargs)
             engine_kwargs = current_execution_engine_kwargs.pop("kwargs", {})
             current_execution_engine_kwargs.pop("connection_string", None)
             engine = self._create_engine()
@@ -257,6 +262,11 @@ class SQLServerDatasource(SQLDatasource):
                 **current_execution_engine_kwargs,
                 **engine_kwargs,
             )
+            # Cache only once the engine exists. Caching first would leave a failed
+            # rebuild holding kwargs no engine was ever built from, so the next call
+            # would compare equal and return the engine from the previous configuration
+            # instead of retrying.
+            self._cached_execution_engine_kwargs = cached_execution_engine_kwargs
         return self._execution_engine
 
     @override

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1439,12 +1439,16 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
         return batch_data, batch_markers
 
     def get_inspector(self) -> sqlalchemy.engine.reflection.Inspector:
-        if self._inspector is None:
-            if version.parse(sa.__version__) < version.parse("1.4"):
-                # Inspector.from_engine deprecated since 1.4, sa.inspect() should be used instead
-                self._inspector = sqlalchemy.reflection.Inspector.from_engine(self.engine)  # type: ignore[assignment] # FIXME CoP
-            else:
-                self._inspector = sa.inspect(self.engine)  # type: ignore[assignment] # FIXME CoP
+        # A fresh inspector on every call. An Inspector caches the reflection it performs for
+        # its whole lifetime, so an inspector held for the lifetime of this execution engine
+        # would keep serving the column list from the first validation after the table's
+        # schema changed. Building one is cheap; the reflection queries are issued only when a
+        # metric asks for them.
+        if version.parse(sa.__version__) < version.parse("1.4"):
+            # Inspector.from_engine deprecated since 1.4, sa.inspect() should be used instead
+            self._inspector = sqlalchemy.reflection.Inspector.from_engine(self.engine)  # type: ignore[assignment] # FIXME CoP
+        else:
+            self._inspector = sa.inspect(self.engine)  # type: ignore[assignment] # FIXME CoP
 
         return self._inspector  # type: ignore[return-value] # FIXME CoP
 

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1380,6 +1380,11 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
     def get_batch_data_and_markers(
         self, batch_spec: BatchSpec
     ) -> Tuple[SqlAlchemyBatchData, BatchMarkers]:
+        # The inspector caches everything it reflects, and this execution engine is reused
+        # across validations. A batch fetched after the table's schema changed must not be
+        # described by the column list reflected for an earlier one, so the inspector is
+        # rebuilt lazily on the next request. Within one batch it is still reflected once.
+        self._inspector = None
         if not isinstance(batch_spec, (SqlAlchemyDatasourceBatchSpec, RuntimeQueryBatchSpec)):
             raise InvalidBatchSpecError(  # noqa: TRY003 # FIXME CoP
                 f"""SqlAlchemyExecutionEngine accepts batch_spec only of type SqlAlchemyDatasourceBatchSpec or
@@ -1439,16 +1444,12 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
         return batch_data, batch_markers
 
     def get_inspector(self) -> sqlalchemy.engine.reflection.Inspector:
-        # A fresh inspector on every call. An Inspector caches the reflection it performs for
-        # its whole lifetime, so an inspector held for the lifetime of this execution engine
-        # would keep serving the column list from the first validation after the table's
-        # schema changed. Building one is cheap; the reflection queries are issued only when a
-        # metric asks for them.
-        if version.parse(sa.__version__) < version.parse("1.4"):
-            # Inspector.from_engine deprecated since 1.4, sa.inspect() should be used instead
-            self._inspector = sqlalchemy.reflection.Inspector.from_engine(self.engine)  # type: ignore[assignment] # FIXME CoP
-        else:
-            self._inspector = sa.inspect(self.engine)  # type: ignore[assignment] # FIXME CoP
+        if self._inspector is None:
+            if version.parse(sa.__version__) < version.parse("1.4"):
+                # Inspector.from_engine deprecated since 1.4, sa.inspect() should be used instead
+                self._inspector = sqlalchemy.reflection.Inspector.from_engine(self.engine)  # type: ignore[assignment] # FIXME CoP
+            else:
+                self._inspector = sa.inspect(self.engine)  # type: ignore[assignment] # FIXME CoP
 
         return self._inspector  # type: ignore[return-value] # FIXME CoP
 

--- a/tests/datasource/fluent/test_sql_datasources.py
+++ b/tests/datasource/fluent/test_sql_datasources.py
@@ -121,6 +121,30 @@ class TestConfigPasstrough:
             },
         )
 
+    def test_execution_engine_is_cached_across_calls(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        ephemeral_context_with_defaults: EphemeralDataContext,
+        ds_kwargs: dict,
+        filter_gx_datasource_warnings: None,
+    ):
+        """The execution engine, and the SQLAlchemy engine it owns, are built once.
+
+        Every validation goes through ``get_execution_engine``. If the cache never hits, each
+        validation builds a new SQLAlchemy engine and connection pool, and the pooled
+        connection of every abandoned engine lingers on the server until garbage collection.
+        """
+        monkeypatch.setenv("MY_CONN_STR", "sqlite:///")
+
+        context = ephemeral_context_with_defaults
+        ds = context.data_sources.add_or_update_sql(name="my_datasource", **ds_kwargs)
+
+        first = ds.get_execution_engine()
+        second = ds.get_execution_engine()
+
+        assert second is first
+        assert second.engine is first.engine
+
     def test_ds_config_passed_to_gx_sqlalchemy_execution_engine(
         self,
         gx_sqlalchemy_execution_engine_spy: mock.MagicMock,  # noqa: TID251 # FIXME CoP

--- a/tests/datasource/fluent/test_sql_datasources.py
+++ b/tests/datasource/fluent/test_sql_datasources.py
@@ -144,7 +144,59 @@ class TestConfigPasstrough:
         second = ds.get_execution_engine()
 
         assert second is first
-        assert second.engine is first.engine
+
+    def test_changed_config_rebuilds_the_execution_engine(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        ephemeral_context_with_defaults: EphemeralDataContext,
+        ds_kwargs: dict,
+        filter_gx_datasource_warnings: None,
+    ):
+        """Caching must not outlive the configuration the engine was built from.
+
+        The kwargs comparison is the only thing separating a cache hit from a rebuild, so a
+        cache that always hits is as wrong as one that never does: it would serve an engine
+        bound to a connection string the datasource no longer carries.
+        """
+        monkeypatch.setenv("MY_CONN_STR", "sqlite:///")
+
+        context = ephemeral_context_with_defaults
+        ds = context.data_sources.add_or_update_sql(name="my_datasource", **ds_kwargs)
+
+        first = ds.get_execution_engine()
+        ds.create_temp_table = not ds.create_temp_table
+
+        assert ds.get_execution_engine() is not first
+
+    def test_failed_rebuild_does_not_suppress_the_next_one(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        ephemeral_context_with_defaults: EphemeralDataContext,
+        ds_kwargs: dict,
+        filter_gx_datasource_warnings: None,
+    ):
+        """A rebuild that raises must not leave the new kwargs cached against the old engine.
+
+        Construction can fail on a configuration change alone - a rotated connection string
+        naming a driver that is not installed, an unreachable host. If the kwargs were cached
+        before the constructor ran, the next call would compare equal, find the previous
+        engine still in place, and silently return an engine bound to the old configuration.
+        """
+        monkeypatch.setenv("MY_CONN_STR", "sqlite:///")
+
+        context = ephemeral_context_with_defaults
+        ds = context.data_sources.add_or_update_sql(name="my_datasource", **ds_kwargs)
+        first = ds.get_execution_engine()
+
+        def _raise_on_construction(*args, **kwargs):
+            raise RuntimeError("could not connect")
+
+        ds.create_temp_table = not ds.create_temp_table
+        with mock.patch.object(SQLDatasource, "execution_engine_type", _raise_on_construction):
+            with pytest.raises(RuntimeError, match="could not connect"):
+                ds.get_execution_engine()
+
+        assert ds.get_execution_engine() is not first
 
     def test_ds_config_passed_to_gx_sqlalchemy_execution_engine(
         self,

--- a/tests/datasource/fluent/test_sql_datasources.py
+++ b/tests/datasource/fluent/test_sql_datasources.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import pathlib
 import warnings
 from pprint import pformat as pf
 from typing import TYPE_CHECKING, Any, Generator
@@ -607,44 +606,3 @@ def test_sql_multi_column_value_partitioner_declares_no_numeric_param_names():
 
 if __name__ == "__main__":
     pytest.main([__file__, "-vv"])
-
-
-@pytest.mark.unit
-def test_cached_execution_engine_sees_schema_changes(
-    ephemeral_context_with_defaults: EphemeralDataContext,
-    tmp_path: pathlib.Path,
-):
-    """Reusing the execution engine must not reuse stale table metadata.
-
-    The engine's SQLAlchemy inspector caches what it reflects. With the execution engine
-    cached across validations, a column added between two validations has to show up in
-    the second one, exactly as it did when every validation built a fresh engine.
-    """
-    import sqlalchemy as sa
-
-    import great_expectations.expectations as gxe
-
-    db_path = tmp_path / "schema_changes.db"
-    raw_engine = sa.create_engine(f"sqlite:///{db_path}")
-    with raw_engine.begin() as conn:
-        conn.execute(sa.text("CREATE TABLE t (a INTEGER, b INTEGER)"))
-        conn.execute(sa.text("INSERT INTO t VALUES (1, 2)"))
-
-    ds = ephemeral_context_with_defaults.data_sources.add_sqlite(
-        name="schema_changes", connection_string=f"sqlite:///{db_path}"
-    )
-    batch = (
-        ds.add_table_asset(name="t", table_name="t")
-        .add_batch_definition_whole_table(name="whole")
-        .get_batch()
-    )
-
-    before = batch.validate(gxe.ExpectTableColumnCountToEqual(value=2))
-    assert ds.get_execution_engine() is ds.get_execution_engine()
-    with raw_engine.begin() as conn:
-        conn.execute(sa.text("ALTER TABLE t ADD COLUMN c INTEGER"))
-    after = batch.validate(gxe.ExpectTableColumnCountToEqual(value=2))
-
-    assert before.success is True
-    assert after.success is False
-    assert after.result["observed_value"] == 3

--- a/tests/datasource/fluent/test_sql_datasources.py
+++ b/tests/datasource/fluent/test_sql_datasources.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import pathlib
 import warnings
 from pprint import pformat as pf
 from typing import TYPE_CHECKING, Any, Generator
@@ -554,3 +555,44 @@ def test_sql_multi_column_value_partitioner_declares_no_numeric_param_names():
 
 if __name__ == "__main__":
     pytest.main([__file__, "-vv"])
+
+
+@pytest.mark.unit
+def test_cached_execution_engine_sees_schema_changes(
+    ephemeral_context_with_defaults: EphemeralDataContext,
+    tmp_path: pathlib.Path,
+):
+    """Reusing the execution engine must not reuse stale table metadata.
+
+    The engine's SQLAlchemy inspector caches what it reflects. With the execution engine
+    cached across validations, a column added between two validations has to show up in
+    the second one, exactly as it did when every validation built a fresh engine.
+    """
+    import sqlalchemy as sa
+
+    import great_expectations.expectations as gxe
+
+    db_path = tmp_path / "schema_changes.db"
+    raw_engine = sa.create_engine(f"sqlite:///{db_path}")
+    with raw_engine.begin() as conn:
+        conn.execute(sa.text("CREATE TABLE t (a INTEGER, b INTEGER)"))
+        conn.execute(sa.text("INSERT INTO t VALUES (1, 2)"))
+
+    ds = ephemeral_context_with_defaults.data_sources.add_sqlite(
+        name="schema_changes", connection_string=f"sqlite:///{db_path}"
+    )
+    batch = (
+        ds.add_table_asset(name="t", table_name="t")
+        .add_batch_definition_whole_table(name="whole")
+        .get_batch()
+    )
+
+    before = batch.validate(gxe.ExpectTableColumnCountToEqual(value=2))
+    assert ds.get_execution_engine() is ds.get_execution_engine()
+    with raw_engine.begin() as conn:
+        conn.execute(sa.text("ALTER TABLE t ADD COLUMN c INTEGER"))
+    after = batch.validate(gxe.ExpectTableColumnCountToEqual(value=2))
+
+    assert before.success is True
+    assert after.success is False
+    assert after.result["observed_value"] == 3

--- a/tests/datasource/fluent/test_sql_server_datasource.py
+++ b/tests/datasource/fluent/test_sql_server_datasource.py
@@ -10,7 +10,7 @@ from great_expectations.compatibility.pydantic import ValidationError
 from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
 from great_expectations.datasource.fluent.config_str import ConfigStr
 from great_expectations.datasource.fluent.interfaces import TestConnectionError
-from great_expectations.datasource.fluent.sql_datasource import TableAsset
+from great_expectations.datasource.fluent.sql_datasource import SQLDatasource, TableAsset
 from great_expectations.datasource.fluent.sql_server_datasource import (
     EntraIDServicePrincipalAuthConnectionDetails,
     MissingODBCDriverError,
@@ -279,6 +279,65 @@ class TestSQLServerDatasource:
         engine1 = ds.get_engine()
         engine2 = ds.get_engine()
         assert engine1 is engine2
+
+    @pytest.mark.usefixtures("create_engine_fake")
+    def test_get_execution_engine_caches_execution_engine(
+        self,
+        connection_details_default: ConnectionDetailsDict,
+    ) -> None:
+        """This override computes its own cache key, so it needs its own coverage.
+
+        Every validation goes through ``get_execution_engine``. If the cache never hits, each
+        validation builds a new SQLAlchemy engine and connection pool, and SQL Server holds a
+        connection open per engine rather than returning it to the pool after each use.
+        """
+        ds = SQLServerDatasource(
+            name="test_ds",
+            connection_string=SQLServerAuthConnectionDetails(**connection_details_default),
+        )
+
+        first = ds.get_execution_engine()
+        second = ds.get_execution_engine()
+
+        assert second is first
+
+    @pytest.mark.usefixtures("create_engine_fake")
+    def test_changed_config_rebuilds_the_execution_engine(
+        self,
+        connection_details_default: ConnectionDetailsDict,
+    ) -> None:
+        """Caching must not outlive the configuration the engine was built from."""
+        ds = SQLServerDatasource(
+            name="test_ds",
+            connection_string=SQLServerAuthConnectionDetails(**connection_details_default),
+        )
+
+        first = ds.get_execution_engine()
+        ds.create_temp_table = not ds.create_temp_table
+
+        assert ds.get_execution_engine() is not first
+
+    @pytest.mark.usefixtures("create_engine_fake")
+    def test_failed_rebuild_does_not_suppress_the_next_one(
+        self,
+        connection_details_default: ConnectionDetailsDict,
+    ) -> None:
+        """A rebuild that raises must not leave the new kwargs cached against the old engine."""
+        ds = SQLServerDatasource(
+            name="test_ds",
+            connection_string=SQLServerAuthConnectionDetails(**connection_details_default),
+        )
+        first = ds.get_execution_engine()
+
+        def _raise_on_construction(*args: Any, **kwargs: Any) -> None:
+            raise RuntimeError("could not connect")
+
+        ds.create_temp_table = not ds.create_temp_table
+        with patch.object(SQLDatasource, "execution_engine_type", _raise_on_construction):
+            with pytest.raises(RuntimeError, match="could not connect"):
+                ds.get_execution_engine()
+
+        assert ds.get_execution_engine() is not first
 
     @pytest.mark.usefixtures("create_engine_fake")
     def test_add_table_asset_inherits_schema_from_datasource(

--- a/tests/integration/data_sources_and_expectations/data_sources/test_sqlite.py
+++ b/tests/integration/data_sources_and_expectations/data_sources/test_sqlite.py
@@ -1,8 +1,12 @@
+import pathlib
 from datetime import datetime, timezone
 
 import pandas as pd
+import pytest
 
 import great_expectations.expectations as gxe
+from great_expectations.compatibility.sqlalchemy import sqlalchemy as sa
+from great_expectations.data_context import AbstractDataContext
 from great_expectations.datasource.fluent.sql_datasource import TableAsset
 from tests.integration.conftest import parameterize_batch_for_data_sources
 from tests.integration.test_utils.data_source_config import SqliteDatasourceTestConfig
@@ -144,3 +148,42 @@ class TestPartitioning:
             )
         )
         assert result.success
+
+
+@pytest.mark.integration
+@pytest.mark.sqlite
+def test_cached_execution_engine_sees_schema_changes(
+    ephemeral_context_with_defaults: AbstractDataContext,
+    tmp_path: pathlib.Path,
+) -> None:
+    """Reusing the execution engine must not reuse stale table metadata.
+
+    The engine's SQLAlchemy inspector caches what it reflects. With the execution engine
+    cached across validations, a column added between two validations has to show up in
+    the second one, exactly as it did when every validation built a fresh engine. Only a
+    real database reflected twice shows this, so it belongs here rather than in a unit test.
+    """
+    db_path = tmp_path / "schema_changes.db"
+    raw_engine = sa.create_engine(f"sqlite:///{db_path}")
+    with raw_engine.begin() as conn:
+        conn.execute(sa.text("CREATE TABLE t (a INTEGER, b INTEGER)"))
+        conn.execute(sa.text("INSERT INTO t VALUES (1, 2)"))
+
+    ds = ephemeral_context_with_defaults.data_sources.add_sqlite(
+        name="schema_changes", connection_string=f"sqlite:///{db_path}"
+    )
+    batch = (
+        ds.add_table_asset(name="t", table_name="t")
+        .add_batch_definition_whole_table(name="whole")
+        .get_batch()
+    )
+
+    before = batch.validate(gxe.ExpectTableColumnCountToEqual(value=2))
+    assert ds.get_execution_engine() is ds.get_execution_engine()
+    with raw_engine.begin() as conn:
+        conn.execute(sa.text("ALTER TABLE t ADD COLUMN c INTEGER"))
+    after = batch.validate(gxe.ExpectTableColumnCountToEqual(value=2))
+
+    assert before.success is True
+    assert after.success is False
+    assert after.result["observed_value"] == 3

--- a/tests/integration/data_sources_and_expectations/data_sources/test_sqlite.py
+++ b/tests/integration/data_sources_and_expectations/data_sources/test_sqlite.py
@@ -150,7 +150,6 @@ class TestPartitioning:
         assert result.success
 
 
-@pytest.mark.integration
 @pytest.mark.sqlite
 def test_cached_execution_engine_sees_schema_changes(
     ephemeral_context_with_defaults: AbstractDataContext,


### PR DESCRIPTION
## Summary

`SQLDatasource.get_execution_engine` now caches its execution engine as intended. It stored the freshly computed kwargs dict as the cache and then popped `kwargs` out of that same object to pass it to the constructor separately, so the cache was always missing a key the next computation always carried. The comparison never matched, and every call built a new `SqlAlchemyExecutionEngine` with its own SQLAlchemy engine and connection pool. The fix caches a copy. A regression test asserts that two consecutive calls return the same execution engine.

`SQLServerDatasource.get_execution_engine` is an `@override` carrying the same defect and one more key: it pops both `kwargs` and `connection_string` out of the object it just cached, so the cached copy is permanently missing both. Neither is in the exec-engine excludes, so its comparison never matched either. SQL Server is one of the persisted-connection dialects, which hold a connection open on the engine rather than returning it to the pool after each use, so every engine that override discarded pinned a server connection until garbage collection. It now caches a copy the same way.

Both implementations also cache only once the constructor has returned. Caching first — which is what the original code did — left a rebuild that raised holding kwargs no engine was ever built from; the next call then compared equal, found the previous engine still in place, and silently returned an engine bound to the old configuration. That was unreachable while the comparison never matched; making the comparison work is what makes it reachable. `Datasource.get_execution_engine` in `interfaces.py` already orders it this way.

Caching the execution engine exposed a second cache underneath it: `SqlAlchemyExecutionEngine.get_inspector` held one SQLAlchemy inspector for the engine's lifetime, and an inspector caches everything it reflects, so a column added to a table between two validations was invisible to the second. That had only worked because the engine was being rebuilt every time. The cached inspector is now reset whenever a batch is fetched, so a validation after a schema change reflects the table afresh while two metric resolutions against one batch still reflect it once, as the existing tests pin.

## Why

Every validation goes through this accessor. A session that validates repeatedly against one SQL datasource accumulated an idle pooled connection per validation until garbage collection reclaimed the abandoned engines. Against a PostgreSQL with the default connection limit, a few hundred validations on one datasource can exhaust the server's connections for the rest of the process. Rebuilding the engine also re-runs dialect setup and connection tests on every validation for no benefit.

## User impact

Fewer connections held and less setup work per validation on datasources served by `SQLDatasource.get_execution_engine` and the SQL Server override, which is every SQL datasource except Snowflake — whose own override is unchanged here, so the guarantee does not extend to it (see below). No behavior change in results: the same execution engine is returned that was previously rebuilt with identical arguments. Changing the datasource's connection configuration still rebuilds the engine, because the comparison now works as originally designed.

## How to review

The production changes are the `dict(...)` copy and the moved cache write in each of the two `get_execution_engine` implementations, plus the inspector reset at the top of `get_batch_data_and_markers`. Reflection cost per batch is unchanged; `test_table_column_types.py` pins that a table is reflected once per batch and still passes.

To see the defect, check out `develop`, add a sqlite datasource, and compare `ds.get_execution_engine() is ds.get_execution_engine()`; it is `False` there and `True` here.

Each new test was checked against the mutation it exists to catch, and fails only for that one:

- `test_execution_engine_is_cached_across_calls` — caching the dict object rather than a copy
- `test_changed_config_rebuilds_the_execution_engine` — dropping the kwargs comparison for a bare `if not self._execution_engine`, which a caching-only test would not catch
- `test_failed_rebuild_does_not_suppress_the_next_one` — writing the cache above the constructor instead of below it
- `test_cached_execution_engine_sees_schema_changes` — the inspector half

The first three exist in both `tests/datasource/fluent/test_sql_datasources.py` (base class) and `tests/datasource/fluent/test_sql_server_datasource.py` (override); the SQL Server ones use the existing `create_engine_fake` fixture and need no server. The docs example `schema_validation_over_time.py` is the end-to-end check for the inspector half; it failed with only the cache fix applied and passes with both.

### Not in this PR

`SnowflakeDatasource.get_execution_engine` is deliberately unchanged, so the caching guarantee above does not cover Snowflake. Its defect is a different one: it never consults `self._execution_engine` at all, so there is no comparison to repair. It does reuse the SQLAlchemy engine via the cached `get_engine()`, so unlike the two overrides fixed here it holds no extra connections — which is what makes it separable rather than urgent.

Sharing that one engine across throwaway execution engines has a consequence of its own, and giving Snowflake a working cache is the fix for it, so the two belong in one change rather than bolted onto this one. Filed separately with a reproduction.
