### PR TITLE
[BUGFIX] Wrap a query asset's SQL whole so Oracle does not add FROM DUAL

### DIFF
--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -90,6 +90,9 @@ from great_expectations.execution_engine.partition_and_sample.data_partitioner i
 from great_expectations.execution_engine.partition_and_sample.sqlalchemy_data_partitioner import (
     SqlAlchemyDataPartitioner,
 )
+from great_expectations.execution_engine.sqlalchemy_execution_engine import (
+    _query_text_as_subquery,
+)
 
 if TYPE_CHECKING:
     # We re-import sqlalchemy here to make type-checking and our compatability layer
@@ -1142,7 +1145,7 @@ class QueryAsset(_SQLAsset):
 
         This can be used in a subselect FROM clause for queries against this data.
         """
-        return sa.select(sa.text(self.query.lstrip()[6:])).subquery()
+        return _query_text_as_subquery(self.query)
 
     @override
     def _create_batch_spec_kwargs(self) -> Dict[str, Any]:

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -266,6 +266,23 @@ def _wrap_raw_sql_as_subquery(selectable: sqlalchemy.TextClause) -> Subquery:
     return sa.text(text).columns().subquery()
 
 
+def _query_text_as_subquery(query: str) -> Subquery:
+    """Wrap a query asset's raw SQL statement as a subquery.
+
+    The statement is handed to SQLAlchemy whole. Rebuilding it as
+    "sa.select(sa.text(<everything after SELECT>))" instead yields a SELECT that owns no
+    FROM clause, which the Oracle dialect completes by appending "FROM DUAL" -- the
+    wrapped query then carries two FROM clauses and no Oracle version accepts it.
+
+    Args:
+        query: The raw SQL statement backing a query asset.
+
+    Returns:
+        A Subquery that selects the statement's result.
+    """
+    return _wrap_raw_sql_as_subquery(sa.text(query.strip().rstrip(";").rstrip()))
+
+
 class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
     """SparkDFExecutionEngine instantiates the ExecutionEngine API to support computations using Spark platform.
 
@@ -1399,10 +1416,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
             if not isinstance(query, str):
                 raise ValueError(f"SQL query should be a str but got {query}")  # noqa: TRY003 # FIXME CoP
             # Query is a valid SELECT query that begins with r"\w+select\w"
-            stripped_query = query.lstrip()[6:].strip().rstrip(";").rstrip()
-            selectable = sa.select(
-                sa.text(_ensure_sql_text_ends_with_newline(stripped_query))
-            ).subquery()
+            selectable = _query_text_as_subquery(query)
 
         return selectable
 

--- a/tests/datasource/fluent/data_asset/test_sql_asset.py
+++ b/tests/datasource/fluent/data_asset/test_sql_asset.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime, timezone
+from importlib import import_module
 from typing import Any
 
 import pytest
