### PR TITLE
[FEATURE] Add ExpectColumnTypeToBe BatchExpectation

### DIFF
--- a/great_expectations/expectations/__init__.py
+++ b/great_expectations/expectations/__init__.py
@@ -19,6 +19,7 @@ from .core import (
     ExpectColumnStdevToBeBetween,
     ExpectColumnSumToBeBetween,
     ExpectColumnToExist,
+    ExpectColumnTypeToBe,
     ExpectColumnUniqueValueCountToBeBetween,
     ExpectColumnValueLengthsToBeBetween,
     ExpectColumnValueLengthsToEqual,

--- a/great_expectations/expectations/core/__init__.py
+++ b/great_expectations/expectations/core/__init__.py
@@ -34,6 +34,7 @@ from .expect_column_quantile_values_to_be_between import (
 from .expect_column_stdev_to_be_between import ExpectColumnStdevToBeBetween
 from .expect_column_sum_to_be_between import ExpectColumnSumToBeBetween
 from .expect_column_to_exist import ExpectColumnToExist
+from .expect_column_type_to_be import ExpectColumnTypeToBe
 from .expect_column_unique_value_count_to_be_between import (
     ExpectColumnUniqueValueCountToBeBetween,
 )

--- a/great_expectations/expectations/core/expect_column_type_to_be.py
+++ b/great_expectations/expectations/core/expect_column_type_to_be.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Type, Union
+
+import numpy as np
+import pandas as pd
+
+from great_expectations.compatibility import pydantic, pyspark
+from great_expectations.compatibility.typing_extensions import override
+from great_expectations.core.suite_parameters import (
+    SuiteParameterDict,  # noqa: TC001
+)
+from great_expectations.expectations.expectation import (
+    BatchExpectation,
+    render_suite_parameter_string,
+)
+from great_expectations.expectations.metadata_types import DataQualityIssues, SupportedDataSources
+from great_expectations.expectations.model_field_descriptions import (
+    COLUMN_DESCRIPTION,
+    FAILURE_SEVERITY_DESCRIPTION,
+)
+from great_expectations.expectations.type_comparison import (
+    compare_column_type,
+    native_type_type_map,
+)
+from great_expectations.render import LegacyRendererType, RenderedStringTemplateContent
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.renderer_configuration import (
+    RendererConfiguration,
+    RendererValueType,
+)
+from great_expectations.render.util import substitute_none_for_missing
+
+if TYPE_CHECKING:
+    from great_expectations.core import (
+        ExpectationValidationResult,
+    )
+    from great_expectations.execution_engine import ExecutionEngine
+    from great_expectations.expectations.expectation_configuration import (
+        ExpectationConfiguration,
+    )
+    from great_expectations.render.renderer_configuration import AddParamArgs
+
+logger = logging.getLogger(__name__)
+
+EXPECTATION_SHORT_DESCRIPTION = "Expect a column to be of a specified data type."
+TYPE_DESCRIPTION = """
+    A string representing the data type of the column. \
+    Valid types are defined by the current backend implementation and are dynamically loaded.
+    """
+DATA_QUALITY_ISSUES = [DataQualityIssues.SCHEMA.value]
+SUPPORTED_DATA_SOURCES = [
+    SupportedDataSources.PANDAS.value,
+    SupportedDataSources.SPARK.value,
+    SupportedDataSources.SQLITE.value,
+    SupportedDataSources.POSTGRESQL.value,
+    SupportedDataSources.AURORA.value,
+    SupportedDataSources.CITUS.value,
+    SupportedDataSources.ALLOY.value,
+    SupportedDataSources.NEON.value,
+    SupportedDataSources.MYSQL.value,
+    SupportedDataSources.SQL_SERVER.value,
+    SupportedDataSources.BIGQUERY.value,
+    SupportedDataSources.SNOWFLAKE.value,
+    SupportedDataSources.DATABRICKS.value,
+    SupportedDataSources.REDSHIFT.value,
+]
+
+
+class ExpectColumnTypeToBe(BatchExpectation):
+    __doc__ = f"""{EXPECTATION_SHORT_DESCRIPTION}
+
+    ExpectColumnTypeToBe is a \
+    Batch Expectation.
+
+    BatchExpectations are one of the most common types of Expectation. They are evaluated for an entire Batch, and answer a semantic question about the Batch itself.
+
+    Args:
+        column (str): {COLUMN_DESCRIPTION}
+        type\\_ (str): {TYPE_DESCRIPTION}
+            For example, valid types for Pandas Datasources include any numpy dtype values \
+            (such as 'int64') or native python types (such as 'int'), whereas valid types \
+            for a SqlAlchemy Datasource include types named by the current driver such as 'INTEGER' \
+            in most SQL dialects and 'TEXT' in dialects such as postgresql. \
+            Valid types for Spark Datasources include 'StringType', 'BooleanType' and other \
+            pyspark-defined type names.
+
+    Other Parameters:
+        result_format (str or None, optional): \
+            Which output mode to use: BOOLEAN_ONLY, BASIC, COMPLETE, or SUMMARY. \
+            For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).
+        catch_exceptions (boolean or None, optional): \
+            If True, then catch exceptions and include them as part of the result object. \
+            For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).
+        meta (dict or None, optional): \
+            A JSON-serializable dictionary (nesting allowed) that will be included in the output without \
+            modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).
+        severity (str or None): \
+            {FAILURE_SEVERITY_DESCRIPTION} \
+            For more detail, see [failure severity](https://docs.greatexpectations.io/docs/cloud/expectations/expectations_overview/#failure-severity).
+
+    Returns:
+        An [ExpectationSuiteValidationResult](https://docs.greatexpectations.io/docs/terms/validation_result)
+
+        Exact fields vary depending on the values passed to result_format, catch_exceptions, and meta.
+
+    Supported Data Sources:
+        [{SUPPORTED_DATA_SOURCES[0]}](https://docs.greatexpectations.io/docs/application_integration_support/)
+        [{SUPPORTED_DATA_SOURCES[1]}](https://docs.greatexpectations.io/docs/application_integration_support/)
+        [{SUPPORTED_DATA_SOURCES[2]}](https://docs.greatexpectations.io/docs/application_integration_support/)
+        [{SUPPORTED_DATA_SOURCES[3]}](https://docs.greatexpectations.io/docs/application_integration_support/)
+        [{SUPPORTED_DATA_SOURCES[4]}](https://docs.greatexpectations.io/docs/application_integration_support/)
+        [{SUPPORTED_DATA_SOURCES[5]}](https://docs.greatexpectations.io/docs/application_integration_support/)
+        [{SUPPORTED_DATA_SOURCES[6]}](https://docs.greatexpectations.io/docs/application_integration_support/)
+        [{SUPPORTED_DATA_SOURCES[7]}](https://docs.greatexpectations.io/docs/application_integration_support/)
+        [{SUPPORTED_DATA_SOURCES[8]}](https://docs.greatexpectations.io/docs/application_integration_support/)
+        [{SUPPORTED_DATA_SOURCES[9]}](https://docs.greatexpectations.io/docs/application_integration_support/)
+        [{SUPPORTED_DATA_SOURCES[10]}](https://docs.greatexpectations.io/docs/application_integration_support/)
+        [{SUPPORTED_DATA_SOURCES[11]}](https://docs.greatexpectations.io/docs/application_integration_support/)
+        [{SUPPORTED_DATA_SOURCES[12]}](https://docs.greatexpectations.io/docs/application_integration_support/)
+
+    Data Quality Issues:
+        {DATA_QUALITY_ISSUES[0]}
+
+    Example Data:
+                test 	test2
+            0 	1.00 	2
+            1 	2.30 	5
+            2 	4.33 	0
+
+    Code Examples:
+        Passing Case:
+            Input:
+                ExpectColumnTypeToBe(
+                    column="test2",
+                    type_="INTEGER"
+            )
+
+            Output:
+                {{
+                  "exception_info": {{
+                    "raised_exception": false,
+                    "exception_traceback": null,
+                    "exception_message": null
+                  }},
+                  "result": {{
+                    "observed_value": "INTEGER"
+                  }},
+                  "meta": {{}},
+                  "success": true
+                }}
+
+        Failing Case:
+            Input:
+                ExpectColumnTypeToBe(
+                    column="test",
+                    type_="INTEGER"
+            )
+
+            Output:
+                {{
+                  "exception_info": {{
+                    "raised_exception": false,
+                    "exception_traceback": null,
+                    "exception_message": null
+                  }},
+                  "result": {{
+                    "observed_value": "FLOAT"
+                  }},
+                  "meta": {{}},
+                  "success": false
+                }}
+    """  # noqa: E501
+
+    column: pydantic.StrictStr = pydantic.Field(min_length=1, description=COLUMN_DESCRIPTION)
+    type_: Union[str, SuiteParameterDict] = pydantic.Field(description=TYPE_DESCRIPTION)
+
+    library_metadata: ClassVar[Dict[str, Union[str, list, bool]]] = {
+        "maturity": "experimental",
+        "tags": ["core expectation", "table expectation"],
+        "contributors": ["@great_expectations"],
+        "requirements": [],
+        "has_full_test_suite": True,
+        "manually_reviewed_code": True,
+    }
+    _library_metadata = library_metadata
+
+    metric_dependencies = ("table.column_types",)
+    success_keys = (
+        "column",
+        "type_",
+    )
+    domain_keys = ("batch_id",)
+    args_keys = (
+        "column",
+        "type_",
+    )
+
+    class Config:
+        title = "Expect column to be of type"
+
+        @staticmethod
+        def schema_extra(schema: Dict[str, Any], model: Type[ExpectColumnTypeToBe]) -> None:
+            BatchExpectation.Config.schema_extra(schema, model)
+            schema["properties"]["metadata"]["properties"].update(
+                {
+                    "data_quality_issues": {
+                        "title": "Data Quality Issues",
+                        "type": "array",
+                        "const": DATA_QUALITY_ISSUES,
+                    },
+                    "library_metadata": {
+                        "title": "Library Metadata",
+                        "type": "object",
+                        "const": model._library_metadata,
+                    },
+                    "short_description": {
+                        "title": "Short Description",
+                        "type": "string",
+                        "const": EXPECTATION_SHORT_DESCRIPTION,
+                    },
+                    "supported_data_sources": {
+                        "title": "Supported Data Sources",
+                        "type": "array",
+                        "const": SUPPORTED_DATA_SOURCES,
+                    },
+                }
+            )
+
+    @classmethod
+    @override
+    def _prescriptive_template(
+        cls,
+        renderer_configuration: RendererConfiguration,
+    ) -> RendererConfiguration:
+        add_param_args: AddParamArgs = (
+            ("column", RendererValueType.STRING),
+            ("type_", RendererValueType.STRING),
+        )
+        for name, param_type in add_param_args:
+            renderer_configuration.add_param(name=name, param_type=param_type)
+
+        template_str = "$column must be of type $type_."
+
+        renderer_configuration.template_str = template_str
+
+        return renderer_configuration
+
+    @classmethod
+    @override
+    @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)
+    @render_suite_parameter_string
+    def _prescriptive_renderer(
+        cls,
+        configuration: Optional[ExpectationConfiguration] = None,
+        result: Optional[ExpectationValidationResult] = None,
+        runtime_configuration: Optional[dict] = None,
+        **kwargs,
+    ) -> list[RenderedStringTemplateContent]:
+        runtime_configuration = runtime_configuration or {}
+        styling = runtime_configuration.get("styling")
+
+        params = substitute_none_for_missing(
+            configuration.kwargs,  # type: ignore[union-attr]
+            ["column", "type_"],
+        )
+
+        template_str = "$column must be of type $type_."
+
+        return [
+            RenderedStringTemplateContent(
+                content_block_type="string_template",
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
+            )
+        ]
+
+    def _validate_pandas(self, actual_column_type, expected_type):
+        if expected_type is None:
+            success = True
+        else:
+            comp_types = []
+
+            try:
+                comp_types.append(np.dtype(expected_type).type)
+            except TypeError:
+                try:
+                    pd_type = getattr(pd, expected_type)
+                    if isinstance(pd_type, type):
+                        comp_types.append(pd_type)
+                except AttributeError:
+                    pass
+
+                try:
+                    pd_type = getattr(pd.core.dtypes.dtypes, expected_type)
+                    if isinstance(pd_type, type):
+                        comp_types.append(pd_type)
+                except AttributeError:
+                    pass
+
+            native_type = native_type_type_map(expected_type)
+            if native_type is not None:
+                comp_types.extend(native_type)
+
+            success = actual_column_type.type in comp_types
+
+        return {
+            "success": success,
+            "result": {"observed_value": actual_column_type.type.__name__},
+        }
+
+    def _validate_sqlalchemy(self, actual_column_type, expected_type, execution_engine):
+        if expected_type is None:
+            observed = type(actual_column_type).__name__
+            return {"success": True, "result": {"observed_value": observed}}
+        success, observed_value = compare_column_type(
+            execution_engine, actual_column_type, expected_type
+        )
+        return {"success": success, "result": {"observed_value": observed_value}}
+
+    def _validate_spark(self, actual_column_type, expected_type):
+        if expected_type is None:
+            success = True
+        else:
+            types = []
+            try:
+                type_class = getattr(pyspark.types, expected_type)
+                types.append(type_class)
+            except AttributeError:
+                logger.debug(f"Unrecognized type: {expected_type}")
+            if len(types) == 0:
+                raise ValueError("No recognized spark types in expected_types_list")  # noqa: TRY003
+            types = tuple(types)
+            success = isinstance(actual_column_type, types)
+        return {
+            "success": success,
+            "result": {"observed_value": type(actual_column_type).__name__},
+        }
+
+    @override
+    def _validate(
+        self,
+        metrics: Dict,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
+    ):
+        from great_expectations.execution_engine import (
+            SparkDFExecutionEngine,
+            SqlAlchemyExecutionEngine,
+        )
+
+        column_name = self._get_success_kwarg("column")
+        expected_type = self._get_success_kwarg("type_")
+        actual_column_types_list = metrics.get("table.column_types", [])
+        matches = [
+            type_dict["type"]
+            for type_dict in actual_column_types_list
+            if type_dict["name"] == column_name
+        ]
+        if not matches:
+            return {"success": False, "result": {"observed_value": None}}
+
+        actual_column_type = matches[0]
+
+        if isinstance(execution_engine, SqlAlchemyExecutionEngine):
+            return self._validate_sqlalchemy(
+                actual_column_type=actual_column_type,
+                expected_type=expected_type,
+                execution_engine=execution_engine,
+            )
+        elif isinstance(execution_engine, SparkDFExecutionEngine):
+            return self._validate_spark(
+                actual_column_type=actual_column_type, expected_type=expected_type
+            )
+        return self._validate_pandas(
+            actual_column_type=actual_column_type, expected_type=expected_type
+        )

--- a/great_expectations/expectations/core/schemas/ExpectColumnTypeToBe.json
+++ b/great_expectations/expectations/core/schemas/ExpectColumnTypeToBe.json
@@ -1,0 +1,249 @@
+{
+    "title": "Expect column to be of type",
+    "description": "Expect a column to be of a specified data type.\n\nExpectColumnTypeToBe is a     Batch Expectation.\n\nBatchExpectations are one of the most common types of Expectation. They are evaluated for an entire Batch, and answer a semantic question about the Batch itself.\n\nArgs:\n    column (str): The column name.\n    type\\_ (str): \nA string representing the data type of the column.     Valid types are defined by the current backend implementation and are dynamically loaded.\n\n        For example, valid types for Pandas Datasources include any numpy dtype values             (such as 'int64') or native python types (such as 'int'), whereas valid types             for a SqlAlchemy Datasource include types named by the current driver such as 'INTEGER'             in most SQL dialects and 'TEXT' in dialects such as postgresql.             Valid types for Spark Datasources include 'StringType', 'BooleanType' and other             pyspark-defined type names.\n\nOther Parameters:\n    result_format (str or None, optional):             Which output mode to use: BOOLEAN_ONLY, BASIC, COMPLETE, or SUMMARY.             For more detail, see [result_format](https://docs.greatexpectations.io/docs/reference/expectations/result_format).\n    catch_exceptions (boolean or None, optional):             If True, then catch exceptions and include them as part of the result object.             For more detail, see [catch_exceptions](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#catch_exceptions).\n    meta (dict or None, optional):             A JSON-serializable dictionary (nesting allowed) that will be included in the output without             modification. For more detail, see [meta](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#meta).\n    severity (str or None):             The impact of this Expectation failing: critical, warning, or info. Defaults to critical if not set. Severity levels can be used to trigger different alerting patterns and actions.             For more detail, see [failure severity](https://docs.greatexpectations.io/docs/cloud/expectations/expectations_overview/#failure-severity).\n\nReturns:\n    An [ExpectationSuiteValidationResult](https://docs.greatexpectations.io/docs/terms/validation_result)\n\n    Exact fields vary depending on the values passed to result_format, catch_exceptions, and meta.\n\nSupported Data Sources:\n    [Pandas](https://docs.greatexpectations.io/docs/application_integration_support/)\n    [Spark](https://docs.greatexpectations.io/docs/application_integration_support/)\n    [SQLite](https://docs.greatexpectations.io/docs/application_integration_support/)\n    [PostgreSQL](https://docs.greatexpectations.io/docs/application_integration_support/)\n    [Amazon Aurora PostgreSQL](https://docs.greatexpectations.io/docs/application_integration_support/)\n    [Citus](https://docs.greatexpectations.io/docs/application_integration_support/)\n    [AlloyDB](https://docs.greatexpectations.io/docs/application_integration_support/)\n    [Neon](https://docs.greatexpectations.io/docs/application_integration_support/)\n    [MySQL](https://docs.greatexpectations.io/docs/application_integration_support/)\n    [SQL Server](https://docs.greatexpectations.io/docs/application_integration_support/)\n    [BigQuery](https://docs.greatexpectations.io/docs/application_integration_support/)\n    [Snowflake](https://docs.greatexpectations.io/docs/application_integration_support/)\n    [Databricks (SQL)](https://docs.greatexpectations.io/docs/application_integration_support/)\n\nData Quality Issues:\n    Schema\n\nExample Data:\n            test    test2\n        0   1.00    2\n        1   2.30    5\n        2   4.33    0\n\nCode Examples:\n    Passing Case:\n        Input:\n            ExpectColumnTypeToBe(\n                column=\"test2\",\n                type_=\"INTEGER\"\n        )\n\n        Output:\n            {\n              \"exception_info\": {\n                \"raised_exception\": false,\n                \"exception_traceback\": null,\n                \"exception_message\": null\n              },\n              \"result\": {\n                \"observed_value\": \"INTEGER\"\n              },\n              \"meta\": {},\n              \"success\": true\n            }\n\n    Failing Case:\n        Input:\n            ExpectColumnTypeToBe(\n                column=\"test\",\n                type_=\"INTEGER\"\n        )\n\n        Output:\n            {\n              \"exception_info\": {\n                \"raised_exception\": false,\n                \"exception_traceback\": null,\n                \"exception_message\": null\n              },\n              \"result\": {\n                \"observed_value\": \"FLOAT\"\n              },\n              \"meta\": {},\n              \"success\": false\n            }",
+    "type": "object",
+    "properties": {
+        "id": {
+            "title": "Id",
+            "type": "string"
+        },
+        "meta": {
+            "title": "Meta",
+            "type": "object"
+        },
+        "notes": {
+            "title": "Notes",
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            ]
+        },
+        "result_format": {
+            "title": "Result Format",
+            "default": "BASIC",
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/ResultFormat"
+                },
+                {
+                    "type": "object"
+                }
+            ]
+        },
+        "description": {
+            "title": "Description",
+            "description": "A short description of your Expectation",
+            "type": "string"
+        },
+        "catch_exceptions": {
+            "title": "Catch Exceptions",
+            "default": false,
+            "type": "boolean"
+        },
+        "rendered_content": {
+            "title": "Rendered Content",
+            "type": "array",
+            "items": {
+                "type": "object"
+            }
+        },
+        "severity": {
+            "description": "Indicate the impact of this Expectation failing. Severity levels can be used to trigger different alerting patterns and actions.",
+            "default": "critical",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/FailureSeverity"
+                }
+            ]
+        },
+        "windows": {
+            "title": "Windows",
+            "description": "Definition(s) for evaluation of temporal windows",
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/Window"
+            }
+        },
+        "batch_id": {
+            "title": "Batch Id",
+            "type": "string"
+        },
+        "column": {
+            "title": "Column",
+            "description": "The column name.",
+            "minLength": 1,
+            "type": "string"
+        },
+        "type_": {
+            "title": "Type ",
+            "description": "\n    A string representing the data type of the column.     Valid types are defined by the current backend implementation and are dynamically loaded.\n    ",
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "object"
+                }
+            ]
+        },
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "expectation_class": {
+                    "title": "Expectation Class",
+                    "type": "string",
+                    "const": "ExpectColumnTypeToBe"
+                },
+                "expectation_type": {
+                    "title": "Expectation Type",
+                    "type": "string",
+                    "const": "expect_column_type_to_be"
+                },
+                "domain_type": {
+                    "title": "Domain Type",
+                    "type": "string",
+                    "const": "table",
+                    "description": "Batch"
+                },
+                "data_quality_issues": {
+                    "title": "Data Quality Issues",
+                    "type": "array",
+                    "const": [
+                        "Schema"
+                    ]
+                },
+                "library_metadata": {
+                    "title": "Library Metadata",
+                    "type": "object",
+                    "const": {
+                        "maturity": "experimental",
+                        "tags": [
+                            "core expectation",
+                            "table expectation"
+                        ],
+                        "contributors": [
+                            "@great_expectations"
+                        ],
+                        "requirements": [],
+                        "has_full_test_suite": true,
+                        "manually_reviewed_code": true
+                    }
+                },
+                "short_description": {
+                    "title": "Short Description",
+                    "type": "string",
+                    "const": "Expect a column to be of a specified data type."
+                },
+                "supported_data_sources": {
+                    "title": "Supported Data Sources",
+                    "type": "array",
+                    "const": [
+                        "Pandas",
+                        "Spark",
+                        "SQLite",
+                        "PostgreSQL",
+                        "Amazon Aurora PostgreSQL",
+                        "Citus",
+                        "AlloyDB",
+                        "Neon",
+                        "MySQL",
+                        "SQL Server",
+                        "BigQuery",
+                        "Snowflake",
+                        "Databricks (SQL)",
+                        "Redshift"
+                    ]
+                }
+            }
+        }
+    },
+    "required": [
+        "column",
+        "type_"
+    ],
+    "additionalProperties": false,
+    "definitions": {
+        "ResultFormat": {
+            "title": "ResultFormat",
+            "description": "An enumeration.",
+            "enum": [
+                "BOOLEAN_ONLY",
+                "BASIC",
+                "COMPLETE",
+                "SUMMARY"
+            ],
+            "type": "string"
+        },
+        "FailureSeverity": {
+            "title": "FailureSeverity",
+            "description": "Severity levels for Expectation failures.",
+            "enum": [
+                "critical",
+                "warning",
+                "info"
+            ],
+            "type": "string"
+        },
+        "Offset": {
+            "title": "Offset",
+            "description": "A threshold in which a metric will be considered passable",
+            "type": "object",
+            "properties": {
+                "positive": {
+                    "title": "Positive",
+                    "type": "number"
+                },
+                "negative": {
+                    "title": "Negative",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "positive",
+                "negative"
+            ],
+            "additionalProperties": false
+        },
+        "Window": {
+            "title": "Window",
+            "description": "A definition for a temporal window across <`range`> number of previous invocations",
+            "type": "object",
+            "properties": {
+                "constraint_fn": {
+                    "title": "Constraint Fn",
+                    "type": "string"
+                },
+                "parameter_name": {
+                    "title": "Parameter Name",
+                    "type": "string"
+                },
+                "range": {
+                    "title": "Range",
+                    "type": "integer"
+                },
+                "offset": {
+                    "$ref": "#/definitions/Offset"
+                },
+                "strict": {
+                    "title": "Strict",
+                    "default": false,
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "constraint_fn",
+                "parameter_name",
+                "range",
+                "offset"
+            ],
+            "additionalProperties": false
+        }
+    }
+}

--- a/great_expectations/expectations/core/schemas/index.json
+++ b/great_expectations/expectations/core/schemas/index.json
@@ -417,6 +417,29 @@
                 "Redshift"
             ]
         },
