### PR TITLE
[BUGFIX] Pin UTF-8 for config_variables.yml save/get round-trip

### DIFF
--- a/great_expectations/core/config_provider.py
+++ b/great_expectations/core/config_provider.py
@@ -157,7 +157,7 @@ class _ConfigurationVariablesConfigurationProvider(_AbstractConfigurationProvide
                 root_directory = ""
 
             var_path = os.path.join(root_directory, defined_path)  # noqa: PTH118 # FIXME CoP
-            with open(var_path) as config_variables_file:
+            with open(var_path, encoding="utf-8") as config_variables_file:
                 contents = config_variables_file.read()
 
             variables = dict(yaml.load(contents)) or {}

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -2335,7 +2335,7 @@ class AbstractDataContext(ConfigPeer, ABC):
         )
         if not os.path.isfile(config_variables_filepath):  # noqa: PTH113 # FIXME CoP
             logger.info(f"Creating new substitution_variables file at {config_variables_filepath}")
-            with open(config_variables_filepath, "w", encoding="utf-8") as template:
+            with open(config_variables_filepath, "w") as template:
                 template.write(CONFIG_VARIABLES_TEMPLATE)
 
         with open(config_variables_filepath, "w", encoding="utf-8") as config_variables_file:

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -2335,10 +2335,10 @@ class AbstractDataContext(ConfigPeer, ABC):
         )
         if not os.path.isfile(config_variables_filepath):  # noqa: PTH113 # FIXME CoP
             logger.info(f"Creating new substitution_variables file at {config_variables_filepath}")
-            with open(config_variables_filepath, "w") as template:
+            with open(config_variables_filepath, "w", encoding="utf-8") as template:
                 template.write(CONFIG_VARIABLES_TEMPLATE)
 
-        with open(config_variables_filepath, "w") as config_variables_file:
+        with open(config_variables_filepath, "w", encoding="utf-8") as config_variables_file:
             yaml.dump(config_variables, config_variables_file)
 
     def _load_fluent_config(self, config_provider: _ConfigurationProvider) -> GxConfig:

--- a/tests/data_context/test_file_backed_encoding.py
+++ b/tests/data_context/test_file_backed_encoding.py
@@ -198,3 +198,61 @@ def test_inline_store_backend_saves_non_ascii_variable_under_non_utf8_locale(
 
     assert reload_result.returncode == 0, reload_result.stderr
     assert "OK" in reload_result.stdout
+
+
+@pytest.mark.filesystem
+def test_config_variables_round_trip_non_ascii_value_under_non_utf8_locale(
+    tmp_path: pathlib.Path,
+) -> None:
+    """A non-ASCII config variable saved by AbstractDataContext.save_config_variable()
+    must read back through the config-variables provider regardless of what encoding
+    the process's ambient locale resolves to.
+
+    See https://github.com/fivetran/great_expectations/issues/12181. Sibling of the
+    tuple-store and great_expectations.yml cases above (#12120): the provider read
+    (FileConfigurationProvider.get_values) and both save_config_variables writes
+    opened config_variables.yml with a bare open().
+
+    Both the save and the reload run under a forced non-UTF-8 locale: either side
+    under the ambient (UTF-8) locale would resolve to UTF-8 regardless of whether
+    the encoding is pinned, leaving nothing for the assertions to catch.
+    """  # FIXME CoP
+    project_root = tmp_path / "project"
+    payload_path = tmp_path / "payload.txt"
+    payload_path.write_text(NON_ASCII_VALUE, encoding="utf-8")
+
+    write_script = textwrap.dedent(f"""
+        import great_expectations as gx
+
+        import os
+
+        assert open(os.devnull).encoding != "utf-8"  # locale override did not take effect
+
+        with open({str(payload_path)!r}, encoding="utf-8") as f:
+            non_ascii_value = f.read()
+
+        context = gx.get_context(mode="file", context_root_dir={str(project_root)!r})
+        context.save_config_variable("db_password", non_ascii_value)
+    """)
+    write_result = _run_under_non_utf8_locale(write_script)
+    assert write_result.returncode == 0, write_result.stderr
+
+    reload_script = textwrap.dedent(f"""
+        import great_expectations as gx
+
+        import os
+
+        assert open(os.devnull).encoding != "utf-8"  # locale override did not take effect
+
+        with open({str(payload_path)!r}, encoding="utf-8") as f:
+            non_ascii_value = f.read()
+
+        context = gx.get_context(mode="file", context_root_dir={str(project_root)!r})
+        assert context.config_variables["db_password"] == non_ascii_value
+        print("OK")
+    """)
+
+    reload_result = _run_under_non_utf8_locale(reload_script)
+
+    assert reload_result.returncode == 0, reload_result.stderr
+    assert "OK" in reload_result.stdout


### PR DESCRIPTION
Closes #12181

## Root cause

GX writes `config_variables.yml` as UTF-8 unconditionally (ruamel emits literal UTF-8 for non-ASCII values), but both sides of the round-trip resolved their encoding from the ambient locale: `FileConfigurationProvider.get_values()` read with a bare `open(var_path)` (`core/config_provider.py:160`), and `AbstractDataContext.save_config_variables` wrote with a bare `open(..., "w")` in two places (`data_context/abstract_data_context.py:2338,2341`). Leftover sibling of #12120 — that issue scoped itself to four other calls, fixed by #12125; `config_variables.yml` was in neither.

## Fix

Pin `encoding="utf-8"` on the three calls (same remedy as #12125).

```diff
-            with open(var_path) as config_variables_file:
+            with open(var_path, encoding="utf-8") as config_variables_file:
-            with open(config_variables_filepath, "w") as template:
+            with open(config_variables_filepath, "w", encoding="utf-8") as template:
-        with open(config_variables_filepath, "w") as config_variables_file:
+        with open(config_variables_filepath, "w", encoding="utf-8") as config_variables_file:
```

## Test

New `test_config_variables_round_trip_non_ascii_value_under_non_utf8_locale` in `tests/data_context/test_file_backed_encoding.py`, in that file's established style (save + reload both under a forced non-UTF-8 locale via `save_config_variable` / `context.config_variables`).

- pre-fix: write side raises `UnicodeEncodeError: 'latin-1' codec can't encode characters`; read side (UTF-8 bytes GX wrote, read back through `get_values()`) raises `ruamel.yaml.reader.ReaderError` from mojibake-decoded bytes. Verified locally, full-context round-trip.
- post-fix: full file green (4 passed, same-locale variant run locally — see note).

Note on local verification: this box's interpreter cannot spawn the file's `LC_ALL=C` children (its site startup chokes on a non-ASCII `.pth` under ASCII), so I ran the identical test body with an ISO-8859-1 locale locally (pre-fix FAIL / post-fix PASS, outputs above) and kept the committed test on the file's `LC_ALL=C` convention for CI.

No RFC needed: bug fix below the RFC threshold (no API change, no new backend, no behavior change under UTF-8 locales).

- [x] Description above links the existing issue (#12181)
- [x] Title prefixed with [BUGFIX]
- [x] Below the RFC threshold (no new data source / execution engine)
- [x] Linted with the repo-pinned toolchain (`ruff format --check` + `ruff check` @ v0.15.15, clean)
- [x] Regression test added; integration-test item N/A (file-IO encoding, not a data source / validation mechanic / Expectation change)
- [x] No third-party library or service adopted, nothing to disclose