@@ -12,6 +13,7 @@ from great_expectations.core.partitioners import (
 )
 from great_expectations.datasource.fluent import SQLDatasource
 from great_expectations.datasource.fluent.sql_datasource import (
+    QueryAsset,
     SqlAddBatchDefinitionError,
     TableAsset,
     _SQLAsset,
@@ -350,3 +352,44 @@ def test_validate_batch_definition(
 # Tests I considered adding for test_validate_batch_definition but have not.
 # 1. Engine dies on connect
 # 2. Connection dies on execute
+
+
+# Every dialect this repo renders SQL for in unit tests, keyed by the alias suffix its
+# compiler emits before a subquery alias. Oracle omits the "AS"; the rest keep it.
+QUERY_ASSET_SUBQUERY_ALIAS_PREFIX_BY_DIALECT = {
+    "sqlite": "AS ",
+    "postgresql": "AS ",
+    "mssql": "AS ",
+    "mysql": "AS ",
+    "oracle": "",
+}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "dialect_name", sorted(QUERY_ASSET_SUBQUERY_ALIAS_PREFIX_BY_DIALECT), ids=str
+)
+def test_query_asset_as_selectable_wraps_the_whole_statement(dialect_name: str) -> None:
+    """A query asset's selectable must wrap the user's statement unchanged.
+
+    The statement has to reach the compiler whole. Rebuilding it as a select over everything
+    after its "SELECT" produces a select that owns no FROM clause, and the Oracle dialect
+    completes such a select by appending "FROM DUAL" -- so the wrapped query went out with two
+    FROM clauses and no Oracle version accepted it. This is the selectable a batch definition
+    is validated against, so the failure landed on adding one, not on reading a batch.
+
+    Only the Oracle case fails without the fix this pins; the other four are here to pin that
+    the change leaves what they select untouched.
+
+    The newline before the closing parenthesis is deliberate: it keeps that parenthesis and
+    the alias out of reach of a line comment the statement may end in.
+    """
+    query = "SELECT id, created_at FROM my_table"
+    asset = QueryAsset(name="query_asset", query=query)
+
+    selectable = asset.as_selectable()
+
+    dialect = import_module(f"sqlalchemy.dialects.{dialect_name}").dialect()
+    rendered = str(sqlalchemy.select("*").select_from(selectable).compile(dialect=dialect))
+    alias_prefix = QUERY_ASSET_SUBQUERY_ALIAS_PREFIX_BY_DIALECT[dialect_name]
+    assert rendered == f"SELECT * \nFROM ({query}\n) {alias_prefix}anon_1"

--- a/tests/datasource/fluent/data_asset/test_sql_asset.py
+++ b/tests/datasource/fluent/data_asset/test_sql_asset.py
@@ -389,6 +389,7 @@ def test_query_asset_as_selectable_wraps_the_whole_statement(dialect_name: str) 
 
     selectable = asset.as_selectable()
 
+    assert isinstance(selectable, sqlalchemy.Subquery)
     dialect = import_module(f"sqlalchemy.dialects.{dialect_name}").dialect()
     rendered = str(sqlalchemy.select("*").select_from(selectable).compile(dialect=dialect))
     alias_prefix = QUERY_ASSET_SUBQUERY_ALIAS_PREFIX_BY_DIALECT[dialect_name]

--- a/tests/datasource/fluent/data_asset/test_sql_asset.py
+++ b/tests/datasource/fluent/data_asset/test_sql_asset.py
@@ -389,7 +389,9 @@ def test_query_asset_as_selectable_wraps_the_whole_statement(dialect_name: str) 
 
     selectable = asset.as_selectable()
 
-    assert isinstance(selectable, sqlalchemy.Subquery)
+    # sqlalchemy.sql.Subquery, not sqlalchemy.Subquery: only the former exists on both
+    # SQLAlchemy 1.4 and 2.0, and the minimum-version lanes install 1.4.
+    assert isinstance(selectable, sqlalchemy.sql.Subquery)
     dialect = import_module(f"sqlalchemy.dialects.{dialect_name}").dialect()
     rendered = str(sqlalchemy.select("*").select_from(selectable).compile(dialect=dialect))
     alias_prefix = QUERY_ASSET_SUBQUERY_ALIAS_PREFIX_BY_DIALECT[dialect_name]

--- a/tests/execution_engine/partition_and_sample/test_sqlalchemy_execution_engine_partitioning.py
+++ b/tests/execution_engine/partition_and_sample/test_sqlalchemy_execution_engine_partitioning.py
@@ -18,6 +18,7 @@ from dateutil.parser import parse
 
 from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
 from great_expectations.data_context.util import file_relative_path
+from great_expectations.execution_engine import SqlAlchemyExecutionEngine
 from great_expectations.execution_engine.partition_and_sample.sqlalchemy_data_partitioner import (
     DatePart,
     SqlAlchemyDataPartitioner,
@@ -41,7 +42,6 @@ from tests.integration.fixtures.partition_and_sample_data.partitioner_test_cases
 from tests.test_utils import convert_string_columns_to_datetime
 
 if TYPE_CHECKING:
-    from great_expectations.execution_engine import SqlAlchemyExecutionEngine
     from great_expectations.execution_engine.sqlalchemy_batch_data import (
         SqlAlchemyBatchData,
     )
@@ -876,3 +876,86 @@ def test_sqlite_get_data_for_batch_identifiers_on_hashed_column(sa):
     assert {
         batch_identifiers[column_name] for batch_identifiers in batch_identifiers_list
     } == expected_hash_values
+
+
+# A query asset carrying a daily batch definition: the batch spec has both a `query` and a
+# `partitioner_method`, which is the combination that skips the unwrapped-query shortcut in
+# `_build_selectable_from_batch_spec` and wraps the statement as a subquery instead.
+PARTITIONED_QUERY_ASSET_QUERY = "SELECT id, created_at FROM my_table"
+PARTITIONED_QUERY_ASSET_BATCH_SPEC = SqlAlchemyDatasourceBatchSpec(
+    data_asset_name="query_asset",
+    query=PARTITIONED_QUERY_ASSET_QUERY,
+    partitioner_method="partition_on_year_and_month_and_day",
+    partitioner_kwargs={"column_name": "created_at"},
+    batch_identifiers={"created_at": {"year": 2024, "month": 1, "day": 15}},
+)
+
+# Pinned exact renderings, one per dialect. Only the Oracle case fails without the fix this
+# pins -- it is the dialect that completes a FROM-less SELECT by appending "FROM DUAL", which
+# left the wrapped statement carrying two FROM clauses. The other four are here to pin that
+# wrapping the whole statement rather than rebuilding it from its column list leaves their
+# rendering untouched, so they pass before and after that change by design.
+EXPECTED_PARTITIONED_QUERY_ASSET_SQL_BY_DIALECT = {
+    "sqlite": (
+        "select*from(selectid,created_atfrommy_table)asanon_1"
+        "wherecast(strftime('%y',created_at)asinteger)=2024"
+        "andcast(strftime('%m',created_at)asinteger)=1"
+        "andcast(strftime('%d',created_at)asinteger)=15"
+    ),
+    "postgresql": (
+        "select*from(selectid,created_atfrommy_table)asanon_1"
+        "whereextract(yearfromcreated_at)=2024"
+        "andextract(monthfromcreated_at)=1"
+        "andextract(dayfromcreated_at)=15"
+    ),
+    "mssql": (
+        "select*from(selectid,created_atfrommy_table)asanon_1"
+        "wheredatepart(year,created_at)=2024"
+        "anddatepart(month,created_at)=1"
+        "anddatepart(day,created_at)=15"
+    ),
+    "mysql": (
+        "select*from(selectid,created_atfrommy_table)asanon_1"
+        "whereextract(yearfromcreated_at)=2024"
+        "andextract(monthfromcreated_at)=1"
+        "andextract(dayfromcreated_at)=15"
+    ),
+    # No "as" before the alias: this dialect's compiler omits it, and that is the form it
+    # accepts. The alias is not what made this construct invalid here.
+    "oracle": (
+        "select*from(selectid,created_atfrommy_table)anon_1"
+        "whereextract(yearfromcreated_at)=2024"
+        "andextract(monthfromcreated_at)=1"
+        "andextract(dayfromcreated_at)=15"
+    ),
+}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "dialect_name", sorted(EXPECTED_PARTITIONED_QUERY_ASSET_SQL_BY_DIALECT), ids=str
+)
+def test_partitioned_query_asset_selectable_wraps_the_whole_statement(dialect_name: str) -> None:
+    """A partitioned query asset's selectable must wrap the user's statement unchanged.
+
+    The statement has to reach the compiler whole. Rebuilding it as a select over everything
+    after its "SELECT" produces a select that owns no FROM clause, and the Oracle dialect
+    completes such a select by appending "FROM DUAL" -- so the wrapped query went out with two
+    FROM clauses and no Oracle version accepted it.
+
+    The engine is built on SQLite because a selectable is dialect-agnostic until it is
+    compiled; compiling against a bare dialect object needs neither a driver nor a live
+    service, so this runs anywhere.
+    """
+    execution_engine = SqlAlchemyExecutionEngine(engine=sqlalchemy.create_engine("sqlite://"))
+
+    selectable = execution_engine._build_selectable_from_batch_spec(
+        PARTITIONED_QUERY_ASSET_BATCH_SPEC
+    )
+
+    compiled = selectable.compile(
+        dialect=PARTITION_QUERY_DIALECT_MODULES_BY_NAME[dialect_name].dialect(),
+        compile_kwargs={"literal_binds": True},
+    )
+    rendered = str(compiled).replace("\n", "").replace(" ", "").lower()
+    assert rendered == EXPECTED_PARTITIONED_QUERY_ASSET_SQL_BY_DIALECT[dialect_name]

--- a/tests/integration/data_sources_and_expectations/data_sources/test_query_asset_partitioning.py
+++ b/tests/integration/data_sources_and_expectations/data_sources/test_query_asset_partitioning.py
@@ -1,0 +1,114 @@
+"""Regression tests for query assets carrying a daily or monthly Batch Definition.
+
+GX wraps a query asset's raw SQL in a subquery before running anything against it. Rebuilding
+that statement as a select over everything after its "SELECT" produces a select that owns no
+FROM clause, and Oracle completes such a select by appending "FROM DUAL" -- so the wrapped
+query went out with two FROM clauses and the database rejected it.
+
+The unpartitioned query asset was exempted from the wrapping and so escaped this. A daily or
+monthly Batch Definition is not exempt, and adding one to a query asset failed before a batch
+was ever read: the Batch Definition is validated by probing the partition column through that
+same selectable.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+import great_expectations.expectations as gxe
+from great_expectations.datasource.fluent.sql_datasource import SQLDatasource, TableAsset
+from tests.integration.conftest import parameterize_batch_for_data_sources
+from tests.integration.test_utils.data_source_config import (
+    OracleDatasourceTestConfig,
+    PostgreSQLDatasourceTestConfig,
+    SqliteDatasourceTestConfig,
+)
+
+if TYPE_CHECKING:
+    from great_expectations.datasource.fluent.interfaces import Batch
+
+RECORD_DATE_COL = "record_date"
+LABEL_COL = "label"
+
+OUTSIDE_MONTH = "outside_month"
+MARCH_FIRST = "march_first"
+MARCH_SECOND_A = "march_second_a"
+MARCH_SECOND_B = "march_second_b"
+
+# Values are chosen so a daily and a monthly partition select different, known row sets: the
+# daily partition (2024-03-02) returns a strict subset of the monthly partition (2024-03), and
+# neither equals the full frame, which also carries a row outside the target month entirely.
+# Without that spread, a selectable that ignored the partition clause would still pass.
+DATA = pd.DataFrame(
+    {
+        RECORD_DATE_COL: [
+            date(2023, 6, 15),
+            date(2024, 3, 1),
+            date(2024, 3, 2),
+            date(2024, 3, 2),
+        ],
+        LABEL_COL: [OUTSIDE_MONTH, MARCH_FIRST, MARCH_SECOND_A, MARCH_SECOND_B],
+    }
+)
+
+DATA_SOURCES = [
+    SqliteDatasourceTestConfig(),
+    PostgreSQLDatasourceTestConfig(),
+    OracleDatasourceTestConfig(),
+]
+
+
+def _add_query_asset(batch_for_datasource: Batch, name: str):
+    """Build a query asset selecting the whole fixture table, through its own datasource.
+
+    Identifiers are quoted the way the connected dialect quotes them rather than pasted in
+    bare: the harness creates lower-case identifiers, which a dialect that folds unquoted
+    names to upper case (Oracle) would otherwise fail to resolve.
+    """
+    asset = batch_for_datasource.data_asset
+    assert isinstance(asset, TableAsset)
+    datasource = batch_for_datasource.datasource
+    assert isinstance(datasource, SQLDatasource)
+
+    quote = datasource.get_engine().dialect.identifier_preparer.quote
+    query = f"SELECT {quote(RECORD_DATE_COL)}, {quote(LABEL_COL)} FROM {quote(asset.table_name)}"
+    return datasource.add_query_asset(name=name, query=query)
+
+
+@parameterize_batch_for_data_sources(data_source_configs=DATA_SOURCES, data=DATA)
+def test_query_asset_daily_batch_definition(batch_for_datasource: Batch) -> None:
+    """A daily Batch Definition on a query asset selects that day's rows and no others."""
+    query_asset = _add_query_asset(batch_for_datasource, "daily_query_asset")
+
+    batch_definition = query_asset.add_batch_definition_daily(
+        "daily_query_asset_bd", column=RECORD_DATE_COL
+    )
+    batch = batch_definition.get_batch(batch_parameters={"year": 2024, "month": 3, "day": 2})
+    result = batch.validate(
+        gxe.ExpectColumnDistinctValuesToEqualSet(
+            column=LABEL_COL, value_set=[MARCH_SECOND_A, MARCH_SECOND_B]
+        )
+    )
+
+    assert result.success, result.exception_info
+
+
+@parameterize_batch_for_data_sources(data_source_configs=DATA_SOURCES, data=DATA)
+def test_query_asset_monthly_batch_definition(batch_for_datasource: Batch) -> None:
+    """A monthly Batch Definition on a query asset selects that month's rows and no others."""
+    query_asset = _add_query_asset(batch_for_datasource, "monthly_query_asset")
+
+    batch_definition = query_asset.add_batch_definition_monthly(
+        "monthly_query_asset_bd", column=RECORD_DATE_COL
+    )
+    batch = batch_definition.get_batch(batch_parameters={"year": 2024, "month": 3})
+    result = batch.validate(
+        gxe.ExpectColumnDistinctValuesToEqualSet(
+            column=LABEL_COL, value_set=[MARCH_FIRST, MARCH_SECOND_A, MARCH_SECOND_B]
+        )
+    )
+
+    assert result.success, result.exception_info


### PR DESCRIPTION
## Summary

Adding a daily or monthly Batch Definition to a **query asset** failed on Oracle with `ORA-00907: missing right parenthesis`. The same query asset with a whole-table Batch Definition worked against the same table and data.

A query asset's raw SQL is wrapped in a subquery before anything runs against it. Both wrapping sites rebuilt the statement as a select over everything after its `SELECT`:

```python
sa.select(sa.text(query.lstrip()[6:])).subquery()
```

That produces a `SELECT` which owns no `FROM` clause of its own. Oracle completes such a select by appending `FROM DUAL`, so the wrapped query went out with two `FROM` clauses:

```sql
SELECT "CREATED_AT"
FROM (SELECT  id, created_at FROM my_table FROM DUAL) anon_1
 FETCH FIRST 1 ROWS ONLY
```

Both sites now hand the statement to SQLAlchemy whole, through `_wrap_raw_sql_as_subquery` — the helper already in this module that wraps raw SQL correctly.

## Why

#11538 fixed this for the **unpartitioned, unsampled** query asset, by returning the user's query unwrapped and skipping the subquery entirely. That guard requires all four of: a `query` in the batch spec, no `sampling_method`, no `partitioner_method`, and a `partition_clause` of `sa.true()`. A daily or monthly Batch Definition sets `partitioner_method`, so the guard does not fire, the statement is wrapped, and `FROM DUAL` comes back.

So the construct itself was never fixed — only one path around it. This change fixes the construct, at both places that build it:

- `SqlAlchemyExecutionEngine._subselectable` — reached when a batch is read.
- `QueryAsset.as_selectable` — reached earlier, and the one that actually surfaced here. A Batch Definition is validated by probing the partition column through this selectable, so the failure landed on *adding* the Batch Definition, before any batch was read.

The #11538 guard is left as it is: it now skips redundant work rather than avoiding a defect, and removing it would change the SQL emitted for the unpartitioned path, which is not what this PR is for.

Background: #10948 (closed as completed on #11538) and #8618 (closed as not-planned) both concern this `FROM DUAL` behavior.

## User impact

Daily and monthly Batch Definitions now work on Oracle query assets. Previously the Batch Definition could not be created at all, so there was no partial or degraded path — the only workaround was a table asset, or materializing the query as a view. Table assets were never affected.

The error users saw was also misleading: it reported that the column type "can't be verified to be a date or datetime", which reads as a schema or type problem, when the actual cause was that the probe query GX built was syntactically invalid.

Two smaller consequences:

- **No change on any other dialect.** The rendered SQL is byte-identical on PostgreSQL, MySQL, SQLite and MSSQL apart from one redundant space that the old string slicing left after `SELECT`. Pinned per-dialect in the tests.
- **A trailing line comment no longer breaks a query asset's Batch Definition.** `as_selectable` never picked up the trailing-newline normalization added for #12122, so a query ending in `-- note` put the appended `)` and alias inside that comment on every backend. Routing it through the shared helper fixes that too.

## How to review

Start with `_query_text_as_subquery` in `sqlalchemy_execution_engine.py` — it is the whole fix; the two call sites just delegate to it.

Worth a careful look:

- **The normalization it applies** (`query.strip().rstrip(";").rstrip()`). `_subselectable` already stripped a trailing semicolon; `as_selectable` did not. They now share one normalization, which is a small behavior change for `as_selectable` in the direction of working more often, not less.
- **The `EXPECTED_*_BY_DIALECT` tables** in the two unit tests, which pin the rendered SQL rather than merely asserting `"FROM DUAL" not in ...`. Note that Oracle renders `) anon_1` with no `AS` — that is the form Oracle accepts, and SQLAlchemy's Oracle compiler already emits it. The alias was never the problem here.

Which cases actually carry the bug, since the parametrization is wide:

- `test_partitioned_query_asset_selectable_wraps_the_whole_statement` — only `[oracle]` fails without the fix. The other four pin that nothing else changed.
- `test_query_asset_as_selectable_wraps_the_whole_statement` — all five fail without the fix, because that site was also missing the #12122 newline.

Verification run locally against Oracle 21c XE (`gvenzl/oracle-xe:21.3.0-slim-faststart`, the same image CI's `oracle` lane brings up):

```bash
pytest tests/integration/data_sources_and_expectations -m oracle          # 18 passed
pytest tests/integration/data_sources_and_expectations -m sqlite          # 209 passed
pytest tests/execution_engine tests/datasource/fluent -m unit             # 1713 passed
```

The new integration tests are in the `oracle`, `postgresql` and `sqlite` lanes and reproduce the failure before the fix. They quote identifiers through the connected dialect's own preparer, because the test harness creates lower-case identifiers and Oracle folds unquoted names to upper case.

Three failures in that unit run (`test_abs_data_connector_whole_directory_path_override`, `test_gcs_data_connector_whole_directory_path_override`, `test_spark_test_connection`) are pre-existing on `develop` at the base commit and unrelated to this change; `develop` is green in CI, so they are local dependency drift.

https://claude.ai/code/session_01498AUvv1ojXXULr8kBPFBC