+        "expect_column_type_to_be": {
+            "data_quality_issues": [
+                "Schema"
+            ],
+            "schema_file": "ExpectColumnTypeToBe.json",
+            "short_description": "Expect a column to be of a specified data type.",
+            "supported_data_sources": [
+                "Pandas",
+                "Spark",
+                "SQLite",
+                "PostgreSQL",
+                "Amazon Aurora PostgreSQL",
+                "Citus",
+                "AlloyDB",
+                "Neon",
+                "MySQL",
+                "SQL Server",
+                "BigQuery",
+                "Snowflake",
+                "Databricks (SQL)",
+                "Redshift"
+            ]
+        },
         "expect_column_unique_value_count_to_be_between": {
             "data_quality_issues": [
                 "Uniqueness"

--- a/tasks.py
+++ b/tasks.py
@@ -532,6 +532,7 @@ SUPPORTED_EXPECTATIONS: Final[tuple[str, ...]] = (
     "ExpectSelectColumnValuesToBeUniqueWithinRecord",
     "ExpectColumnPairValuesAToBeGreaterThanB",
     "ExpectColumnToExist",
+    "ExpectColumnTypeToBe",
     "ExpectTableColumnCountToEqual",
     "ExpectTableColumnsToMatchSet",
     "ExpectTableColumnCountToBeBetween",

--- a/tests/expectations/core/test_expect_column_type_to_be.py
+++ b/tests/expectations/core/test_expect_column_type_to_be.py
@@ -1,0 +1,90 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+import great_expectations.expectations as gxe
+from great_expectations.expectations.core.expect_column_type_to_be import (
+    ExpectColumnTypeToBe,
+)
+from great_expectations.self_check.util import build_sa_validator_with_data
+
+
+@pytest.mark.unit
+def test_registered_and_uses_table_column_types_metric():
+    assert gxe.ExpectColumnTypeToBe is ExpectColumnTypeToBe
+    assert ExpectColumnTypeToBe.metric_dependencies == ("table.column_types",)
+    assert set(ExpectColumnTypeToBe.success_keys) == {"column", "type_"}
+    assert ExpectColumnTypeToBe.args_keys == ("column", "type_")
+
+
+@pytest.mark.unit
+def test_validate_pandas_success_and_observed_value():
+    expectation = ExpectColumnTypeToBe(column="a", type_="int64")
+    result = expectation._validate_pandas(
+        actual_column_type=np.dtype("int64"), expected_type="int64"
+    )
+    assert result["success"] is True
+    assert result["result"] == {"observed_value": "int64"}
+
+
+@pytest.mark.unit
+def test_validate_pandas_failure_reports_observed_value():
+    expectation = ExpectColumnTypeToBe(column="a", type_="int64")
+    result = expectation._validate_pandas(
+        actual_column_type=np.dtype("float64"), expected_type="int64"
+    )
+    assert result["success"] is False
+    assert result["result"] == {"observed_value": "float64"}
+
+
+@pytest.mark.unit
+def test_validate_missing_column_fails_with_null_observed_value():
+    expectation = ExpectColumnTypeToBe(column="missing", type_="INTEGER")
+    result = expectation._validate(metrics={"table.column_types": []})
+    assert result == {"success": False, "result": {"observed_value": None}}
+
+
+@pytest.mark.unit
+def test_result_has_no_row_level_fields():
+    expectation = ExpectColumnTypeToBe(column="a", type_="int64")
+    result = expectation._validate_pandas(
+        actual_column_type=np.dtype("int64"), expected_type="int64"
+    )
+    assert set(result["result"]) == {"observed_value"}
+    assert "mostly" not in expectation.success_keys
+
+
+@pytest.mark.sqlite
+def test_delegates_to_compare_column_type(sa, mocker):
+    df = pd.DataFrame({"str_col": ["a", "b", "c"]})
+    validator = build_sa_validator_with_data(
+        df=df, sa_engine_name="sqlite", table_name="column_type_to_be_wiring"
+    )
+
+    mock_compare = mocker.patch(
+        "great_expectations.expectations.core.expect_column_type_to_be.compare_column_type",
+        return_value=(True, "SENTINEL_TYPE"),
+    )
+
+    result = validator.expect_column_type_to_be("str_col", type_="TEXT")
+
+    mock_compare.assert_called_once_with(validator.execution_engine, mocker.ANY, "TEXT")
+    assert result.success is True
+    assert result.result["observed_value"] == "SENTINEL_TYPE"
+
+
+@pytest.mark.sqlite
+def test_sqlite_end_to_end_success_and_failure(sa):
+    df = pd.DataFrame({"col": ["test_val1", "test_val2"]})
+    validator = build_sa_validator_with_data(
+        df=df,
+        sa_engine_name="sqlite",
+        table_name="expect_column_type_to_be_sqlite_e2e",
+    )
+
+    success_result = validator.expect_column_type_to_be("col", type_="TEXT")
+    assert success_result.success is True
+    assert success_result.result["observed_value"] == "TEXT"
+
+    failure_result = validator.expect_column_type_to_be("col", type_="INTEGER")
+    assert failure_result.success is False

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_type_to_be.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_type_to_be.py
@@ -1,0 +1,73 @@
+import pandas as pd
+
+import great_expectations.expectations as gxe
+from great_expectations.datasource.fluent.interfaces import Batch
+from tests.integration.conftest import parameterize_batch_for_data_sources
+from tests.integration.data_sources_and_expectations.data_source_lists import (
+    JUST_PANDAS_DATA_SOURCES,
+)
+from tests.integration.test_utils.data_source_config import (
+    SqliteDatasourceTestConfig,
+)
+
+INTEGER_COLUMN = "integers"
+STRING_COLUMN = "strings"
+
+DATA = pd.DataFrame(
+    {
+        INTEGER_COLUMN: [1, 2, 3, 4, 5],
+        STRING_COLUMN: ["a", "b", "c", "d", "e"],
+    },
+    dtype="object",
+)
+
+TYPED_DATA = pd.DataFrame(
+    {
+        INTEGER_COLUMN: pd.Series([1, 2, 3, 4, 5], dtype="int64"),
+        STRING_COLUMN: pd.Series(["a", "b", "c", "d", "e"], dtype="str"),
+    }
+)
+
+
+@parameterize_batch_for_data_sources(
+    data_source_configs=JUST_PANDAS_DATA_SOURCES,
+    data=TYPED_DATA,
+)
+def test_success_pandas(batch_for_datasource: Batch) -> None:
+    expectation = gxe.ExpectColumnTypeToBe(column=INTEGER_COLUMN, type_="int64")
+    result = batch_for_datasource.validate(expectation)
+    assert result.success
+    assert set(result.result) == {"observed_value"}
+
+
+@parameterize_batch_for_data_sources(
+    data_source_configs=[
+        SqliteDatasourceTestConfig(),
+    ],
+    data=DATA,
+)
+def test_success_sql_integer(batch_for_datasource: Batch) -> None:
+    expectation = gxe.ExpectColumnTypeToBe(column=INTEGER_COLUMN, type_="INTEGER")
+    result = batch_for_datasource.validate(expectation)
+    assert result.success
+    assert result.result["observed_value"] == "INTEGER"
+
+
+@parameterize_batch_for_data_sources(
+    data_source_configs=JUST_PANDAS_DATA_SOURCES,
+    data=DATA,
+)
+def test_failure(batch_for_datasource: Batch) -> None:
+    expectation = gxe.ExpectColumnTypeToBe(column=INTEGER_COLUMN, type_="NUMBER")
+    result = batch_for_datasource.validate(expectation)
+    assert not result.success
+
+
+@parameterize_batch_for_data_sources(
+    data_source_configs=JUST_PANDAS_DATA_SOURCES,
+    data=DATA,
+)
+def test_missing_column_failure(batch_for_datasource: Batch) -> None:
+    expectation = gxe.ExpectColumnTypeToBe(column="non_existent_column", type_="INTEGER")
+    result = batch_for_datasource.validate(expectation)
+    assert not result.success


### PR DESCRIPTION
Implements the schema-level column type Expectation requested in #11963, separating it from the row-level behavior of `ExpectColumnValuesToBeOfType` (see #11076).

Closes https://github.com/fivetran/great_expectations/issues/11963

No RFC needed: new Expectation conforming to the existing Expectation interface

### Changes

- Added `ExpectColumnTypeToBe` (`BatchExpectation`) in `great_expectations/expectations/core/expect_column_type_to_be.py`. It validates a column's declared type via the existing `table.column_types` metric on Pandas, SQLAlchemy, and Spark backends, reusing the aggregate matching logic from `ExpectColumnValuesToBeOfType`.
- Result contains `observed_value` only; no `mostly` and no row-level fields. A missing column returns `success=False` with `observed_value=None`.
- Registered the Expectation (`core` and top-level `__init__`, `tasks.py` `SUPPORTED_EXPECTATIONS`) and regenerated `ExpectColumnTypeToBe.json` and `index.json` via `invoke schemas --sync`.
- Added unit coverage in `tests/expectations/core/test_expect_column_type_to_be.py` (7 passed) and integration coverage in `tests/integration/data_sources_and_expectations/expectations/test_expect_column_type_to_be.py` (4 passed: Pandas, SQLite, failure, missing column).

### Verification

- `tests/expectations/core/test_core_model_schemas.py`: 6 passed
- `ruff format --check` and `ruff check` on all touched files: clean
- Sibling suites (`ExpectColumnValuesToBeOfType`, `ExpectColumnToExist`): 15 passed; remaining errors are pre-existing missing cloud credentials
- mypy on the new module: no new findings (only the repo-wide missing `pandas-stubs` note, identical on the sibling module)

<!--
Describe your change above.

Some changes need an RFC (Request For Comment) agreed before implementation, so that the
design discussion happens before anyone invests in code. An RFC is required for:

  - breaking changes to a public API
  - adding support for a new data source or execution engine
  - changes to a canonical JSON schema's version
  - cross-cutting architectural decisions that affect multiple subsystems

An RFC is not required for bug fixes, additive non-breaking API changes, new Expectations that
conform to the existing Expectation interface, documentation changes, or performance changes
that don't alter behavior.

If your change needs an RFC, open one in the Request For Comment discussion category first, then
add a line to the description above linking it. Full criteria and process:
https://github.com/fivetran/great_expectations/blob/develop/CONTRIBUTING.md#requesting-comment-on-larger-changes

For changes that add a new data source or execution engine, an automated check looks for one of
these two lines in the description above, written exactly in this form:

  RFC: <link to the accepted discussion>
  No RFC needed: <reason this isn't new backend support>

Either answer satisfies the check — it only asks that the question was answered. Linking the RFC
in prose won't be recognized, so use the line form.
-->

- [x] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/fivetran/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [x] This change is below the [RFC threshold](https://github.com/fivetran/great_expectations/blob/develop/CONTRIBUTING.md#requesting-comment-on-larger-changes), or the description above carries an `RFC: <link>` line pointing at an accepted RFC
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated
- [x] For any behavioral change to a data source, validation mechanic, or Expectation, at least one integration test exists in `tests/integration/data_sources_and_expectations` (see [AGENTS.md](https://github.com/fivetran/great_expectations/blob/develop/AGENTS.md#integration-test-requirement))
- [ ] If this PR proposes adopting or recommending a particular third-party library or service, any affiliation with it (employment, financial interest, maintainership) is disclosed above for the reviewer's context