### PR TITLE
[CONTRIB] Type-check validator tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,8 +127,6 @@ exclude = [
     'tests/render',
     'tests/test_utils\.py',
     'tests/validator/test_metric_configuration\.py',
-    'tests/validator/test_metrics_calculator\.py',
-    'tests/validator/test_validation_graph\.py',
 ]
 
 [[tool.mypy.overrides]]

--- a/scripts/mypy_relaxation_inventory.json
+++ b/scripts/mypy_relaxation_inventory.json
@@ -93,9 +93,7 @@
     "tests/performance",
     "tests/render",
     "tests/test_utils\\.py",
-    "tests/validator/test_metric_configuration\\.py",
-    "tests/validator/test_metrics_calculator\\.py",
-    "tests/validator/test_validation_graph\\.py"
+    "tests/validator/test_metric_configuration\\.py"
   ],
   "files": [
     "docs",

--- a/tests/validator/test_metrics_calculator.py
+++ b/tests/validator/test_metrics_calculator.py
@@ -115,8 +115,10 @@ def _test_column_partition_metric(
 
     increment = float(n_bins + 1) / n_bins
     for idx, element in enumerate(results[desired_metric.id]):
+        expected_value = increment * idx
         assert isinstance(element, Number)
-        assert isclose(operand_a=element, operand_b=(increment * idx))
+        assert isinstance(expected_value, Number)
+        assert isclose(operand_a=element, operand_b=expected_value)
 
     # Test using "datetime.datetime" column.
 

--- a/tests/validator/test_metrics_calculator.py
+++ b/tests/validator/test_metrics_calculator.py
@@ -1,4 +1,5 @@
 import datetime
+from numbers import Number
 from typing import TYPE_CHECKING, Any, Union, cast
 from unittest import mock
 
@@ -11,8 +12,6 @@ from great_expectations.validator.metric_configuration import MetricConfiguratio
 from great_expectations.validator.metrics_calculator import MetricsCalculator
 
 if TYPE_CHECKING:
-    import pandas as pd
-
     from great_expectations.validator.validator import Validator
 
 
@@ -102,8 +101,6 @@ def _test_column_partition_metric(
     n_bins = 10
 
     increment: Union[float, datetime.timedelta]
-    idx: int
-    element: Union[float, pd.Timestamp]
 
     desired_metric = MetricConfiguration(
         metric_name="column.partition",
@@ -117,10 +114,9 @@ def _test_column_partition_metric(
     results, _ = metrics_calculator.compute_metrics(metric_configurations=[desired_metric])
 
     increment = float(n_bins + 1) / n_bins
-    assert all(
-        isclose(operand_a=element, operand_b=(increment * idx))
-        for idx, element in enumerate(results[desired_metric.id])
-    )
+    for idx, element in enumerate(results[desired_metric.id]):
+        assert isinstance(element, Number)
+        assert isclose(operand_a=element, operand_b=(increment * idx))
 
     # Test using "datetime.datetime" column.
 
@@ -136,15 +132,14 @@ def _test_column_partition_metric(
     results, _ = metrics_calculator.compute_metrics(metric_configurations=[desired_metric])
 
     increment = datetime.timedelta(seconds=(seconds_in_week * float(n_bins + 1) / n_bins))
-    assert all(
-        isclose(
-            operand_a=element.to_pydatetime()
-            if isinstance(validator_with_data.execution_engine, PandasExecutionEngine)
-            else element,
+    for idx, element in enumerate(results[desired_metric.id]):
+        if isinstance(validator_with_data.execution_engine, PandasExecutionEngine):
+            element = element.to_pydatetime()
+        assert isinstance(element, datetime.datetime)
+        assert isclose(
+            operand_a=element,
             operand_b=(datetime.datetime(2021, 1, 1, 0, 0, 0) + (increment * idx)),  # noqa: DTZ001 # FIXME CoP
         )
-        for idx, element in enumerate(results[desired_metric.id])
-    )
 
 
 @pytest.mark.unit

--- a/tests/validator/test_metrics_calculator.py
+++ b/tests/validator/test_metrics_calculator.py
@@ -133,11 +133,12 @@ def _test_column_partition_metric(
 
     increment = datetime.timedelta(seconds=(seconds_in_week * float(n_bins + 1) / n_bins))
     for idx, element in enumerate(results[desired_metric.id]):
+        comparison_value = element
         if isinstance(validator_with_data.execution_engine, PandasExecutionEngine):
-            element = element.to_pydatetime()
-        assert isinstance(element, datetime.datetime)
+            comparison_value = element.to_pydatetime()
+        assert isinstance(comparison_value, datetime.datetime)
         assert isclose(
-            operand_a=element,
+            operand_a=comparison_value,
             operand_b=(datetime.datetime(2021, 1, 1, 0, 0, 0) + (increment * idx)),  # noqa: DTZ001 # FIXME CoP
         )
 

--- a/tests/validator/test_validation_graph.py
+++ b/tests/validator/test_validation_graph.py
@@ -1,6 +1,6 @@
 import sys
 import uuid
-from typing import TYPE_CHECKING, Dict, Iterable, Optional, Set, Union, cast
+from typing import TYPE_CHECKING, Callable, Dict, Iterable, Optional, cast
 from unittest import mock
 
 import pytest
@@ -21,6 +21,7 @@ from great_expectations.validator.validation_graph import (
     MAX_METRIC_COMPUTATION_RETRIES,
     ExpectationValidationGraph,
     MetricEdge,
+    MetricsCalculatorErrorResultValue,
     ValidationGraph,
 )
 
@@ -210,9 +211,11 @@ def test_ExpectationValidationGraph_constructor(
     expect_column_values_to_be_unique_expectation_config: ExpectationConfiguration,
     validation_graph_with_no_edges: ValidationGraph,
 ):
+    untyped_constructor: Callable[..., ExpectationValidationGraph] = ExpectationValidationGraph
+
     with pytest.raises(ValueError) as ve:
         # noinspection PyUnusedLocal,PyTypeChecker
-        expectation_validation_graph = ExpectationValidationGraph(
+        expectation_validation_graph = untyped_constructor(
             configuration=None,
             graph=None,
         )
@@ -223,7 +226,7 @@ def test_ExpectationValidationGraph_constructor(
 
     with pytest.raises(ValueError) as ve:
         # noinspection PyUnusedLocal,PyTypeChecker
-        expectation_validation_graph = ExpectationValidationGraph(
+        expectation_validation_graph = untyped_constructor(
             configuration=expect_column_values_to_be_unique_expectation_config,
             graph=None,
         )
@@ -261,6 +264,7 @@ def test_ExpectationValidationGraph_get_exception_info(
 ) -> None:
     left = metric_edge.left
     right = metric_edge.right
+    assert right is not None
 
     left_exception = ExceptionInfo(
         exception_traceback="my first traceback",
@@ -272,9 +276,17 @@ def test_ExpectationValidationGraph_get_exception_info(
         raised_exception=False,
     )
 
-    metric_info = {
-        left.id: {"exception_info": left_exception},
-        right.id: {"exception_info": right_exception},
+    metric_info: Dict[MetricConfigurationID, MetricsCalculatorErrorResultValue] = {
+        left.id: {
+            "metric_configuration": left,
+            "exception_info": left_exception,
+            "num_failures": 1,
+        },
+        right.id: {
+            "metric_configuration": right,
+            "exception_info": right_exception,
+            "num_failures": 1,
+        },
     }
 
     expect_column_values_to_be_unique_expectation_validation_graph.update(
@@ -384,11 +396,6 @@ def test_resolve_validation_graph_with_bad_config_catch_exceptions_true(
         runtime_configuration=runtime_configuration,
     )
 
-    resolved_metrics: Dict[MetricConfigurationID, MetricValue]
-    aborted_metrics_info: Dict[
-        MetricConfigurationID,
-        Dict[str, Union[MetricConfiguration, Set[ExceptionInfo], int]],
-    ]
     _resolved_metrics, aborted_metrics_info = graph.resolve(
         runtime_configuration=runtime_configuration,
         min_graph_edges_pbar_enable=0,
@@ -404,7 +411,7 @@ def test_resolve_validation_graph_with_bad_config_catch_exceptions_true(
 
     assert (
         'Error: The column "not_in_table" in BatchData does not exist.'
-        in exception_info["exception_message"]
+        in exception_info.exception_message
     )
 
 
@@ -462,24 +469,14 @@ def test_progress_bar_config(
             "great_expectations.validator.validation_graph.tqdm",
         ) as mock_tqdm,
     ):
-        call_args = {
-            "runtime_configuration": None,
-        }
-        if show_progress_bars is not None:
-            call_args.update(
-                {
-                    "show_progress_bars": show_progress_bars,
-                }
-            )
-
         graph = ValidationGraph(execution_engine=execution_engine)
-        resolved_metrics: Dict[MetricConfigurationID, MetricValue]
-        aborted_metrics_info: Dict[
-            MetricConfigurationID,
-            Dict[str, Union[MetricConfiguration, Set[ExceptionInfo], int]],
-        ]
-        # noinspection PyUnusedLocal
-        _resolved_metrics, _aborted_metrics_info = graph.resolve(**call_args)
+        if show_progress_bars is None:
+            _resolved_metrics, _aborted_metrics_info = graph.resolve(runtime_configuration=None)
+        else:
+            _resolved_metrics, _aborted_metrics_info = graph.resolve(
+                runtime_configuration=None,
+                show_progress_bars=show_progress_bars,
+            )
         assert mock_tqdm.called is True
         assert mock_tqdm.call_args[1]["disable"] is are_progress_bars_disabled
 


### PR DESCRIPTION
Closes #12135

This PR removes the mypy exclusions for the validator metric calculator and validation graph tests and resolves the existing typing issues without changing production behavior.

Changes include:
- narrow metric values to their expected numeric and datetime types
- use the typed validation graph error result structure
- preserve the intentional invalid-constructor runtime coverage using the maintainer-recommended untyped `Callable` alias
- pass `ValidationGraph.resolve()` arguments directly instead of through an ambiguously typed dictionary
- remove the two validator test exclusions from `pyproject.toml`
- update the mypy relaxation inventory to match

Testing:
- Not run locally in this environment.
- Opening as a draft so the repository CI can run the required type-checking and test validation.

No production behavior is changed by this PR.
<!--
Describe your change above.

Some changes need an RFC (Request For Comment) agreed before implementation, so that the
design discussion happens before anyone invests in code. An RFC is required for:

  - breaking changes to a public API
  - adding support for a new data source or execution engine
  - changes to a canonical JSON schema's version
  - cross-cutting architectural decisions that affect multiple subsystems

An RFC is not required for bug fixes, additive non-breaking API changes, new Expectations that
conform to the existing Expectation interface, documentation changes, or performance changes
that don't alter behavior.

If your change needs an RFC, open one in the Request For Comment discussion category first, then
add a line to the description above linking it. Full criteria and process:
https://github.com/fivetran/great_expectations/blob/develop/CONTRIBUTING.md#requesting-comment-on-larger-changes

For changes that add a new data source or execution engine, an automated check looks for one of
these two lines in the description above, written exactly in this form:

  RFC: <link to the accepted discussion>
  No RFC needed: <reason this isn't new backend support>

Either answer satisfies the check — it only asks that the question was answered. Linking the RFC
in prose won't be recognized, so use the line form.
-->

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/fivetran/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] This change is below the [RFC threshold](https://github.com/fivetran/great_expectations/blob/develop/CONTRIBUTING.md#requesting-comment-on-larger-changes), or the description above carries an `RFC: <link>` line pointing at an accepted RFC
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated
- [x] For any behavioral change to a data source, validation mechanic, or Expectation, at least one integration test exists in `tests/integration/data_sources_and_expectations` (see [AGENTS.md](https://github.com/fivetran/great_expectations/blob/develop/AGENTS.md#integration-test-requirement))
- [x] If this PR proposes adopting or recommending a particular third-party library or service, any affiliation with it (employment, financial interest, maintainership) is disclosed above for the reviewer's context

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
