### PR TITLE
[MAINTENANCE]Type-check tests/render

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,6 @@ exclude = [
     'tests/integration/test_definitions',
     'tests/integration/test_script_runner\.py',
     'tests/performance',
-    'tests/render',
     'tests/validator/test_metric_configuration\.py',
     'tests/validator/test_metrics_calculator\.py',
     'tests/validator/test_validation_graph\.py',

--- a/scripts/mypy_relaxation_inventory.json
+++ b/scripts/mypy_relaxation_inventory.json
@@ -89,7 +89,6 @@
     "tests/integration/test_definitions",
     "tests/integration/test_script_runner\\.py",
     "tests/performance",
-    "tests/render",
     "tests/validator/test_metric_configuration\\.py",
     "tests/validator/test_metrics_calculator\\.py",
     "tests/validator/test_validation_graph\\.py"

--- a/tests/render/conftest.py
+++ b/tests/render/conftest.py
@@ -1,35 +1,19 @@
 from __future__ import annotations
 
 import json
-import os
 from typing import TYPE_CHECKING
 
 import pytest
 
-import great_expectations as gx
 from great_expectations.checkpoint.checkpoint import Checkpoint, CheckpointResult
 from great_expectations.core.expectation_validation_result import ExpectationSuiteValidationResult
 from great_expectations.core.run_identifier import RunIdentifier
-from great_expectations.data_context.data_context.file_data_context import (
-    FileDataContext,
-)
 from great_expectations.data_context.types.resource_identifiers import ValidationResultIdentifier
 from great_expectations.data_context.util import file_relative_path
 from great_expectations.self_check.util import expectationSuiteValidationResultSchema
 
 if TYPE_CHECKING:
     import pytest_mock
-
-
-@pytest.fixture(scope="module")
-def empty_data_context_module_scoped(tmp_path_factory) -> FileDataContext:
-    # Re-enable GE_USAGE_STATS
-    project_path = str(tmp_path_factory.mktemp("empty_data_context"))
-    context = gx.data_context.FileDataContext.create(project_path)
-    context_path = os.path.join(project_path, FileDataContext.GX_DIR)  # noqa: PTH118 # FIXME CoP
-    asset_config_path = os.path.join(context_path, "expectations")  # noqa: PTH118 # FIXME CoP
-    os.makedirs(asset_config_path, exist_ok=True)  # noqa: PTH103 # FIXME CoP
-    return context
 
 
 @pytest.fixture

--- a/tests/render/renderer/content_block/test_content_block.py
+++ b/tests/render/renderer/content_block/test_content_block.py
@@ -61,6 +61,7 @@ if TYPE_CHECKING:
 def test__render_expectation_notes_with_notes(expectation: Expectation, expected: list[dict]):
     config = expectation.configuration
     content = ContentBlockRenderer._render_expectation_notes(config)
+    assert isinstance(content.collapse, list)
     notes_block = content.collapse[0]
     actual = notes_block.to_json_dict()["text"]
     assert actual == expected

--- a/tests/render/test_inline_renderer.py
+++ b/tests/render/test_inline_renderer.py
@@ -39,7 +39,7 @@ def test_inline_renderer_instantiation_error_message(
 ):
     expectation_suite: ExpectationSuite = basic_expectation_suite
     with pytest.raises(InlineRendererError) as e:
-        InlineRenderer(render_object=expectation_suite)  # type: ignore # FIXME CoP
+        InlineRenderer(render_object=expectation_suite)  # type: ignore[arg-type] # FIXME CoP
     assert (
         str(e.value)
         == "InlineRenderer can only be used with an ExpectationConfiguration or ExpectationValidationResult, but <class 'great_expectations.core.expectation_suite.ExpectationSuite'> was used."  # noqa: E501 # FIXME CoP

--- a/tests/render/test_page_renderer.py
+++ b/tests/render/test_page_renderer.py
@@ -9,6 +9,7 @@ import mistune
 import pytest
 
 from great_expectations.checkpoint import UpdateDataDocsAction
+from great_expectations.compatibility.pydantic import AnyUrl, parse_obj_as
 from great_expectations.core.expectation_suite import ExpectationSuite
 from great_expectations.core.expectation_validation_result import (
     ExpectationSuiteValidationResult,
@@ -567,7 +568,7 @@ def _normalize_graph_blocks(obj: dict | list) -> None:
 
 
 def test_snapshot_ValidationResultsPageRenderer_render_with_run_info_at_end(
-    titanic_profiled_evrs_1: ExpectationValidationResult,
+    titanic_profiled_evrs_1: ExpectationSuiteValidationResult,
     ValidationResultsPageRenderer_render_with_run_info_at_end,
 ):
     validation_results_page_renderer = ValidationResultsPageRenderer(run_info_at_end=True)
@@ -585,7 +586,7 @@ def test_snapshot_ValidationResultsPageRenderer_render_with_run_info_at_end(
 
 
 def test_snapshot_ValidationResultsPageRenderer_render_with_run_info_at_start(
-    titanic_profiled_evrs_1: ExpectationValidationResult,
+    titanic_profiled_evrs_1: ExpectationSuiteValidationResult,
     ValidationResultsPageRenderer_render_with_run_info_at_start,
 ):
     validation_results_page_renderer = ValidationResultsPageRenderer(run_info_at_end=False)
@@ -622,7 +623,10 @@ def test_asset_name_is_part_of_resource_info_index(mocker: MockerFixture):
 
     data_asset = context.data_sources.pandas_default.add_csv_asset(
         "my_asset",
-        "https://raw.githubusercontent.com/great-expectations/gx_tutorials/main/data/yellow_tripdata_sample_2019-01.csv",
+        parse_obj_as(
+            AnyUrl,
+            "https://raw.githubusercontent.com/great-expectations/gx_tutorials/main/data/yellow_tripdata_sample_2019-01.csv",
+        ),
     )
 
     batch_definition = data_asset.add_batch_definition_whole_dataframe("my_batch")

--- a/tests/render/test_renderer_configuration.py
+++ b/tests/render/test_renderer_configuration.py
@@ -7,6 +7,7 @@ import pytest
 from great_expectations.compatibility.pydantic import (
     error_wrappers as pydantic_error_wrappers,
 )
+from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core import (
     ExpectationValidationResult,
 )
@@ -77,7 +78,7 @@ def test_successful_renderer_configuration_instantiation(
         type=expectation_type,
         kwargs=kwargs,
     )
-    renderer_configuration = RendererConfiguration(
+    renderer_configuration: RendererConfiguration = RendererConfiguration(
         configuration=expectation_configuration,
         runtime_configuration=runtime_configuration,
     )
@@ -165,7 +166,7 @@ def test_successful_renderer_row_condition_params(
         type=expectation_type,
         kwargs=kwargs,
     )
-    renderer_configuration = RendererConfiguration(
+    renderer_configuration: RendererConfiguration = RendererConfiguration(
         configuration=expectation_configuration,
         runtime_configuration={},
     )
@@ -192,6 +193,7 @@ def test_failed_renderer_configuration_instantiation():
 
 
 class NotString:
+    @override
     def __str__(self):
         raise TypeError("I'm not a string")
 
@@ -213,7 +215,9 @@ def test_renderer_configuration_add_param_validation(
         type="expect_table_row_count_to_equal",
         kwargs={"value": value},
     )
-    renderer_configuration = RendererConfiguration(configuration=expectation_configuration)
+    renderer_configuration: RendererConfiguration = RendererConfiguration(
+        configuration=expectation_configuration
+    )
     with pytest.raises(pydantic_error_wrappers.ValidationError) as e:
         renderer_configuration.add_param(name="value", param_type=param_type)
 
@@ -223,10 +227,15 @@ def test_renderer_configuration_add_param_validation(
         )
     else:
         exception_message = f"Param type: <{param_type}> does not match value: <{value}>."
-    assert any(
-        str(error_wrapper_exc) == exception_message
-        for error_wrapper_exc in [error_wrapper.exc for error_wrapper in e.value.raw_errors]
-    )
+
+    found_expected_error = False
+
+    for error_wrapper in e.value.raw_errors:
+        assert isinstance(error_wrapper, pydantic_error_wrappers.ErrorWrapper)
+        if str(error_wrapper.exc) == exception_message:
+            found_expected_error = True
+
+    assert found_expected_error
 
 
 @pytest.mark.unit


### PR DESCRIPTION

<!--
Describe your change above.

Some changes need an RFC (Request For Comment) agreed before implementation, so that the
design discussion happens before anyone invests in code. An RFC is required for:

  - breaking changes to a public API
  - adding support for a new data source or execution engine
  - changes to a canonical JSON schema's version
  - cross-cutting architectural decisions that affect multiple subsystems

An RFC is not required for bug fixes, additive non-breaking API changes, new Expectations that
conform to the existing Expectation interface, documentation changes, or performance changes
that don't alter behavior.

If your change needs an RFC, open one in the Request For Comment discussion category first, then
add a line to the description above linking it. Full criteria and process:
https://github.com/fivetran/great_expectations/blob/develop/CONTRIBUTING.md#requesting-comment-on-larger-changes

For changes that add a new data source or execution engine, an automated check looks for one of
these two lines in the description above, written exactly in this form:

  RFC: <link to the accepted discussion>
  No RFC needed: <reason this isn't new backend support>

Either answer satisfies the check — it only asks that the question was answered. Linking the RFC
in prose won't be recognized, so use the line form.
-->

Closes #12136

Fix type-checking issues in tests/render/ with minimal code changes.

The changes are limited to type annotations and small test adjustments needed to satisfy mypy without changing rendering behavior.

Tests:
- pytest tests/render/

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/fivetran/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] This change is below the [RFC threshold](https://github.com/fivetran/great_expectations/blob/develop/CONTRIBUTING.md#requesting-comment-on-larger-changes), or the description above carries an `RFC: <link>` line pointing at an accepted RFC
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated
- [x] For any behavioral change to a data source, validation mechanic, or Expectation, at least one integration test exists in `tests/integration/data_sources_and_expectations` (see [AGENTS.md](https://github.com/fivetran/great_expectations/blob/develop/AGENTS.md#integration-test-requirement))
- [x] If this PR proposes adopting or recommending a particular third-party library or service, any affiliation with it (employment, financial interest, maintainership) is disclosed above for the reviewer's context

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
