### PR TITLE
[MAINTENANCE] Type-check metric repository tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,6 @@ exclude = [
     'tests/datasource/fluent/tasks\.py',
     'tests/datasource/test_datasource_dict\.py',
     'tests/expectations',
-    'tests/experimental/metric_repository/test_metric_list_metric_retriever\.py',
 ]
 
 [[tool.mypy.overrides]]

--- a/scripts/mypy_relaxation_inventory.json
+++ b/scripts/mypy_relaxation_inventory.json
@@ -61,8 +61,7 @@
     "tests/datasource/data_connector",
     "tests/datasource/fluent/tasks\\.py",
     "tests/datasource/test_datasource_dict\\.py",
-    "tests/expectations",
-    "tests/experimental/metric_repository/test_metric_list_metric_retriever\\.py"
+    "tests/expectations"
   ],
   "files": [
     "docs",

--- a/tests/experimental/metric_repository/test_metric_list_metric_retriever.py
+++ b/tests/experimental/metric_repository/test_metric_list_metric_retriever.py
@@ -1,6 +1,8 @@
-from typing import Dict, List
+import logging
+from typing import TYPE_CHECKING, Dict, List
 
 import pytest
+from pytest_mock import MockerFixture
 
 from great_expectations.data_context import CloudDataContext
 from great_expectations.datasource.fluent import BatchRequest
@@ -15,16 +17,16 @@ from great_expectations.experimental.metric_repository.metrics import (
     TableMetric,
 )
 from great_expectations.validator.exception_info import ExceptionInfo
-from great_expectations.validator.computed_metric import MetricValue
-from great_expectations.validator.metric_configuration import MetricConfigurationID
-from great_expectations.validator.validation_graph import MetricsCalculatorErrorResultValue
 from great_expectations.validator.validator import Validator
 
+if TYPE_CHECKING:
+    from great_expectations.validator.computed_metric import MetricValue
+    from great_expectations.validator.metric_configuration import MetricConfigurationID
+    from great_expectations.validator.validation_graph import (
+        MetricsCalculatorErrorResultValue,
+    )
+
 pytestmark = pytest.mark.unit
-
-import logging
-
-from pytest_mock import MockerFixture
 
 LOGGER = logging.getLogger(__name__)
 
@@ -724,9 +726,11 @@ def test_get_metrics_only_gets_new_validator_on_asset_change(
 def test_get_metrics_with_no_metrics(
     mock_context, mock_validator, mock_batch_request, metric_retriever
 ):
-    computed_metrics = {}
+    computed_metrics: Dict[MetricConfigurationID, MetricValue] = {}
     metrics_list: List[MetricTypes] = []
-    aborted_metrics = {}
+    aborted_metrics: Dict[
+        MetricConfigurationID, MetricsCalculatorErrorResultValue
+    ] = {}
     mock_validator.compute_metrics.return_value = (
         computed_metrics,
         aborted_metrics,

--- a/tests/experimental/metric_repository/test_metric_list_metric_retriever.py
+++ b/tests/experimental/metric_repository/test_metric_list_metric_retriever.py
@@ -15,6 +15,9 @@ from great_expectations.experimental.metric_repository.metrics import (
     TableMetric,
 )
 from great_expectations.validator.exception_info import ExceptionInfo
+from great_expectations.validator.computed_metric import MetricValue
+from great_expectations.validator.metric_configuration import MetricConfigurationID
+from great_expectations.validator.validation_graph import MetricsCalculatorErrorResultValue
 from great_expectations.validator.validator import Validator
 
 pytestmark = pytest.mark.unit
@@ -298,7 +301,7 @@ def test_column_metrics_not_returned_if_column_types_missing(
         MetricTypes.COLUMN_MAX,
         MetricTypes.COLUMN_NON_NULL_COUNT,
     ]
-    aborted_metrics = {}
+    aborted_metrics: Dict[MetricConfigurationID, MetricsCalculatorErrorResultValue] = {}
     mock_validator.compute_metrics.return_value = (
         computed_metrics,
         aborted_metrics,
@@ -355,7 +358,7 @@ def test_get_metrics_metrics_missing(
         MetricTypes.TABLE_COLUMN_TYPES,
         MetricTypes.COLUMN_MIN,
     ]
-    mock_aborted_metrics = {}
+    mock_aborted_metrics: Dict[MetricConfigurationID, MetricsCalculatorErrorResultValue] = {}
     mock_validator.compute_metrics.return_value = (
         mock_computed_metrics,
         mock_aborted_metrics,
@@ -602,7 +605,7 @@ def test_get_metrics_with_timestamp_columns(
         MetricTypes.COLUMN_MAX,
         MetricTypes.COLUMN_NON_NULL_COUNT,
     ]
-    aborted_metrics = {}
+    aborted_metrics: Dict[MetricConfigurationID, MetricsCalculatorErrorResultValue] = {}
     mock_validator.compute_metrics.return_value = (
         computed_metrics,
         aborted_metrics,
@@ -660,7 +663,7 @@ def test_get_metrics_with_timestamp_columns(
 def test_get_metrics_only_gets_a_validator_once(
     mocker: MockerFixture, mock_context, mock_validator, mock_batch_request, metric_retriever
 ):
-    aborted_metrics = {}
+    aborted_metrics: Dict[MetricConfigurationID, MetricsCalculatorErrorResultValue] = {}
 
     computed_metrics = {
         ("table.row_count", (), ()): 2,
@@ -692,7 +695,7 @@ def test_get_metrics_only_gets_new_validator_on_asset_change(
     mock_batch_request_variant,
     metric_retriever,
 ):
-    aborted_metrics = {}
+    aborted_metrics: Dict[MetricConfigurationID, MetricsCalculatorErrorResultValue] = {}
 
     computed_metrics = {
         ("table.row_count", (), ()): 2,
@@ -784,7 +787,7 @@ def test_get_table_column_types(
             {"name": "col2", "type": "float"},
         ],
     }
-    aborted_metrics = {}
+    aborted_metrics: Dict[MetricConfigurationID, MetricsCalculatorErrorResultValue] = {}
     mock_validator.compute_metrics.return_value = (
         computed_metrics,
         aborted_metrics,
@@ -799,7 +802,7 @@ def test_get_table_columns(
     computed_metrics = {
         ("table.columns", (), ()): ["col1", "col2"],
     }
-    aborted_metrics = {}
+    aborted_metrics: Dict[MetricConfigurationID, MetricsCalculatorErrorResultValue] = {}
     mock_validator.compute_metrics.return_value = (computed_metrics, aborted_metrics)
 
     ret = metric_retriever._get_table_columns(mock_batch_request)
@@ -815,7 +818,7 @@ def test_get_table_row_count(
     mocker: MockerFixture, mock_context, mock_validator, mock_batch_request, metric_retriever
 ):
     computed_metrics = {("table.row_count", (), ()): 2}
-    aborted_metrics = {}
+    aborted_metrics: Dict[MetricConfigurationID, MetricsCalculatorErrorResultValue] = {}
     mock_validator.compute_metrics.return_value = (computed_metrics, aborted_metrics)
 
     ret = metric_retriever._get_table_row_count(mock_batch_request)
@@ -850,7 +853,7 @@ def test_get_metrics_with_timestamp_columns_exclude_time(
         MetricTypes.COLUMN_MAX,
         MetricTypes.COLUMN_NON_NULL_COUNT,
     ]
-    aborted_metrics = {}
+    aborted_metrics: Dict[MetricConfigurationID, MetricsCalculatorErrorResultValue] = {}
     mock_validator.compute_metrics.return_value = (
         computed_metrics,
         aborted_metrics,

--- a/tests/experimental/metric_repository/test_metric_list_metric_retriever.py
+++ b/tests/experimental/metric_repository/test_metric_list_metric_retriever.py
@@ -728,9 +728,7 @@ def test_get_metrics_with_no_metrics(
 ):
     computed_metrics: Dict[MetricConfigurationID, MetricValue] = {}
     metrics_list: List[MetricTypes] = []
-    aborted_metrics: Dict[
-        MetricConfigurationID, MetricsCalculatorErrorResultValue
-    ] = {}
+    aborted_metrics: Dict[MetricConfigurationID, MetricsCalculatorErrorResultValue] = {}
     mock_validator.compute_metrics.return_value = (
         computed_metrics,
         aborted_metrics,


### PR DESCRIPTION
Closes #12137

## Summary

Brings `tests/experimental/metric_repository/test_metric_list_metric_retriever.py` into the mypy type-check.

### Changes

- add concrete local variable annotations for the 9 empty metric dictionaries reported by mypy;
- use `MetricConfigurationID`, `MetricValue`, and `MetricsCalculatorErrorResultValue` instead of `Any`;
- remove the test module from the `[tool.mypy]` exclude list;
- regenerate `scripts/mypy_relaxation_inventory.json` using `mypy_config_guard.py`.

No production files under `great_expectations/` were changed, and no test behavior was weakened.

## Validation

- `pytest tests/experimental/metric_repository/test_metric_list_metric_retriever.py`
  - 18 passed
- `git diff --check`
  - clean
- relaxation inventory regenerated with:
  - `python scripts/mypy_config_guard.py --emit-inventory`

Full `invoke type-check --ci --pretty` could not be run locally on Windows because Invoke attempted to use the unsupported `pty` module. CI is expected to provide the authoritative type-check validation.
