### PR TITLE
[MAINTENANCE] Type-check tests/execution_engine/partition_and_sample/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,6 @@ exclude = [
     'tests/datasource/data_connector',
     'tests/datasource/fluent/tasks\.py',
     'tests/datasource/test_datasource_dict\.py',
-    'tests/execution_engine/partition_and_sample',
     'tests/expectations',
     'tests/experimental/metric_repository/test_metric_list_metric_retriever\.py',
     'tests/integration/common_workflows',

--- a/scripts/mypy_relaxation_inventory.json
+++ b/scripts/mypy_relaxation_inventory.json
@@ -68,7 +68,6 @@
     "tests/datasource/data_connector",
     "tests/datasource/fluent/tasks\\.py",
     "tests/datasource/test_datasource_dict\\.py",
-    "tests/execution_engine/partition_and_sample",
     "tests/expectations",
     "tests/experimental/metric_repository/test_metric_list_metric_retriever\\.py",
     "tests/integration/common_workflows",

--- a/tests/execution_engine/partition_and_sample/partition_and_sample_test_cases.py
+++ b/tests/execution_engine/partition_and_sample/partition_and_sample_test_cases.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import datetime
-from typing import List
+from typing import TYPE_CHECKING, List
 
 import pytest
 
@@ -8,7 +10,10 @@ from great_expectations.execution_engine.partition_and_sample.data_partitioner i
     DatePart,
 )
 
