### PR TITLE
fix(sqlite): guard stddev formula against division by zero for n<2

### DIFF
--- a/great_expectations/execution_engine/sqlite_execution_engine.py
+++ b/great_expectations/execution_engine/sqlite_execution_engine.py
@@ -35,9 +35,17 @@ class ColumnStandardDeviation(BaseColumnStandardDeviation):
         nonnull_row_count = _metrics[
             f"column_values.null.{SummarizationMetricNameSuffixes.UNEXPECTED_COUNT.value}"
         ]
-        standard_deviation = sa.func.sqrt(
-            sa.func.sum((1.0 * column - mean) * (1.0 * column - mean))
-            / ((1.0 * nonnull_row_count) - 1.0)
+        standard_deviation = sa.case(
+            [
+                (
+                    (1.0 * nonnull_row_count) - 1.0 > 0,
+                    sa.func.sqrt(
+                        sa.func.sum((1.0 * column - mean) * (1.0 * column - mean))
+                        / ((1.0 * nonnull_row_count) - 1.0)
+                    ),
+                )
+            ],
+            else_=None,
         )
         return standard_deviation
 

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_stdev_to_be_between.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_stdev_to_be_between.py
@@ -10,6 +10,7 @@ from tests.integration.data_sources_and_expectations.data_source_lists import (
 )
 from tests.integration.test_utils.data_source_config import (
     ALL_DATA_SOURCES,
+    SqliteDatasourceTestConfig,
 )
 
 NUM_COL = "all_numbers"
@@ -144,3 +145,40 @@ def test_success_with_suite_param_strict_max_(
         expectation, expectation_parameters={suite_param_key: suite_param_value}
     )
     assert result.success == expected_result
+
+
+SINGLE_VALUE_COL = "single_value"
+ALL_NULL_COL = "all_null"
+
+UNDER_TWO_VALUES = pd.DataFrame(
+    {
+        SINGLE_VALUE_COL: pd.Series([5.0, None], dtype="float64"),
+        ALL_NULL_COL: pd.Series([None, None], dtype="float64"),
+    }
+)
+
+
+@pytest.mark.parametrize(
+    "column",
+    [
+        pytest.param(SINGLE_VALUE_COL, id="single_value"),
+        pytest.param(ALL_NULL_COL, id="all_null"),
+    ],
+)
+@parameterize_batch_for_data_sources(
+    data_source_configs=[SqliteDatasourceTestConfig()], data=UNDER_TWO_VALUES
+)
+def test_under_two_values_returns_success_false_with_null_observed(
+    batch_for_datasource: Batch, column: str
+) -> None:
+    """Columns with fewer than 2 non-null values have undefined stddev.
+
+    SQLite has no native stddev_samp, so the hand-written formula divides by
+    (n - 1) with no guard. Other backends return success=False with
+    observed_value=None; SQLite must match that shape instead of raising
+    an opaque engine exception.
+    """
+    expectation = gxe.ExpectColumnStdevToBeBetween(column=column, min_value=0, max_value=10)
+    result = batch_for_datasource.validate(expectation, result_format=ResultFormat.COMPLETE)
+    assert not result.success
+    assert result.to_json_dict()["result"]["observed_value"] is None


### PR DESCRIPTION
## What

`ExpectColumnStdevToBeBetween` on SQLite raised an opaque engine exception (`user-defined function raised exception`) for columns with fewer than 2 non-null values, instead of returning `success=False` with `observed_value=None` like every other backend.

## Why

SQLite has no native `stddev_samp`, so the hand-written formula in `sqlite_execution_engine.py` divides by `(nonnull_row_count - 1.0)` with no guard. When `n < 2`, this produces:
- A division-by-zero inside the `math.sqrt` shim GX registers on every SQLite connection
- An `OperationalError` caught during metric resolution
- A result with **no `observed_value` key** (not even `None`) and an `exception_info` entry that names neither the column, table, nor cause

Other backends (pandas, Spark, generic SQL) all return `success=False` with `observed_value=None` for the same input.

## How

Wrap the formula in a `CASE WHEN (n - 1) > 0` guard so SQLite returns `NULL` for undefined standard deviations, matching the behavior of every other backend.

## Test plan

- Added `test_under_two_values_returns_success_false_with_null_observed` covering both a single-value column and an all-null column on SQLite
- Verified the existing `test_success` and `test_failure` cases still pass (no regression on the happy path)

## Notes

- CLA: I have read and agree to the terms of the Individual Contributor License Agreement.
- AI-assisted: yes (disclosed per `CONTRIBUTING.md`)

Fixes #12164
