### PR TITLE
[BUGFIX] expect_column_values_to_be_unique raises KeyError on mixed-case column names

### DIFF
--- a/docs/sphinx_api_docs_source/public_api_missing_threshold.py
+++ b/docs/sphinx_api_docs_source/public_api_missing_threshold.py
@@ -622,6 +622,12 @@ ITEMS_IGNORED_FROM_PUBLIC_API = [
     ),
     PrintableDefinition(
         file=pathlib.Path(
+            "great_expectations/expectations/metrics/column_map_metrics/column_values_unique.py"
+        ),
+        name="column",
+    ),
+    PrintableDefinition(
+        file=pathlib.Path(
             "great_expectations/expectations/metrics/map_metric_provider/column_condition_partial.py"
         ),
         name="column_condition_partial",

--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_unique.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_unique.py
@@ -72,6 +72,28 @@ def _count_label(table_columns: Sequence[Any]) -> str:
     return label
 
 
+def _column_by_name(selectable: Any, column_name: str) -> Any:
+    """Return the column named "column_name" from a projection built on "table.columns".
+
+    On the dialects GX treats as case-insensitive, the "table.columns" metric reports
+    names as "CaseInsensitiveString", which hashes by its case-folded value. A plain
+    "str" holding the same name is then an equal key that hashes differently, so a
+    projection built from "table.columns" cannot be indexed by a raw domain column name
+    unless that name is already lower case -- ".c" lookup raises "KeyError" instead.
+
+    Try the hash lookup first so the common path stays O(1), and fall back to matching
+    by equality, which both spellings agree on. A name that matches nothing still raises
+    the original "KeyError".
+    """
+    try:
+        return selectable.c[column_name]
+    except KeyError:
+        for key, column in selectable.c.items():
+            if key == column_name:
+                return column
+        raise
+
+
 class _DuplicateRowsSource(NamedTuple):
     """The pieces of a query that returns the source rows whose target value repeats.
 
@@ -82,6 +104,10 @@ class _DuplicateRowsSource(NamedTuple):
     columns: Any
     from_clause: Any
     whereclause: Any
+
+    def column(self, column_name: str) -> Any:
+        """Return the source column named "column_name"."""
+        return _column_by_name(self.columns, column_name)
 
 
 def _build_duplicate_rows_source(
@@ -146,7 +172,7 @@ def _build_duplicate_rows_source(
         columns=source,
         from_clause=source.join(
             dup_keys,
-            source.c[column_name] == dup_keys.c[column_name],
+            _column_by_name(source, column_name) == dup_keys.c[column_name],
         ),
         whereclause=None,
     )
@@ -174,7 +200,7 @@ def _sqlalchemy_unique_unexpected_rows(
         column_name=column_name,
         table_columns=table_columns,
     )
-    column_selector = [duplicates.columns.c[c] for c in table_columns]
+    column_selector = [duplicates.column(c) for c in table_columns]
     query = sa.select(*column_selector).select_from(duplicates.from_clause)
     if duplicates.whereclause is not None:
         query = query.where(duplicates.whereclause)
@@ -224,8 +250,8 @@ def _sqlalchemy_unique_unexpected_index_list(
         column_name=column_name,
         table_columns=all_table_columns,
     )
-    column_selector = [duplicates.columns.c[c] for c in unexpected_index_column_names]
-    column_selector.append(duplicates.columns.c[column_name])
+    column_selector = [duplicates.column(c) for c in unexpected_index_column_names]
+    column_selector.append(duplicates.column(column_name))
     query = sa.select(*column_selector).select_from(duplicates.from_clause)
     if duplicates.whereclause is not None:
         query = query.where(duplicates.whereclause)
@@ -287,8 +313,8 @@ def _sqlalchemy_unique_unexpected_index_query(
         column_name=column_name,
         table_columns=all_table_columns,
     )
-    column_selector = [duplicates.columns.c[c] for c in unexpected_index_column_names]
-    column_selector.append(duplicates.columns.c[column_name])
+    column_selector = [duplicates.column(c) for c in unexpected_index_column_names]
+    column_selector.append(duplicates.column(column_name))
     query = sa.select(*column_selector).select_from(duplicates.from_clause)
     if duplicates.whereclause is not None:
         query = query.where(duplicates.whereclause)

--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_unique.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_unique.py
@@ -82,15 +82,25 @@ def _column_by_name(selectable: Any, column_name: str) -> Any:
     unless that name is already lower case -- ".c" lookup raises "KeyError" instead.
 
     Try the hash lookup first so the common path stays O(1), and fall back to matching
-    by equality, which both spellings agree on. A name that matches nothing still raises
-    the original "KeyError".
+    by equality, which both spellings agree on. Two columns that differ only by case are
+    physically distinct (e.g. via quoted identifiers), so an exact-spelling match is
+    preferred over a merely case-folded one -- the loop keeps scanning past a folded
+    match in case a later entry matches exactly, and only settles for the folded match
+    if no exact one turns up. A name that matches nothing still raises the original
+    "KeyError".
     """
     try:
         return selectable.c[column_name]
     except KeyError:
+        case_insensitive_match = None
         for key, column in selectable.c.items():
             if key == column_name:
-                return column
+                if str(key) == column_name:
+                    return column
+                if case_insensitive_match is None:
+                    case_insensitive_match = column
+        if case_insensitive_match is not None:
+            return case_insensitive_match
         raise
 
 

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_values_to_be_unique.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_values_to_be_unique.py
@@ -485,6 +485,34 @@ def test_complete_with_mixed_case_unexpected_index_column_names_sql(
     ]
 
 
+@parameterize_batch_for_data_sources(
+    data_source_configs=RESULT_FORMAT_GUARD_DATA_SOURCES, data=MIXED_CASE_DATA
+)
+def test_include_unexpected_rows_with_mixed_case_column_sql(
+    batch_for_datasource: Batch,
+) -> None:
+    """include_unexpected_rows drives a distinct row-retrieval path from the other
+    mixed-case tests above: it indexes the projection by every table column name
+    (`duplicates.column(c) for c in table_columns`), not just the target and index
+    columns, so it must be exercised with a mixed-case column too.
+    """
+    expectation = gxe.ExpectColumnValuesToBeUnique(column=MIXED_CASE_COLUMN)
+    result = batch_for_datasource.validate(
+        expectation,
+        result_format={"result_format": "COMPLETE", "include_unexpected_rows": True},
+    )
+
+    _assert_no_metric_exceptions(result)
+    assert not result.success
+    unexpected_rows = sorted(
+        result.result["unexpected_rows"], key=lambda row: row[MIXED_CASE_ROW_ID]
+    )
+    assert unexpected_rows == [
+        {MIXED_CASE_ROW_ID: 2, MIXED_CASE_COLUMN: "1000000002"},
+        {MIXED_CASE_ROW_ID: 3, MIXED_CASE_COLUMN: "1000000002"},
+    ]
+
+
 @pytest.mark.timeout(30)  # the subprocess pays full library import cost
 @pytest.mark.unit
 def test_import_does_not_emit_metric_reregistration_warnings() -> None:

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_values_to_be_unique.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_values_to_be_unique.py
@@ -424,6 +424,67 @@ def test_column_named_like_internal_count_label_sql(
     assert sorted(entry[ROW_ID] for entry in result.result["unexpected_index_list"]) == [1, 2]
 
 
+# Some backends report the names in "table.columns" as case-insensitive strings, whose
+# hash is derived from the case-folded name. A plain string carrying the same mixed-case
+# name is an equal but differently-hashed key, so a projection built from one and read
+# back with the other only agrees when the name is already lower case.
+MIXED_CASE_ROW_ID = "Row_Id"
+MIXED_CASE_COLUMN = "Rndrng_NPI"
+
+MIXED_CASE_DATA = pd.DataFrame(
+    {
+        MIXED_CASE_ROW_ID: [1, 2, 3],
+        MIXED_CASE_COLUMN: ["1000000001", "1000000002", "1000000002"],
+    }
+)
+
+
+@parameterize_batch_for_data_sources(
+    data_source_configs=RESULT_FORMAT_GUARD_DATA_SOURCES, data=MIXED_CASE_DATA
+)
+def test_complete_with_mixed_case_column_sql(batch_for_datasource: Batch) -> None:
+    """Row retrieval must work for a column whose name is not lower case.
+
+    Mixed-case identifiers are ordinary in data warehouses fed from external extracts.
+    The row-retrieval paths index an intermediate projection by column name, and the
+    expectation must evaluate normally rather than fail with an exception from that
+    lookup.
+    """
+    expectation = gxe.ExpectColumnValuesToBeUnique(column=MIXED_CASE_COLUMN)
+    result = batch_for_datasource.validate(expectation, result_format=ResultFormat.COMPLETE)
+
+    _assert_no_metric_exceptions(result)
+    assert not result.success
+    # Only the second value repeats, so both of its rows are unexpected.
+    assert result.result["unexpected_count"] == 2
+    assert sorted(result.result["unexpected_list"]) == ["1000000002", "1000000002"]
+
+
+@parameterize_batch_for_data_sources(
+    data_source_configs=RESULT_FORMAT_GUARD_DATA_SOURCES, data=MIXED_CASE_DATA
+)
+def test_complete_with_mixed_case_unexpected_index_column_names_sql(
+    batch_for_datasource: Batch,
+) -> None:
+    """The index columns are indexed by name too, so they carry the same requirement."""
+    expectation = gxe.ExpectColumnValuesToBeUnique(column=MIXED_CASE_COLUMN)
+    result = batch_for_datasource.validate(
+        expectation,
+        result_format={
+            "result_format": "COMPLETE",
+            "unexpected_index_column_names": [MIXED_CASE_ROW_ID],
+        },
+    )
+
+    _assert_no_metric_exceptions(result)
+    assert not result.success
+    assert result.result["unexpected_count"] == 2
+    assert sorted(entry[MIXED_CASE_ROW_ID] for entry in result.result["unexpected_index_list"]) == [
+        2,
+        3,
+    ]
+
+
 @pytest.mark.timeout(30)  # the subprocess pays full library import cost
 @pytest.mark.unit
 def test_import_does_not_emit_metric_reregistration_warnings() -> None:


### PR DESCRIPTION
## Summary

Closes #12179.

Since 1.20.0, `ExpectColumnValuesToBeUnique` raised `KeyError: '<column>'` on a
SQLAlchemy backend whenever the column name was not already lower case and the result
format asked for rows or unexpected indices (`COMPLETE`, or any format setting
`unexpected_index_column_names`). The expectation was reported as failed with an
exception rather than evaluated.

The row-retrieval paths build an intermediate projection from the names reported by the
`table.columns` metric, then index that projection back by the domain column name. On
the dialects GX treats as case-insensitive, `table.columns` reports names as
`CaseInsensitiveString`, which hashes by its case-folded value. A plain `str` carrying
the same mixed-case name is an equal key that hashes differently, so the `.c` lookup
missed and raised. A lower-cased name was unaffected, because folded and original then
coincide.

This adds `_column_by_name`, which keeps the O(1) hash lookup as the fast path and falls
back to matching the key by equality — which both spellings agree on — before letting a
genuinely absent column raise as before. All four read-back sites now go through it.

## Why

The affected dialects are exactly `CASE_INSENSITIVE_DIALECTS`: Databricks, PostgreSQL,
Snowflake, SQL Server and Trino. Mixed-case identifiers are ordinary on these backends,
since warehouse tables are routinely loaded from external extracts that ship their own
capitalization, and lower-casing them is not a workaround — GX emits quoted identifiers,
so renaming moves the failure to every other lookup instead.

The other consumers of `table.columns` normalize the name through
`get_dbms_compatible_column_names` before use. `column_values_unique.py` was the one
place that built a projection from the raw metric output and indexed it back with the
raw domain name, so the fix stays local to it.

## User impact

`ExpectColumnValuesToBeUnique` now evaluates normally on a mixed-case column instead of
erroring, on every SQL backend. No public API changes, no result-shape changes, and no
behavior change for lower-cased column names, which took the fast path before and still
do. Users pinned to 1.19.1 for this reason can unpin.

## How to review

Two integration tests are added to
`tests/integration/data_sources_and_expectations/expectations/test_expect_column_values_to_be_unique.py`,
covering the mixed-case target column and mixed-case `unexpected_index_column_names`.
They are parameterized over PostgreSQL and SQLite: PostgreSQL is affected, SQLite is not
(it is not a case-insensitive dialect and its names arrive as plain `str`), so the SQLite
leg is a control that the fix does not disturb the existing path.

Both tests fail on `develop` with the reported `KeyError` and pass with the fix. Removing
just the equality fallback from `_column_by_name` reverts them to red, so the new branch
is the part carrying the fix.

Worth a look: `_column_by_name` matches by `==` on the collection key. On the affected
dialects that comparison is deliberately case-insensitive, which is the same matching
semantics `.c[...]` already had there — but it is the one place where a table holding two
columns differing only in case could resolve differently than an exact match would.