-SINGLE_DATE_PART_BATCH_IDENTIFIERS: List[pytest.param] = [
+if TYPE_CHECKING:
+    from _pytest.mark.structures import ParameterSet
+
+SINGLE_DATE_PART_BATCH_IDENTIFIERS: List[ParameterSet] = [
     pytest.param({"month": 10}, id="month_dict"),
     pytest.param("10-31-2018", id="dateutil parseable date string"),
     pytest.param(
@@ -37,7 +42,7 @@ SINGLE_DATE_PART_BATCH_IDENTIFIERS: List[pytest.param] = [
     ),
 ]
 
-SINGLE_DATE_PART_DATE_PARTS: List[pytest.param] = [
+SINGLE_DATE_PART_DATE_PARTS: List[ParameterSet] = [
     pytest.param(
         [DatePart.MONTH],
         id="month_with_DatePart",
@@ -71,7 +76,7 @@ SINGLE_DATE_PART_DATE_PARTS: List[pytest.param] = [
 ]
 
 
-MULTIPLE_DATE_PART_BATCH_IDENTIFIERS: List[pytest.param] = [
+MULTIPLE_DATE_PART_BATCH_IDENTIFIERS: List[ParameterSet] = [
     pytest.param({"year": 2018, "month": 10}, id="year_and_month_dict"),
     pytest.param("10-31-2018", id="dateutil parseable date string"),
     pytest.param(
@@ -105,7 +110,7 @@ MULTIPLE_DATE_PART_BATCH_IDENTIFIERS: List[pytest.param] = [
     ),
 ]
 
-MULTIPLE_DATE_PART_DATE_PARTS: List[pytest.param] = [
+MULTIPLE_DATE_PART_DATE_PARTS: List[ParameterSet] = [
     pytest.param(
         [DatePart.YEAR, DatePart.MONTH],
         id="year_month_with_DatePart",

--- a/tests/execution_engine/partition_and_sample/test_sqlalchemy_execution_engine_partitioning.py
+++ b/tests/execution_engine/partition_and_sample/test_sqlalchemy_execution_engine_partitioning.py
@@ -197,10 +197,9 @@ def test_get_data_for_batch_identifiers_year(
 ):
     """test that get_data_for_batch_identifiers_for_partition_on_date_parts() was called with the appropriate params."""  # noqa: E501 # FIXME CoP
     data_partitioner: SqlAlchemyDataPartitioner = SqlAlchemyDataPartitioner(dialect="sqlite")
-    # selectable should be a sa.Selectable object but since we are mocking out
-    # get_data_for_batch_identifiers_for_partition_on_date_parts
-    # and just verifying its getting passed through, we ignore the type here.
-    selectable: str = "mock_selectable"
+    # get_data_for_batch_identifiers_for_partition_on_date_parts is mocked out, so this is only
+    # ever passed through -- but it is passed as the Selectable the signature declares.
+    selectable: sqlalchemy.TableClause = sqlalchemy.table("mock_selectable")
     column_name: str = "column_name"
 
     data_partitioner.get_data_for_batch_identifiers_year(
@@ -228,7 +227,7 @@ def test_get_data_for_batch_identifiers_year_and_month(
 ):
     """test that get_data_for_batch_identifiers_for_partition_on_date_parts() was called with the appropriate params."""  # noqa: E501 # FIXME CoP
     data_partitioner: SqlAlchemyDataPartitioner = SqlAlchemyDataPartitioner(dialect="sqlite")
-    selectable: str = "mock_selectable"
+    selectable: sqlalchemy.TableClause = sqlalchemy.table("mock_selectable")
     column_name: str = "column_name"
 
     data_partitioner.get_data_for_batch_identifiers_year_and_month(
@@ -256,7 +255,7 @@ def test_get_data_for_batch_identifiers_year_and_month_and_day(
 ):
     """test that get_data_for_batch_identifiers_for_partition_on_date_parts() was called with the appropriate params."""  # noqa: E501 # FIXME CoP
     data_partitioner: SqlAlchemyDataPartitioner = SqlAlchemyDataPartitioner(dialect="sqlite")
-    selectable: str = "mock_selectable"
+    selectable: sqlalchemy.TableClause = sqlalchemy.table("mock_selectable")
     column_name: str = "column_name"
 
     data_partitioner.get_data_for_batch_identifiers_year_and_month_and_day(
@@ -392,7 +391,7 @@ def _render_partition_query_for_date_parts(dialect_name: str, date_parts: List[D
     a driver nor a live service, so this is safe to run in any environment.
     """
     data_partitioner = SqlAlchemyDataPartitioner(dialect=dialect_name)
-    selectable = sqlalchemy.text("table_name")
+    selectable = sqlalchemy.table("table_name")
     query = data_partitioner.get_partition_query_for_data_for_batch_identifiers_for_partition_on_date_parts(  # noqa: E501 # FIXME CoP
         selectable=selectable,
         column_name="column_name",

--- a/tests/execution_engine/partition_and_sample/test_sqlalchemy_execution_engine_sampling.py
+++ b/tests/execution_engine/partition_and_sample/test_sqlalchemy_execution_engine_sampling.py
@@ -11,6 +11,7 @@ from dateutil.parser import parse
 from great_expectations.compatibility.sqlalchemy_compatibility_wrappers import (
     add_dataframe_to_db,
 )
+from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
 from great_expectations.core.id_dict import BatchSpec
 from great_expectations.data_context.util import file_relative_path
@@ -149,7 +150,18 @@ def test_sample_using_limit_builds_correct_query_where_clause_none(  # noqa: C90
         )
 
     # 1. Setup
-    class MockSqlAlchemyExecutionEngine:
+    def _required_dialect(module_name: str) -> sa.engine.Dialect:
+        """The dialect from a driver this dialect's own lane installs.
+
+        import_library_module returns None when the driver is absent, and this test only runs
+        under the pytest flag that installs it -- so None here means a broken lane, not a
+        dialect to skip over.
+        """
+        module = import_library_module(module_name=module_name)
+        assert module is not None, f"{module_name} is required to build this dialect"
+        return module.dialect()
+
+    class MockSqlAlchemyExecutionEngine(SqlAlchemyExecutionEngine):
         def __init__(self, dialect_name: GXSqlDialect):
             self._dialect_name = dialect_name
             self._connection_string = self.dialect_name_to_connection_string(dialect_name)
@@ -172,31 +184,31 @@ def test_sample_using_limit_builds_correct_query_where_clause_none(  # noqa: C90
         }
 
         @property
+        @override
         def dialect_name(self) -> str:
             return self._dialect_name.value
 
         def dialect_name_to_connection_string(self, dialect_name: GXSqlDialect) -> str:
-            return self.DIALECT_TO_CONNECTION_STRING_STUB.get(dialect_name)
+            return self.DIALECT_TO_CONNECTION_STRING_STUB[dialect_name]
 
         _BIGQUERY_MODULE_NAME = "sqlalchemy_bigquery"
 
         @property
+        @override
         def dialect(self) -> sa.engine.Dialect:
             # TODO: AJB 20220512 move this dialect retrieval to a separate class from the SqlAlchemyExecutionEngine  # noqa: E501 # FIXME CoP
             #  and then use it here.
             dialect_name: GXSqlDialect = self._dialect_name
             if dialect_name == GXSqlDialect.ORACLE:
                 # noinspection PyUnresolvedReferences
-                return import_library_module(module_name="sqlalchemy.dialects.oracle").dialect()
+                return _required_dialect("sqlalchemy.dialects.oracle")
             elif dialect_name == GXSqlDialect.SNOWFLAKE:
                 # noinspection PyUnresolvedReferences
-                return import_library_module(
-                    module_name="snowflake.sqlalchemy.snowdialect"
-                ).dialect()
+                return _required_dialect("snowflake.sqlalchemy.snowdialect")
             elif dialect_name == GXSqlDialect.DREMIO:
                 # WARNING: Dremio Support is experimental, functionality is not fully under test
                 # noinspection PyUnresolvedReferences
-                return import_library_module(module_name="sqlalchemy_dremio.pyodbc").dialect()
+                return _required_dialect("sqlalchemy_dremio.pyodbc")
             # NOTE: AJB 20220512 Redshift dialect is not yet fully supported.
             # The below throws an `AttributeError: type object 'RedshiftDialect_psycopg2' has no attribute 'positional'`  # noqa: E501 # FIXME CoP
             # elif dialect_name == "redshift":
@@ -205,11 +217,11 @@ def test_sample_using_limit_builds_correct_query_where_clause_none(  # noqa: C90
             #     ).RedshiftDialect
             elif dialect_name == GXSqlDialect.BIGQUERY:
                 # noinspection PyUnresolvedReferences
-                return import_library_module(module_name=self._BIGQUERY_MODULE_NAME).dialect()
+                return _required_dialect(self._BIGQUERY_MODULE_NAME)
             elif dialect_name == GXSqlDialect.TERADATASQL:
                 # WARNING: Teradata Support is experimental, functionality is not fully under test
                 # noinspection PyUnresolvedReferences
-                return import_library_module(module_name="teradatasqlalchemy.dialect").dialect()
+                return _required_dialect("teradatasqlalchemy.dialect")
             else:
                 return sa.create_engine(self._connection_string).dialect
 
@@ -231,8 +243,9 @@ def test_sample_using_limit_builds_correct_query_where_clause_none(  # noqa: C90
         execution_engine=mock_execution_engine, batch_spec=batch_spec, where_clause=None
     )
 
+    query_str: str
     if not isinstance(query, str):
-        query_str: str = clean_query_for_comparison(
+        query_str = clean_query_for_comparison(
             str(
                 query.compile(
                     dialect=mock_execution_engine.dialect,
@@ -241,7 +254,7 @@ def test_sample_using_limit_builds_correct_query_where_clause_none(  # noqa: C90
             )
         )
     else:
-        query_str: str = clean_query_for_comparison(query)
+        query_str = clean_query_for_comparison(query)
 
     expected: str = clean_query_for_comparison(dialect_name_to_sql_statement(dialect_name))
 

--- a/tests/integration/fixtures/partition_and_sample_data/partitioner_test_cases_and_fixtures.py
+++ b/tests/integration/fixtures/partition_and_sample_data/partitioner_test_cases_and_fixtures.py
@@ -119,8 +119,8 @@ class TaxiTestData:
 
     def get_unique_sorted_test_column_values(
         self,
-        reverse: Optional[bool] = False,
-        move_null_to_front: Optional[bool] = False,
+        reverse: bool = False,
+        move_null_to_front: bool = False,
         limit: Optional[int] = None,
     ) -> List[Optional[Any]]:
         column_values: List[Optional[Any]] = self.get_test_column_values()
@@ -148,7 +148,7 @@ class TaxiTestData:
         return column_values[:limit]
 
     def get_divided_integer_test_column_values(self, divisor: int) -> List[Optional[Any]]:
-        column_values: List[Optional[Any]] = self.get_test_column_values()
+        column_values: List[Any] = self.get_test_column_values()
 
         column_value: Any
         column_values = [column_value // divisor for column_value in column_values]
@@ -156,7 +156,7 @@ class TaxiTestData:
         return list(set(column_values))
 
     def get_mod_integer_test_column_values(self, mod: int) -> List[Optional[Any]]:
-        column_values: List[Optional[Any]] = self.get_test_column_values()
+        column_values: List[Any] = self.get_test_column_values()
 
         column_value: Any
         column_values = [column_value % mod for column_value in column_values]
@@ -189,11 +189,11 @@ class TaxiPartitioningTestCasesBase(ABC):
         return self._taxi_test_data.test_df
 
     @property
-    def test_column_name(self) -> str:
+    def test_column_name(self) -> Optional[str]:
         return self._taxi_test_data.test_column_name
 
     @property
-    def test_column_names(self) -> List[str]:
+    def test_column_names(self) -> Optional[List[str]]:
         return self._taxi_test_data.test_column_names
 
     @abstractmethod


### PR DESCRIPTION
Part of #12128. Closes #12134.

No RFC needed: type-checking existing test modules, no new data source or execution engine.

Fixes the 16 mypy errors in three of the directory's eight modules, removes the covering `exclude` pattern from `pyproject.toml`, and regenerates `scripts/mypy_relaxation_inventory.json` with the guard's emit mode.

## `partition_and_sample_test_cases.py` — 4

`List[pytest.param]` annotated the factory function rather than the type it returns. `pytest.param()` returns a `ParameterSet`, imported under `TYPE_CHECKING` the same way `tests/integration/test_utils/test_shared_column_type_renderings.py` already does, with `from __future__ import annotations` so the module-level annotations are not evaluated at import time.

## `test_sqlalchemy_execution_engine_sampling.py` — 8

- **The test double is now a real subtype.** `MockSqlAlchemyExecutionEngine` was passed where `sample_using_limit` declares `SqlAlchemyExecutionEngine`. It subclasses it now rather than being cast over the mismatch, and overrides only `dialect` and `dialect_name` — the two members the sampler actually reads — both with `@override`. The parametrizations that exercise this all skip without a dialect flag, so I re-ran the body standalone against SQLite to confirm the subclass constructs and produces the same query:

  ```
  dialect_name: sqlite
  query type: Select
  SELECT * FROM s.test_table WHERE 1 = 1 LIMIT 10 OFFSET 0
  ```

- **`import_library_module` returns `Optional[ModuleType]`** and five call sites unpacked it blind. Folded into one `_required_dialect` helper that asserts the driver is present — this test only runs under the pytest flag that installs the driver, so `None` here means a broken lane, not a dialect to skip past.

- **`dialect_name_to_connection_string` is declared `-> str`** but returned `DIALECT_TO_CONNECTION_STRING_STUB.get(...)`. Now indexes. **One thing worth a maintainer's eye:** `CLICKHOUSE`, `DATABRICKS` and `SINGLESTOREDB` are in `GXSqlDialect.get_all_dialects()` and so are parametrized, but are absent from that stub. Before this change they got `None`, which then reached `sa.create_engine(None)` and failed there; now they raise `KeyError` at lookup. Either way those three cannot pass if their flag is ever set — this only moves the failure earlier and makes it legible. Say the word if you'd rather I add the three stub entries instead.

- **`query_str` was annotated in both arms** of an if/else. Declared once above it.

## `test_sqlalchemy_execution_engine_partitioning.py` — 4

Four calls passed a `str` (`"mock_selectable"`) or a `TextClause` (`sqlalchemy.text("table_name")`) where `SqlAlchemyDataPartitioner` declares `Selectable`. Neither is one. They now pass `sqlalchemy.table(...)`, a `TableClause`, which is — including at the one site that compiles a real query rather than feeding a mock. The rendered SQL is unchanged; those tests pass with identical counts.

## `partitioner_test_cases_and_fixtures.py` — 5, consequential

Worth flagging, since the issue's Notes expected these to stay out of the way. `exclude` governs file *discovery*, not `follow_imports` — so removing this directory's pattern pulls the sibling module into the checked set through `test_sqlalchemy_execution_engine_partitioning.py`'s import of it, and its five errors surface on this PR. Requirement 1 asks for zero errors, so they're fixed here; the sibling's own `exclude` pattern is left in place, untouched, so its issue still has its deliverable. All five are annotation-only:

- `TaxiPartitioningTestCasesBase.test_column_name` / `.test_column_names` declared `str` / `List[str]` while delegating to `TaxiTestData`, which correctly declares them `Optional` — exactly one of the pair is ever set.
- `reverse` and `move_null_to_front` were `Optional[bool] = False`; `sorted(reverse=...)` takes a `bool`, and neither flag has a third state.
- The two integer helpers annotated their local as `List[Optional[Any]]`, so `//` and `%` were checked against `None`.

Happy to drop this file from the PR if you'd rather the sibling own it — it just means this one cannot be green on its own.

## Verification

```
mypy: Success: no issues found in 837 source files
```

against `Success: no issues found in 829 source files` on develop — zero errors, eight more files checked, and `python scripts/mypy_config_guard.py` passes. Inventory regenerated with `--emit-inventory`, a one-line delta.

Every test in the directory keeps its exact prior outcome, before and after:

| module | before | after |
|---|---|---|
| `test_sqlalchemy_execution_engine_partitioning.py` | 100 passed, 121 xfailed | 100 passed, 121 xfailed |
| `test_sqlalchemy_execution_engine_sampling.py` | 17 passed, 17 skipped | 17 passed, 17 skipped |
| `test_pandas_execution_engine_partitioning.py` | 1 failed, 67 passed, 107 xfailed | 1 failed, 67 passed, 107 xfailed |
| `test_pandas_execution_engine_sampling.py` | 10 passed, 4 xfailed | 10 passed, 4 xfailed |

The one failure is `test_get_batch_with_partition_on_whole_table_s3`, which fails identically on unmodified `develop` here — it wants S3 credentials this machine doesn't have. The Spark modules need a runtime I don't have locally; they are untouched and already type-clean.

No file under `great_expectations/` changed, no test function signature gained annotations, and no assertion was deleted, loosened, skipped or xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxphSQWkGcC4sgncbRU64C
