### PR TITLE
[MAINTENANCE] Clean up check-actor-permissions and dead CI workflow code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,41 +70,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Notify on Lack of Permission
-        if: steps.check-user-permission.outputs.require-result == 'false'
-        id: slack-user-permission
-        uses: slackapi/slack-github-action@v1.27.0
-        with:
-          payload: |
-            {
-              "MESSAGE": "${{github.actor}} opened a PR from a fork. Please carefully review the code and retry failed jobs.",
-              "GHA_LINK": "${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PERMISSION_CHECK_WEBHOOK_URL }}
-
-      - name: Notify on Bot Commiting
-        if: steps.check-user-permission.outputs.check-result == 'false'
-        id: slack-bot-user
-        uses: slackapi/slack-github-action@v1.27.0
-        with:
-          payload: |
-            {
-              "MESSAGE": "${{github.actor}} modified a branch but can't run CI. Please carefully review the code and retry failed jobs.",
-              "GHA_LINK": "${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PERMISSION_CHECK_WEBHOOK_URL }}
-
       - name: Add comment to add helpful context for contributors
-        if: steps.check-user-permission.outputs.require-result == 'false' && steps.check-user-permission.outputs.check-result == 'false'
+        if: steps.check-user-permission.outputs.require-result == 'false'
         uses: thollander/actions-comment-pull-request@v2.5.0
         with:
           comment_tag: execution
           message: |
             Thanks for the PR @${{github.actor}} :wave:
 
-            Our GitHub actions pipelines require a user with write permissions to retry the failed jobs. We've sent a message to a maintainer to review your PR. Please be patient and we'll get back to you as soon as possible.
+            Our GitHub actions pipelines require a user with write permissions to retry the failed jobs. A maintainer will review your PR and re-run CI. Please be patient and we'll get back to you as soon as possible.
 
       - name: Fail if No Write Permission
         if: steps.check-user-permission.outputs.require-result == 'false'
@@ -405,30 +379,6 @@ jobs:
           NODE_OPTIONS: --max_old_space_size=4096
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
         run: cd docs/docusaurus && yarn install && bash ../build_docs
-
-      - name: Restore lychee cache
-        uses: actions/cache@v4
-        with:
-          path: .lycheecache
-          key: cache-lychee-${{ github.sha }}
-          restore-keys: cache-lychee-
-
-      # - name: Run broken link checker
-      #   uses: lycheeverse/lychee-action@v2.0.2
-      #   with:
-      #     # We decided to exclude all external HTTP requests but the ones that under the domain greatexpectations.io
-      #     # The reason is to avoid having network errors such as pages that throw 429 after too many requests (like Github)
-      #     # and to prevent other possible errors related to user agent or lychee capturing hrefs from metadata that don't resolve
-      #     # to a specific page (preconnects in JS)
-      #     args: >-
-      #       --method GET
-      #       --user-agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
-      #       --max-concurrency 16
-      #       --max-retries 3
-      #       --accept '100..=103,200..=299,403'
-      #       --exclude='http.*'
-      #       --include='^https://(.+\.)?greatexpectations\.io/'
-      #       'docs/docusaurus/build/**/*.html'
 
   docs-tests:
     needs: [check-actor-permissions]
@@ -1017,6 +967,7 @@ jobs:
       - docs-snippets
       - integration-tests
       - marker-tests
+      - pyspark4-marker-tests
       - marker-tests-snowflake
       - redshift
       - py310-min-versions
@@ -1025,6 +976,7 @@ jobs:
       - py313-min-versions
       - pydantic-v1
       - pandas2-test
+      - marshmallow4-test
       - airflow-min-versions
       - import_gx
     runs-on: ubuntu-latest
@@ -1061,6 +1013,7 @@ jobs:
         unit-tests,
         integration-tests,
         marker-tests,
+        pyspark4-marker-tests,
         marker-tests-snowflake,
         py310-min-versions,
         py311-min-versions,
@@ -1068,6 +1021,7 @@ jobs:
         py313-min-versions,
         pydantic-v1,
         pandas2-test,
+        marshmallow4-test,
         airflow-min-versions,
         import_gx,
       ]
@@ -1112,6 +1066,7 @@ jobs:
         unit-tests,
         integration-tests,
         marker-tests,
+        pyspark4-marker-tests,
         marker-tests-snowflake,
         py310-min-versions,
         py311-min-versions,
@@ -1119,6 +1074,7 @@ jobs:
         py313-min-versions,
         pydantic-v1,
         pandas2-test,
+        marshmallow4-test,
         airflow-min-versions,
         import_gx,
         build-n-publish,


### PR DESCRIPTION
## Summary

`check-actor-permissions` posts a custom `{MESSAGE, GHA_LINK}` JSON body to `slackapi/slack-github-action`, but the destination webhook rejects it (`missing_args`) since it expects a standard Incoming Webhook payload (`text`/`blocks`), not custom keys. Flagged in a community discussion; maintainers monitor the repo through other channels, so this removes the broken Slack steps rather than fixing the payload shape.

While in the job: the "Add comment to add helpful context for contributors" step required `check-user-permission`'s `check-result` output to be `'false'`, but nothing in the job ever sets the `check-bot`/`check-contributor` inputs that populate that output — so it's never set, and the condition could never be true. Fork contributors have never actually seen this comment. Dropped the dead conjunct (the comment's text is also updated now that it no longer references a Slack message being sent). "Notify on Bot Commiting" was gated the same unreachable way and is removed for the same reason.

While surveying the rest of the file for similar rot:
- `pyspark4-marker-tests` and `marshmallow4-test` were never added to `ci-required`'s or `build-n-publish`'s `needs`, so a failure in either lane currently has no effect on merge or release gating. Added both.
- `docs-build` restored a lychee cache for a broken-link-checker step that's been fully commented out for a while; removed both since nothing consumes the cache.

## Why

The Slack notification for fork PRs has silently never worked since it was introduced, and the fallback contributor-facing PR comment has independently never fired due to an unrelated condition bug from the same PR. Neither gap was visible from the outside since `check-actor-permissions` still fails as designed for fork PRs regardless of whether these side-effects succeed — this only surfaced because a contributor noticed the missing Slack ping and asked about it.

## User impact

Contributors opening PRs from forks will now see the "we'll review your PR" comment again. No change to required-check behavior for fork PRs (a maintainer still needs to approve and re-run CI) — only the notification/comment side-effects and the two dead-code cleanups.

`pyspark4-marker-tests` and `marshmallow4-test` failures will now block `ci-required` and (on tagged pushes) `build-n-publish`, where previously they did not.

## How to review

- Confirm the removed Slack steps and cache-restore step have no other consumers.
- Confirm the `check-result`/`check-bot`/`check-contributor` analysis: `check-user-permission`'s own source only sets the `check-result` output when one of those inputs is provided, and this job supplies neither.
- The `ci-required`/`build-n-publish` `needs` additions are a real (if narrow) gating behavior change — worth a second look on whether that's desired now vs. as a follow-up.